### PR TITLE
[Feat] loginId/password 기반 일반 로그인 및 인증 상태 처리 구현 (#17)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,9 +4,11 @@ import { useEffect } from "react";
 import { useAtomValue } from "jotai";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+
 import { loginPageStyles } from "@/ui/styles/loginPageStyles";
 import SocialLoginButton from "@/features/auth/ui/components/SocialLoginButton";
 import type { AuthProvider } from "@/features/auth/domain/model/AuthProvider";
+import { useLogin } from "@/features/auth/application/hooks/useLogin";
 import {
   isAuthenticatedAtom,
   isAuthLoadingAtom,
@@ -18,6 +20,17 @@ export default function LoginPage() {
   const router = useRouter();
   const isAuthenticated = useAtomValue(isAuthenticatedAtom);
   const isAuthLoading = useAtomValue(isAuthLoadingAtom);
+
+  const {
+    loginId,
+    setLoginId,
+    password,
+    setPassword,
+    errorMessage,
+    isSubmitting,
+    isValid,
+    submit,
+  } = useLogin();
 
   useEffect(() => {
     if (!isAuthLoading && isAuthenticated) {
@@ -47,16 +60,35 @@ export default function LoginPage() {
         <div className={loginPageStyles.formGroup}>
           <div className={loginPageStyles.inputGroup}>
             <label className={loginPageStyles.label}>아이디</label>
-            <input type="text" className={loginPageStyles.input} />
+            <input
+              type="text"
+              value={loginId}
+              onChange={(e) => setLoginId(e.target.value)}
+              className={loginPageStyles.input}
+            />
           </div>
 
           <div className={loginPageStyles.inputGroup}>
             <label className={loginPageStyles.label}>비밀번호</label>
-            <input type="password" className={loginPageStyles.input} />
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className={loginPageStyles.input}
+            />
           </div>
 
-          <button className={loginPageStyles.loginButton}>
-            로그인
+          {errorMessage && (
+            <p className="text-sm text-red-500">{errorMessage}</p>
+          )}
+
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!isValid || isSubmitting}
+            className={loginPageStyles.loginButton}
+          >
+            {isSubmitting ? "로그인 중..." : "로그인"}
           </button>
         </div>
 

--- a/src/features/auth/application/hooks/useLogin.ts
+++ b/src/features/auth/application/hooks/useLogin.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { HttpError } from "@/infrastructure/http/httpClient";
+import { login } from "@/features/auth/application/usecase/login";
+
+export function useLogin() {
+    const router = useRouter();
+
+    const [loginId, setLoginId] = useState("");
+    const [password, setPassword] = useState("");
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const isValid = useMemo(() => {
+        return loginId.trim().length > 0 && password.trim().length > 0;
+    }, [loginId, password]);
+
+    const submit = useCallback(async () => {
+        if (!isValid || isSubmitting) return;
+
+        setIsSubmitting(true);
+        setErrorMessage(null);
+
+        try {
+            await login({
+                loginId: loginId.trim(),
+                password,
+            });
+
+            router.replace("/home");
+        } catch (error) {
+            if (error instanceof HttpError && error.status === 401) {
+                setErrorMessage("아이디 또는 비밀번호가 올바르지 않습니다.");
+            } else {
+                setErrorMessage("로그인 중 문제가 발생했습니다.");
+            }
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [isSubmitting, isValid, loginId, password, router]);
+
+    return {
+        loginId,
+        setLoginId,
+        password,
+        setPassword,
+        errorMessage,
+        isSubmitting,
+        isValid,
+        submit,
+    };
+}

--- a/src/features/auth/application/usecase/login.ts
+++ b/src/features/auth/application/usecase/login.ts
@@ -1,0 +1,20 @@
+import { authApi } from "@/features/auth/infrastructure/api/authApi";
+import type { LoginRequest } from "@/features/auth/domain/model/LoginRequest";
+import {
+    clearAuth,
+    setAuthenticated,
+} from "@/features/auth/application/store/authStore";
+
+export async function login(request: LoginRequest) {
+    try {
+        const response = await authApi.login(request);
+        const accessToken = response.data.accessToken;
+
+        setAuthenticated(accessToken);
+
+        return response;
+    } catch (error) {
+        clearAuth();
+        throw error;
+    }
+}

--- a/src/features/auth/domain/model/LoginMember.ts
+++ b/src/features/auth/domain/model/LoginMember.ts
@@ -1,0 +1,5 @@
+// 서버 응답 구조를 타입으로 정의
+export interface LoginMember {
+    readonly id: number;
+    readonly role: string;
+}

--- a/src/features/auth/domain/model/LoginRequest.ts
+++ b/src/features/auth/domain/model/LoginRequest.ts
@@ -1,0 +1,4 @@
+export interface LoginRequest {
+    readonly loginId: string;
+    readonly password: string;
+}

--- a/src/features/auth/infrastructure/api/authApi.ts
+++ b/src/features/auth/infrastructure/api/authApi.ts
@@ -3,6 +3,8 @@ import type { AuthProvider } from "@/features/auth/domain/model/AuthProvider";
 import type { OAuthExchangeResponse } from "@/features/auth/infrastructure/api/dto/OAuthExchangeResponse";
 import type { RefreshResponse } from "@/features/auth/infrastructure/api/dto/RefreshResponse";
 import type { LogoutResponse } from "@/features/auth/infrastructure/api/dto/LogoutResponse";
+import type { LoginRequest } from "@/features/auth/domain/model/LoginRequest";
+import type { LoginResponse } from "@/features/auth/infrastructure/api/dto/LoginResponse";
 
 interface LoginIdExistsResponse {
     success: boolean;
@@ -55,6 +57,10 @@ export const authApi = {
 
     logout() {
         return httpClient.post<LogoutResponse>("/api/v1/auth/logout");
+    },
+
+    login(payload: LoginRequest) {
+        return httpClient.post<LoginResponse>("/api/v1/auth/login", payload);
     },
 
     checkLoginIdExists(loginId: string) {

--- a/src/features/auth/infrastructure/api/dto/LoginResponse.ts
+++ b/src/features/auth/infrastructure/api/dto/LoginResponse.ts
@@ -1,0 +1,12 @@
+// 일반 로그인 성공 응답 타입
+import type { ApiResponse } from "@/features/auth/domain/model/ApiResponse";
+import type { LoginMember } from "@/features/auth/domain/model/LoginMember";
+
+export interface LoginResponseData {
+    readonly accessToken: string;
+    readonly refreshToken: string | null;
+    readonly expiresIn: number;
+    readonly member: LoginMember;
+}
+
+export type LoginResponse = ApiResponse<LoginResponseData>;

--- a/src/ui/styles/loginPageStyles.ts
+++ b/src/ui/styles/loginPageStyles.ts
@@ -5,7 +5,7 @@ export const loginPageStyles = {
   formGroup: "flex flex-col gap-4 w-full",
   inputGroup: "flex flex-col gap-1",
   label: "text-sm font-medium text-zinc-700",
-  input: "w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400",
+  input: "w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-400",
   loginButton: "w-full rounded-md bg-blue-500 py-2 text-white font-semibold hover:bg-blue-600 transition",
   divider: "flex items-center gap-3 text-sm text-zinc-400",
   dividerLine: "flex-1 h-px bg-zinc-300",


### PR DESCRIPTION
## 관련 이슈
Closes #17 

## 요약
- loginId/password 기반 일반 로그인 기능 구현
- 로그인 성공 시 accessToken 저장 및 인증 상태 반영
- 로그인 실패 시 에러 메시지 처리
- 로그인 후 회원 전용 페이지로 이동 처리

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
