### PR TITLE
feat: 로그인 페이지 UI 렌더링 (#6)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,44 @@
+import { loginPageStyles } from "@/ui/styles/loginPageStyles";
+
+export default function LoginPage() {
+  return (
+    <div className={loginPageStyles.container}>
+      <div className={loginPageStyles.card}>
+
+        {/* 타이틀 영역 */}
+        <div className="flex flex-col gap-1 w-full">
+          <h1 className={loginPageStyles.title}>로그인</h1>
+        </div>
+
+        {/* 입력 폼 */}
+        <div className={loginPageStyles.formGroup}>
+
+          {/* 아이디 */}
+          <div className={loginPageStyles.inputGroup}>
+            <label className={loginPageStyles.label}>아이디</label>
+            <input type="text" className={loginPageStyles.input} />
+          </div>
+
+          {/* 비밀번호 */}
+          <div className={loginPageStyles.inputGroup}>
+            <label className={loginPageStyles.label}>비밀번호</label>
+            <input type="password" className={loginPageStyles.input} />
+          </div>
+
+          {/* 로그인 버튼 */}
+          <button className={loginPageStyles.loginButton}>
+            로그인
+          </button>
+        </div>
+
+        {/* divider */}
+        <div className={loginPageStyles.divider}>
+          <div className={loginPageStyles.dividerLine}></div>
+          <span>또는</span>
+          <div className={loginPageStyles.dividerLine}></div>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/src/ui/styles/loginPageStyles.ts
+++ b/src/ui/styles/loginPageStyles.ts
@@ -1,0 +1,13 @@
+export const loginPageStyles = {
+  container: "flex min-h-screen items-center justify-center bg-sky-100 px-4",
+  card: "flex w-full max-w-md flex-col gap-6 rounded-2xl bg-white p-8 shadow-md",
+  title: "text-2xl font-bold text-zinc-900 text-left",
+  formGroup: "flex flex-col gap-4 w-full",
+  inputGroup: "flex flex-col gap-1",
+  label: "text-sm font-medium text-zinc-700",
+  input: "w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400",
+  loginButton: "w-full rounded-md bg-blue-500 py-2 text-white font-semibold hover:bg-blue-600 transition",
+  divider: "flex items-center gap-3 text-sm text-zinc-400",
+  dividerLine: "flex-1 h-px bg-zinc-300",
+  buttonGroup: "flex flex-col gap-3 font-semibold",
+} as const;


### PR DESCRIPTION
## 관련 이슈
Closes #6 

## 요약
- 무엇을 변경했나요?
로그인 페이지(/login) 기본 UI를 구현
사용자 인증 진입 화면을 제공하기 위해 로그인 폼(아이디/비밀번호 입력, 로그인 버튼)을 구성

- 왜 필요한가요?
인증 기능 구현 전, 사용자 진입 화면(UI)을 먼저 구성하여 이후 소셜 로그인 및 인증 로직을 연결하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`