### PR TITLE
[Fix] 미구현 사이드바 메뉴 클릭 시 404 발생 문제 수정 (#53)

### DIFF
--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -18,18 +18,17 @@ import {
 
 const MENUS = [
   { href: "/home", label: "홈", icon: Home, enabled: true },
-  { href: "/personal", label: "개인 메뉴 추천", icon: User },
-  { href: "/group", label: "그룹 메뉴 추천", icon: Users },
-  { href: "/preference", label: "취향 관리", icon: UtensilsCrossed },
-  { href: "/location", label: "위치 설정", icon: MapPin },
-  { href: "/settings", label: "설정", icon: Settings },
+  { href: "/personal", label: "개인 메뉴 추천", icon: User, enabled: false },
+  { href: "/group", label: "그룹 메뉴 추천", icon: Users, enabled: false },
+  { href: "/preference", label: "취향 관리", icon: UtensilsCrossed, enabled: false },
+  { href: "/location", label: "위치 설정", icon: MapPin, enabled: false },
+  { href: "/settings", label: "설정", icon: Settings, enabled: false },
 ];
 
 export default function Sidebar() {
   const pathname = usePathname();
 
-  const handleNotReady = (e: React.MouseEvent) => {
-    e.preventDefault(); // 라우팅 막기
+  const handleNotReady = () => {
     alert("준비중인 기능입니다.");
   };
 
@@ -46,22 +45,33 @@ export default function Sidebar() {
         {MENUS.map((menu) => {
           const active = pathname === menu.href;
           const Icon = menu.icon;
-          const isEnabled = menu.enabled;
+          const className = active
+            ? `${sidebarMenuItemStyles.base} ${sidebarMenuItemStyles.active}`
+            : `${sidebarMenuItemStyles.base} ${sidebarMenuItemStyles.inactive}`;
+
+          if (menu.enabled) {
+            return (
+              <Link
+                key={menu.href}
+                href={menu.href}
+                className={className}
+              >
+                <Icon className={sidebarMenuItemStyles.icon} />
+                <span>{menu.label}</span>
+              </Link>
+            );
+          }
 
           return (
-            <Link
+            <button
               key={menu.href}
-              href={menu.href}
-              onClick={!isEnabled ? handleNotReady : undefined}
-              className={
-                active
-                  ? `${sidebarMenuItemStyles.base} ${sidebarMenuItemStyles.active}`
-                  : `${sidebarMenuItemStyles.base} ${sidebarMenuItemStyles.inactive}`
-              }
+              type="button"
+              onClick={handleNotReady}
+              className={`${className} w-full text-left`}
             >
               <Icon className={sidebarMenuItemStyles.icon} />
               <span>{menu.label}</span>
-            </Link>
+            </button>
           );
         })}
       </nav>


### PR DESCRIPTION
## 관련 이슈
Closes #53 

## 요약
- 무엇을 변경했나요?
미구현 사이드바 메뉴가 실제 라우팅되지 않도록 수정, 준비중 안내만 표시되도록 변경
- 왜 이 변경이 필요한가요?
미구현 메뉴 접근 시 발생하던 404 요청을 방지하고 사용자 경험을 개선

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
