### PR TITLE
[Feat] 미구현 페이지 클릭 시 준비중 안내 처리 (#51)

### DIFF
--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -17,9 +17,9 @@ import {
 } from "@/ui/styles/sidebarStyles";
 
 const MENUS = [
-  { href: "/home", label: "홈", icon: Home },
-  { href: "/recommend/personal", label: "개인 메뉴 추천", icon: User },
-  { href: "/recommend/group", label: "그룹 메뉴 추천", icon: Users },
+  { href: "/home", label: "홈", icon: Home, enabled: true },
+  { href: "/personal", label: "개인 메뉴 추천", icon: User },
+  { href: "/group", label: "그룹 메뉴 추천", icon: Users },
   { href: "/preference", label: "취향 관리", icon: UtensilsCrossed },
   { href: "/location", label: "위치 설정", icon: MapPin },
   { href: "/settings", label: "설정", icon: Settings },
@@ -27,6 +27,11 @@ const MENUS = [
 
 export default function Sidebar() {
   const pathname = usePathname();
+
+  const handleNotReady = (e: React.MouseEvent) => {
+    e.preventDefault(); // 라우팅 막기
+    alert("준비중인 기능입니다.");
+  };
 
   return (
     <aside className={sidebarStyles.container}>
@@ -41,11 +46,13 @@ export default function Sidebar() {
         {MENUS.map((menu) => {
           const active = pathname === menu.href;
           const Icon = menu.icon;
+          const isEnabled = menu.enabled;
 
           return (
             <Link
               key={menu.href}
               href={menu.href}
+              onClick={!isEnabled ? handleNotReady : undefined}
               className={
                 active
                   ? `${sidebarMenuItemStyles.base} ${sidebarMenuItemStyles.active}`


### PR DESCRIPTION
## 관련 이슈
Closes #51

## 요약
- 무엇을 변경했나요?
미구현 페이지 클릭 시 "준비중" 안내 메시지를 표시하도록 처리
- 왜 이 변경이 필요한가요?
404 에러로 인한 사용자 혼란을 줄이고, 서비스 상태를 명확히 안내하기 위해

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
