### PR TITLE
[Chore] Github Actions의 Node를 24 버전으로 마이그레이션

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Auto Labeling based on Branch Name
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const branchName = context.payload.pull_request.head.ref.toLowerCase();


### PR DESCRIPTION
## 관련 이슈
Closes #37 

## 요약
- Github Actions에 Node 버전을 20 -> 24로 변경

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항

<img width="2290" height="975" alt="image" src="https://github.com/user-attachments/assets/4373848e-c18a-4a27-a1a1-f707c0c436bc" />

Actions는 성공하나 경고문 발생

<img width="2326" height="611" alt="image" src="https://github.com/user-attachments/assets/9cb53f40-513d-46ba-8a25-e8659ccb23d1" />

현재는 정상 작동
