### PR TITLE
[Feat] 로그인 상태 기반 사이드 네비 및 레이아웃 전환 UI 구현 (#41)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "clsx": "^2.1.1",
         "jotai": "^2.19.1",
+        "lucide-react": "^1.8.0",
         "next": "^16.2.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -4909,6 +4910,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "jotai": "^2.19.1",
+    "lucide-react": "^1.8.0",
     "next": "^16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/src/features/auth/application/hooks/useAuthAction.ts
+++ b/src/features/auth/application/hooks/useAuthAction.ts
@@ -1,25 +1,24 @@
-"use client";
-
 import { useSetAtom } from "jotai";
+import { useCallback } from "react";
 import { authAtom } from "@/features/auth/application/atom/authAtom";
 
-export const useAuthAction = () => {
+export function useAuthAction() {
     const setAuth = useSetAtom(authAtom);
 
-    const setLoading = () => {
+    const setLoading = useCallback(() => {
         setAuth({ status: "LOADING" });
-    };
+    }, [setAuth]);
 
-    const setAuthenticated = (accessToken: string) => {
+    const setAuthenticated = useCallback((accessToken: string) => {
         setAuth({
-            status: "AUTHENTICATED",
-            accessToken,
+        status: "AUTHENTICATED",
+        accessToken,
         });
-    };
+    }, [setAuth]);
 
-    const clearAuth = () => {
+    const clearAuth = useCallback(() => {
         setAuth({ status: "UNAUTHENTICATED" });
-    };
+    }, [setAuth]);
 
     return { setLoading, setAuthenticated, clearAuth };
-};
+}

--- a/src/features/auth/application/hooks/useAuthInit.ts
+++ b/src/features/auth/application/hooks/useAuthInit.ts
@@ -6,48 +6,48 @@ import { getAccessToken } from "@/features/auth/infrastructure/token/authTokenPr
 import { clientEnv } from "@/infrastructure/config/env";
 
 export function useAuthInit() {
-    const { setLoading, setAuthenticated, clearAuth } = useAuthAction();
+  const { setAuthenticated, setLoading, clearAuth } = useAuthAction();
 
-    useEffect(() => {
-        const init = async () => {
-            console.log("[AuthInit] 시작");
+  useEffect(() => {
+    const init = async () => {
+      const existingToken = getAccessToken();
 
-            const existingToken = getAccessToken();
-            if (existingToken) {
-                console.log("[AuthInit] 이미 로그인 상태 → skip");
-                return;
-            }
+      if (existingToken) {
+        setAuthenticated(existingToken);
+        return;
+      }
 
-            setLoading();
+      setLoading();
 
-            try {
-                const response = await fetch(
-                    `${clientEnv.apiBaseUrl}/api/v1/auth/refresh`,
-                    {
-                        method: "POST",
-                        credentials: "include",
-                    }
-                );
+      try {
+        const response = await fetch(
+          `${clientEnv.apiBaseUrl}/api/v1/auth/refresh`,
+          {
+            method: "POST",
+            credentials: "include",
+          }
+        );
 
-                if (!response.ok) {
-                    throw new Error("refresh 실패");
-                }
+        if (!response.ok) {
+          clearAuth();
+          return;
+        }
 
-                const data = await response.json();
-                const token = data.data?.accessToken;
+        const data = await response.json();
+        const token = data.data?.accessToken;
 
-                if (!token) throw new Error("accessToken 없음");
+        if (!token) {
+          clearAuth();
+          return;
+        }
 
-                setAuthenticated(token);
+        setAuthenticated(token);
+      } catch (error) {
+        console.error("[네트워크 오류]", error);
+        clearAuth();
+      }
+    };
 
-                console.log("[AuthInit] 자동 로그인 성공");
-
-            } catch (error) {
-                clearAuth();
-                console.log("[AuthInit] 자동 로그인 실패", error);
-            }
-        };
-
-        init();
-    }, [setLoading, setAuthenticated, clearAuth]);
+    init();
+  }, [setAuthenticated, setLoading, clearAuth]);
 }

--- a/src/ui/components/Navbar.tsx
+++ b/src/ui/components/Navbar.tsx
@@ -6,60 +6,56 @@ import { useAtomValue } from "jotai";
 import { authAtom } from "@/features/auth/application/atom/authAtom";
 
 import {
-    navbarStyles,
-    authButtonStyles,
+  navbarStyles,
+  authButtonStyles,
 } from "@/ui/styles/navbarStyles";
 
 export default function Navbar() {
-    const auth = useAtomValue(authAtom);
+  const auth = useAtomValue(authAtom);
+  const [open, setOpen] = useState(false);
+  const isAuth = auth.status === "AUTHENTICATED";
 
-    const [open, setOpen] = useState(false);
-    const isAuth = auth.status === "AUTHENTICATED";
+  return (
+    <nav
+      className={`${navbarStyles.nav} ${
+        isAuth ? "left-[280px]" : "left-0"
+      }`}
+    >
+      {!isAuth && (
+        <Link href="/" className={navbarStyles.logo}>
+          Matchuri
+        </Link>
+      )}
 
-    return (
-        <nav className={navbarStyles.nav}>
-          {/* 좌측 로고 */}
-          <Link href="/" className={navbarStyles.logo}>
-            Matchuri
+      <div className={isAuth ? navbarStyles.authRightOnly : navbarStyles.rightGroup}>
+        {!isAuth && (
+          <Link
+            href="/login"
+            className={`${authButtonStyles.base} ${authButtonStyles.login}`}
+          >
+            로그인
           </Link>
+        )}
 
-          {/* RIGHT - AUTH AREA */}
-          <div className={navbarStyles.rightGroup}>
-            {/* 게스트 */}
-            {!isAuth && (
-              <Link
-                href="/login"
-                className={`${authButtonStyles.base} ${authButtonStyles.login}`}
-              >
-                Login
-              </Link>
-            )}
+        {isAuth && (
+          <div className="relative">
+            <button
+              onClick={() => setOpen((prev) => !prev)}
+              className={`${authButtonStyles.base} ${authButtonStyles.profile}`}
+            >
+              Profile
+            </button>
 
-            {/* 로그인 성공 */}
-            {isAuth && (
-              <div className="relative">
-                <button
-                    onClick={() => setOpen((prev) => !prev)}
-                    className={`${authButtonStyles.base} ${authButtonStyles.profile}`}
-                >
-                Profile
+            {open && (
+              <div className={navbarStyles.dropdown}>
+                <button className={navbarStyles.dropdownItem}>
+                  로그아웃
                 </button>
-
-                {open && (
-                    <div className={navbarStyles.dropdown}>
-                        <button
-                            onClick={() => {
-                                console.log("로그아웃 버튼 클릭");
-                            }}
-                            className={navbarStyles.dropdownItem}
-                        >
-                            로그아웃
-                        </button>
-                    </div>
-                )}
               </div>
             )}
           </div>
-        </nav>
-    );
+        )}
+      </div>
+    </nav>
+  );
 }

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Home,
+  User,
+  Users,
+  UtensilsCrossed,
+  MapPin,
+  Settings,
+} from "lucide-react";
+
+import {
+  sidebarStyles,
+  sidebarMenuItemStyles,
+} from "@/ui/styles/sidebarStyles";
+
+const MENUS = [
+  { href: "/home", label: "홈", icon: Home },
+  { href: "/recommend/personal", label: "개인 메뉴 추천", icon: User },
+  { href: "/recommend/group", label: "그룹 메뉴 추천", icon: Users },
+  { href: "/preference", label: "취향 관리", icon: UtensilsCrossed },
+  { href: "/location", label: "위치 설정", icon: MapPin },
+  { href: "/settings", label: "설정", icon: Settings },
+];
+
+export default function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className={sidebarStyles.container}>
+      <div className={sidebarStyles.brandSection}>
+        <Link href="/home" className={sidebarStyles.brandLink}>
+          <UtensilsCrossed className={sidebarStyles.brandIcon} />
+          <span className={sidebarStyles.brandText}>Matchuri</span>
+        </Link>
+      </div>
+
+      <nav className={sidebarStyles.nav}>
+        {MENUS.map((menu) => {
+          const active = pathname === menu.href;
+          const Icon = menu.icon;
+
+          return (
+            <Link
+              key={menu.href}
+              href={menu.href}
+              className={
+                active
+                  ? `${sidebarMenuItemStyles.base} ${sidebarMenuItemStyles.active}`
+                  : `${sidebarMenuItemStyles.base} ${sidebarMenuItemStyles.inactive}`
+              }
+            >
+              <Icon className={sidebarMenuItemStyles.icon} />
+              <span>{menu.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/src/ui/layout/AppLayout.tsx
+++ b/src/ui/layout/AppLayout.tsx
@@ -1,16 +1,30 @@
 "use client";
 
-import { Provider } from "jotai";
+import { Provider, useAtomValue } from "jotai";
 import { useAuthInit } from "@/features/auth/application/hooks/useAuthInit";
+import { authAtom } from "@/features/auth/application/atom/authAtom";
+
 import Navbar from "@/ui/components/Navbar";
+import Sidebar from "@/ui/components/Sidebar";
 
 function AppContent({ children }: { children: React.ReactNode }) {
     useAuthInit();
 
+    const auth = useAtomValue(authAtom);
+    const isAuth = auth.status === "AUTHENTICATED";
+
     return (
         <>
             <Navbar />
-            <main>{children}</main>
+            {isAuth && <Sidebar />}
+            <main
+                className={[
+                    "h-screen overflow-y-auto",
+                    isAuth ? "ml-[280px]" : "",
+                ].join(" ")}
+            >
+            {children}
+            </main>
         </>
     );
 }

--- a/src/ui/styles/navbarStyles.ts
+++ b/src/ui/styles/navbarStyles.ts
@@ -1,22 +1,16 @@
 export const navbarStyles = {
-  nav: "fixed top-0 left-0 right-0 z-50 flex h-16 items-center justify-between px-6 bg-transparent backdrop-blur-sm",
-  logo: "text-lg font-bold tracking-tight text-zinc-900 dark:text-zinc-50",
-  menuGroup: "flex items-center gap-6",
+  nav: "fixed top-0 right-0 z-50 flex h-16 items-center justify-between px-6 transition-all",
+  logo: "text-lg font-bold tracking-tight text-slate-900",
   rightGroup: "flex items-center gap-4",
+  authRightOnly: "ml-auto flex items-center gap-4",
   dropdown:
-    "absolute right-0 mt-2 w-44 overflow-hidden rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900",
+    "absolute right-0 mt-2 w-44 overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg",
   dropdownItem:
-    "w-full px-4 py-2 text-left text-sm text-zinc-700 transition-colors hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800",
-  dropdownDivider:
-    "h-px w-full bg-zinc-200 dark:bg-zinc-700",
+    "w-full px-4 py-2 text-left text-sm text-slate-700 hover:bg-slate-100",
 } as const;
 
 export const authButtonStyles = {
-  base: "rounded-md px-3 py-1.5 text-sm font-medium transition-all duration-150",
-  login:
-    "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300",
-  profile:
-    "bg-zinc-100 text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-50 dark:hover:bg-zinc-700",
-  logout:
-    "text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20",
+  base: "rounded-md px-3 py-1.5 text-sm font-medium",
+  login: "border border-slate-400",
+  profile: "border border-slate-300 bg-transparent",
 } as const;

--- a/src/ui/styles/sidebarStyles.ts
+++ b/src/ui/styles/sidebarStyles.ts
@@ -1,0 +1,16 @@
+export const sidebarStyles = {
+  container:
+    "fixed top-0 left-0 w-[280px] h-screen border-r border-slate-200 bg-[#EDF2F7] px-5 py-6",
+  brandSection: "mb-8 mt-2",
+  brandLink: "flex items-center gap-3 px-3",
+  brandIcon: "h-7 w-7 text-blue-500",
+  brandText: "text-[20px] font-extrabold tracking-tight text-slate-900",
+  nav: "flex flex-col gap-3 mt-6",
+} as const;
+
+export const sidebarMenuItemStyles = {
+  base: "flex items-center gap-4 rounded-full px-5 py-4 text-[18px] font-semibold transition-colors",
+  active: "bg-white text-blue-600",
+  inactive: "text-slate-700 hover:bg-white/70",
+  icon: "h-6 w-6 shrink-0",
+} as const;


### PR DESCRIPTION
## 관련 이슈
Closes #41 

## 요약
로그인 상태일 때 회원 전용 레이아웃으로 전환되며,
좌측 사이드 네비게이션이 표시되고 상단 네비게이션과 메인 영역이 이에 맞게 재배치


## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
