### PR TITLE
[Feat] 로그인 성공 후 UI 전환 (#22)

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useAtomValue } from "jotai";
+import { authAtom } from "@/features/auth/application/atom/authAtom";
+
+export default function HomePage() {
+    const auth = useAtomValue(authAtom);
+
+    if (auth.status !== "AUTHENTICATED") {
+        return null;
+    }
+
+    return (
+        <main className="flex min-h-screen items-center justify-center bg-green-500">
+            <h1 className="text-3xl font-bold text-white">
+                회원 전용 메인 페이지
+            </h1>
+        </main>
+    );
+}

--- a/src/features/auth/application/hooks/useOAuthCallback.ts
+++ b/src/features/auth/application/hooks/useOAuthCallback.ts
@@ -67,7 +67,7 @@ export function useOAuthCallback() {
                 console.log("accessToken:", response.data.accessToken);
                 console.log("member:", response.data.member);
 
-                router.replace("/");
+                router.replace("/home");
             } catch (e) {
                 console.error("exchange 실패:", e);
                 router.replace("/login?error=exchange_failed");

--- a/src/ui/components/Navbar.tsx
+++ b/src/ui/components/Navbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { useAtomValue } from "jotai";
 import { authAtom } from "@/features/auth/application/atom/authAtom";
 
@@ -12,8 +13,8 @@ import {
 export default function Navbar() {
     const auth = useAtomValue(authAtom);
 
-    const isAuthenticated = auth.status === "AUTHENTICATED";
-    const isLoading = auth.status === "LOADING";
+    const [open, setOpen] = useState(false);
+    const isAuth = auth.status === "AUTHENTICATED";
 
     return (
         <nav className={navbarStyles.nav}>
@@ -24,11 +25,8 @@ export default function Navbar() {
 
           {/* RIGHT - AUTH AREA */}
           <div className={navbarStyles.rightGroup}>
-            {/* 로딩 */}
-            {isLoading && null}
-
             {/* 게스트 */}
-            {!isLoading && !isAuthenticated && (
+            {!isAuth && (
               <Link
                 href="/login"
                 className={`${authButtonStyles.base} ${authButtonStyles.login}`}
@@ -38,11 +36,27 @@ export default function Navbar() {
             )}
 
             {/* 로그인 성공 */}
-            {!isLoading && isAuthenticated && (
-              <div
-                className={`${authButtonStyles.base} ${authButtonStyles.profile}`}
-              >
+            {isAuth && (
+              <div className="relative">
+                <button
+                    onClick={() => setOpen((prev) => !prev)}
+                    className={`${authButtonStyles.base} ${authButtonStyles.profile}`}
+                >
                 Profile
+                </button>
+
+                {open && (
+                    <div className={navbarStyles.dropdown}>
+                        <button
+                            onClick={() => {
+                                console.log("로그아웃 버튼 클릭");
+                            }}
+                            className={navbarStyles.dropdownItem}
+                        >
+                            로그아웃
+                        </button>
+                    </div>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## 관련 이슈
Closes #22 

## 요약
- 로그인 상태일 때 메인 페이지 UI가 회원 전용 구조로 변경되도록 함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`

## UI 증빙
- [x] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.
https://github.com/user-attachments/assets/3316f153-d4ff-4256-aa19-a025edd587e5


## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
