### PR TITLE
[Feat] 소셜 로그인 콜백 후 온보딩 상태 기반 분기 처리 (#33)

### DIFF
--- a/src/app/signup/nickname/page.tsx
+++ b/src/app/signup/nickname/page.tsx
@@ -2,13 +2,15 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { useAtomValue } from "jotai";
 
 import { nicknamePageStyles } from "@/ui/styles/nicknamePageStyles";
 import { accountStorage } from "@/features/auth/infrastructure/storage/accountStorage";
 import { termsStorage } from "@/features/terms/infrastructure/storage/termsStorage";
 import { authApi } from "@/features/auth/infrastructure/api/authApi";
 
-import type { TermsAgreement } from "@/features/terms/domain/model/termsAgreement";
+import { onboardingAtom } from "@/features/auth/application/selectors/authSelectors";
+import { useSubmitMyNickname } from "@/features/auth/application/hooks/useSubmitMyNickname";
 
 type NicknameStatus =
   | "idle"
@@ -19,45 +21,55 @@ type NicknameStatus =
 
 export default function NicknamePage() {
   const router = useRouter();
+  const onboarding = useAtomValue(onboardingAtom);
 
-  // 이전 단계 데이터
-  const [accountId, setAccountId] = useState("");
-  const [accountPass, setAccountPass] = useState("");
-  const [agreements, setAgreements] = useState<TermsAgreement[]>([]);
+  const { submit: submitMyNickname, isSubmitting } = useSubmitMyNickname();
+  const isSocialOnboarding = onboarding?.nextStep === "REQUIRED_NICKNAME";
 
   // 닉네임
   const [nickname, setNickname] = useState("");
-  const [nicknameStatus, setNicknameStatus] =
-    useState<NicknameStatus>("idle");
-
-  // 가입 처리
-  const [submitting, setSubmitting] = useState(false);
+  const [nicknameStatus, setNicknameStatus] = useState<NicknameStatus>("idle");
 
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
 
-   // 가입 버튼 활성화: 닉네임 사용 가능 + 제출 중 아님
-  const canSubmit =
-    nicknameStatus === "available" &&
-    !submitting;
+  // 가입 버튼 활성화: 닉네임 사용 가능 + 제출 중 아님
+  const canSubmit = nicknameStatus === "available" && !isSubmitting;
 
+  // 일반 회원가입 데이터 로딩
   useEffect(() => {
     const account = accountStorage.load();
-    const agreements = termsStorage.load();
+    const savedAgreements = termsStorage.load();
 
-    // 이전 단계 데이터 없으면 회원가입 첫 단계로 이동
-    if (!account || !agreements || agreements.length === 0) {
-      router.replace("/signup");
+    const isGeneralSignup =
+      !!account && !!savedAgreements && savedAgreements.length > 0;
+
+    // 1. 일반 회원가입 흐름
+    if (isGeneralSignup) return;
+
+    // 2. 소셜 온보딩: 닉네임 단계
+    if (onboarding?.nextStep === "REQUIRED_NICKNAME") return;
+
+    // 3. 소셜 온보딩: 약관 단계로 돌아가야 하는 상태
+    if (onboarding?.nextStep === "REQUIRED_AGREEMENTS") {
+      router.replace("/terms");
       return;
     }
 
-    // 콘솔 확인용
-    console.log("accountStorage:", account);
-    console.log("termsStorage:", agreements);
+    // 4. 소셜 온보딩 완료 상태
+    if (onboarding?.nextStep === "READY") {
+      router.replace("/home");
+      return;
+    }
 
-    setAccountId(account.id);
-    setAccountPass(account.password);
-    setAgreements(agreements);
-  }, [router]);
+    // 5. onboarding이 아직 null이면 auth 초기화/상태 반영 대기
+    if (onboarding === null) {
+      return;
+    }
+
+    // 6. 여기까지 왔으면 일반 회원가입 데이터도 없고 온보딩 상태도 맞지 않는 비정상 접근
+    router.replace("/signup");
+
+  }, [router, onboarding]);
 
    // 닉네임 입력 시 즉시 유효성 검사
   const handleChangeNickname = (value: string) => {
@@ -76,14 +88,8 @@ export default function NicknamePage() {
       return;
     }
 
-    // 최대 100자
-    if (trimmed.length > 100) {
-      setNicknameStatus("invalid");
-      return;
-    }
-
-    // 공백만 있는 값 방지
-    if (trimmed.length === 0) {
+    // 최대 100자 && 공백만 있는 값 방지
+    if (trimmed.length === 0 || trimmed.length > 100) {
       setNicknameStatus("invalid");
       return;
     }
@@ -92,7 +98,7 @@ export default function NicknamePage() {
     setNicknameStatus("checking");
   };
 
-   // 닉네임 중복 확인
+   // 닉네임 중복 검사
   useEffect(() => {
     const trimmed = nickname.trim();
 
@@ -128,13 +134,26 @@ export default function NicknamePage() {
     if (!canSubmit) return;
 
     try {
-      setSubmitting(true);
+      // 소셜 온보딩
+      if (isSocialOnboarding) {
+        await submitMyNickname(nickname.trim());
+        return;
+      }
 
+      const account = accountStorage.load();
+      const savedAgreements = termsStorage.load();
+
+      if (!account || !savedAgreements || savedAgreements.length === 0) {
+        router.replace("/signup");
+        return;
+      }
+
+      // 일반 회원가입
       const payload = {
-        loginId: accountId,
-        password: accountPass,
+        loginId: account.id,
+        password: account.password,
         nickname: nickname.trim(),
-        agreements: agreements
+        agreements: savedAgreements
           .filter((item) => item.agreed)
           .map((item) => ({
             agreementType: item.agreementType,
@@ -158,9 +177,6 @@ export default function NicknamePage() {
     } catch (error) {
       console.error("회원가입 실패:", error);
       router.push("/login");
-
-    } finally {
-      setSubmitting(false);
     }
   };
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -2,22 +2,41 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
+import { useAtomValue } from "jotai";
+
 import { getTerms } from "@/features/terms/domain/model/getTerms";
 import TermGroupItem from "@/features/terms/ui/components/TermGroupItem";
 import { termsPageStyles } from "@/ui/styles/termsPageStyles";
 import { termsStorage } from "@/features/terms/infrastructure/storage/termsStorage";
-import { accountStorage } from "@/features/auth/infrastructure/storage/accountStorage";
+
+import { onboardingAtom } from "@/features/auth/application/selectors/authSelectors";
+import { useSubmitRequiredAgreements } from "@/features/auth/application/hooks/useSubmitRequiredAgreements";
+import { getOnboardingRoute } from "@/features/auth/application/onboarding/getOnboardingRoute";
 
 export default function TermsPage() {
   const router = useRouter();
   const terms = getTerms();
-//   const [ready, setReady] = useState(false);
+
+  const onboarding = useAtomValue(onboardingAtom);
+  const { submit, isSubmitting } = useSubmitRequiredAgreements();
+
+  const shouldSubmitAgreementsToServer = onboarding?.nextStep === "REQUIRED_AGREEMENTS";
 
   const [checkedMap, setCheckedMap] = useState<Record<string, boolean>>(() =>
     Object.fromEntries(terms.map((t) => [t.name, false])),
   );
 
+  // 소셜 온보딩인데 이미 약관 단계가 아니면 맞는 페이지로 이동
+  useEffect(() => {
+    if (!onboarding) return;
+
+    if (onboarding.nextStep !== "REQUIRED_AGREEMENTS") {
+      router.replace(getOnboardingRoute(onboarding.nextStep));
+    }
+  }, [onboarding, router]);
+
   const allChecked = terms.every((t) => checkedMap[t.name]);
+
   const requiredAllChecked = useMemo(
     () => terms.filter((t) => t.required).every((t) => checkedMap[t.name]),
     [terms, checkedMap],
@@ -32,26 +51,30 @@ export default function TermsPage() {
     setCheckedMap(Object.fromEntries(terms.map((t) => [t.name, next])));
   };
 
-  const handleSubmit = () => {
-    const agreements = terms.map((t) => ({
-      agreementType: t.type,
-      agreementVersion: t.version,
-      agreed: checkedMap[t.name],
+  const handleSubmit = async () => {
+    const agreements = terms.map((term) => ({
+      agreementType: term.type,
+      agreementVersion: term.version,
+      agreed: checkedMap[term.name],
     }));
 
-    termsStorage.save(agreements);
-    router.push("/signup/nickname/");
-  };
-
-  useEffect(() => {
-    const profile = accountStorage.load();
-
-    if (!profile) {
-      router.replace("/signup");
+    // 일반 회원가입: 서버 호출 없이 로컬에 저장
+    if (!shouldSubmitAgreementsToServer) {
+      termsStorage.save(agreements);
+      router.push("/signup/nickname");
       return;
     }
 
-  }, [router]);
+    // 소셜 온보딩: 약관 동의 정보를 서버로 제출
+    await submit(
+      agreements
+        .filter((agreement) => agreement.agreed)
+        .map((agreement) => ({
+          agreementType: agreement.agreementType,
+          agreementVersion: agreement.agreementVersion,
+        })),
+    );
+  };
 
   return (
     <div className={termsPageStyles.container}>
@@ -86,15 +109,15 @@ export default function TermsPage() {
 
         <button
           type="button"
-          disabled={!requiredAllChecked}
+          disabled={!requiredAllChecked || isSubmitting}
           onClick={handleSubmit}
           className={
-            requiredAllChecked
+            requiredAllChecked && !isSubmitting
               ? termsPageStyles.submitButton
               : termsPageStyles.submitButtonDisabled
           }
         >
-          동의하고 계속하기
+          {isSubmitting ? "처리 중..." : "동의하고 계속하기"}
         </button>
       </div>
     </div>

--- a/src/features/auth/application/hooks/useAuthInit.ts
+++ b/src/features/auth/application/hooks/useAuthInit.ts
@@ -18,8 +18,9 @@ export function useAuthInit() {
             try {
                 const response = await authApi.refresh();
                 const accessToken = response.data.accessToken;
+                const onboarding = response.data.onboarding;
 
-                if (!accessToken) {
+                if (!accessToken || !onboarding) {
                     if (!cancelled) {
                         clearAuth();
                     }
@@ -27,7 +28,7 @@ export function useAuthInit() {
                 }
 
                 if (!cancelled) {
-                    setAuthenticated(accessToken);
+                    setAuthenticated(accessToken, onboarding);
                 }
             } catch {
                 if (!cancelled) {

--- a/src/features/auth/application/hooks/useLogin.ts
+++ b/src/features/auth/application/hooks/useLogin.ts
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { HttpError } from "@/infrastructure/http/httpClient";
 import { login } from "@/features/auth/application/usecase/login";
+import { getOnboardingRoute } from "@/features/auth/application/onboarding/getOnboardingRoute";
 
 export function useLogin() {
     const router = useRouter();
@@ -24,12 +25,12 @@ export function useLogin() {
         setErrorMessage(null);
 
         try {
-            await login({
+            const response = await login({
                 loginId: loginId.trim(),
                 password,
             });
 
-            router.replace("/home");
+            router.replace(getOnboardingRoute(response.data.onboarding.nextStep));
         } catch (error) {
             if (error instanceof HttpError && error.status === 401) {
                 setErrorMessage("아이디 또는 비밀번호가 올바르지 않습니다.");

--- a/src/features/auth/application/hooks/useOAuthCallback.ts
+++ b/src/features/auth/application/hooks/useOAuthCallback.ts
@@ -4,6 +4,9 @@ import { useEffect } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { AuthProviderMap } from "@/features/auth/domain/model/AuthProviderMap";
 import { exchangeOAuthCode } from "@/features/auth/application/usecase/exchangeOAuthCode";
+import { getOnboardingRoute } from "@/features/auth/application/onboarding/getOnboardingRoute";
+
+const OAUTH_PROCESSING_CODE_KEY = "oauth_processing_code";
 
 export function useOAuthCallback() {
     const router = useRouter();
@@ -11,8 +14,6 @@ export function useOAuthCallback() {
     const params = useParams<{ provider: string }>();
 
     useEffect(() => {
-        let cancelled = false;
-
         const run = async () => {
             const loginResult = searchParams.get("loginResult");
             const code = searchParams.get("code");
@@ -21,11 +22,21 @@ export function useOAuthCallback() {
             const providerParam = params.provider;
             const normalizedProvider = AuthProviderMap[providerParam];
 
+            console.log("📌 callback params:", {
+                loginResult,
+                code,
+                errorCode,
+                providerParam,
+                normalizedProvider,
+            });
+
+            // 1. provider 유효성 체크
             if (!normalizedProvider) {
                 router.replace("/auth/login?error=invalid_provider");
                 return;
             }
 
+            // 2. OAuth 실패 케이스
             if (loginResult === "failed") {
                 router.replace(
                     `/auth/login?error=${encodeURIComponent(errorCode ?? "oauth_failed")}`,
@@ -33,44 +44,46 @@ export function useOAuthCallback() {
                 return;
             }
 
+            // 3. 잘못된 콜백 접근
             if (loginResult !== "success") {
                 router.replace("/auth/login?error=invalid_callback");
                 return;
             }
 
+            // 4. code 없음
             if (!code) {
                 router.replace("/auth/login?error=missing_code");
                 return;
             }
 
+            const processingCode = sessionStorage.getItem(OAUTH_PROCESSING_CODE_KEY);
+
+            if (processingCode === code) {
+                console.warn("이미 처리 중인 OAuth code입니다. 중복 exchange를 막습니다.");
+                return;
+            }
+
+            sessionStorage.setItem(OAUTH_PROCESSING_CODE_KEY, code);
+
             try {
+                console.log("🚀 exchange 요청 직전");
+
+                // 5. 서버에 code 전달 → 토큰 + onboarding 받기
                 const response = await exchangeOAuthCode(normalizedProvider, code);
 
-                if (cancelled) return;
+                console.log("✅ exchange 성공:", response);
 
-                /**
-                 * 추후 회원가입 분기 확장 포인트
-                 *
-                 * 예:
-                 * if (response.data.nextAction === "SIGNUP_REQUIRED") {
-                 *   router.replace("/signup/terms");
-                 *   return;
-                 * }
-                 */
+                // 6. onboarding 기준으로 분기
+                const nextStep = response.data.onboarding.nextStep;
+                router.replace(getOnboardingRoute(nextStep));
+            } catch (error) {
+                console.error("🚫OAuth exchange 실패:", error);
 
-                void response;
-                router.replace("/home");
-            } catch {
-                if (!cancelled) {
-                    router.replace("/auth/login?error=exchange_failed");
-                }
+                // 디버깅 중에는 이동 막기
+//                 router.replace("/auth/login?error=exchange_failed");
             }
         };
 
         run();
-
-        return () => {
-            cancelled = true;
-        };
     }, [router, searchParams, params.provider]);
 }

--- a/src/features/auth/application/hooks/useSubmitMyNickname.ts
+++ b/src/features/auth/application/hooks/useSubmitMyNickname.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { authApi } from "@/features/auth/infrastructure/api/authApi";
+import {
+    updateOnboarding,
+} from "@/features/auth/application/store/authStore";
+import { getOnboardingRoute } from "@/features/auth/application/onboarding/getOnboardingRoute";
+
+export function useSubmitMyNickname() {
+    const router = useRouter();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const submit = useCallback(
+        async (nickname: string) => {
+            if (isSubmitting) return;
+
+            setIsSubmitting(true);
+
+            try {
+                const response = await authApi.updateOnboardingNickname({
+                    nickname,
+                });
+
+                console.log("닉네임 완료 응답:", response.data.onboarding);
+                console.log(
+                    "이동 경로:",
+                    getOnboardingRoute(response.data.onboarding.nextStep)
+                );
+
+                // onboarding 상태 업데이트
+                updateOnboarding(response.data.onboarding);
+
+                // 다음 단계 이동 (READY → /home)
+                router.replace(
+                    getOnboardingRoute(response.data.onboarding.nextStep),
+                );
+            } finally {
+                setIsSubmitting(false);
+            }
+        },
+        [isSubmitting, router],
+    );
+
+    return {
+        isSubmitting,
+        submit,
+    };
+}

--- a/src/features/auth/application/hooks/useSubmitRequiredAgreements.ts
+++ b/src/features/auth/application/hooks/useSubmitRequiredAgreements.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import { authApi } from "@/features/auth/infrastructure/api/authApi";
+import {
+    setAuthenticated,
+    updateOnboarding,
+} from "@/features/auth/application/store/authStore";
+import { getOnboardingRoute } from "@/features/auth/application/onboarding/getOnboardingRoute";
+
+interface AgreementItem {
+    agreementType: string;
+    agreementVersion: string;
+}
+
+export function useSubmitRequiredAgreements() {
+    const router = useRouter();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const submit = useCallback(
+        async (agreements: AgreementItem[]) => {
+            if (isSubmitting) return;
+
+            setIsSubmitting(true);
+
+            try {
+                const response = await authApi.submitRequiredAgreements({ agreements });
+
+                if (response.data.accessToken) {
+                    setAuthenticated(response.data.accessToken, response.data.onboarding);
+                } else {
+                    updateOnboarding(response.data.onboarding);
+                }
+
+                router.replace(getOnboardingRoute(response.data.onboarding.nextStep));
+            } finally {
+                setIsSubmitting(false);
+            }
+        },
+        [isSubmitting, router],
+    );
+
+    return {
+        isSubmitting,
+        submit,
+    };
+}

--- a/src/features/auth/application/onboarding/getOnboardingRoute.ts
+++ b/src/features/auth/application/onboarding/getOnboardingRoute.ts
@@ -1,0 +1,11 @@
+import type { OnboardingNextStep } from "@/features/auth/domain/model/Onboarding";
+
+const ONBOARDING_ROUTE_MAP: Record<OnboardingNextStep, string> = {
+  REQUIRED_AGREEMENTS: "/terms",
+  REQUIRED_NICKNAME: "/signup/nickname",
+  READY: "/home",
+};
+
+export function getOnboardingRoute(nextStep: OnboardingNextStep): string {
+  return ONBOARDING_ROUTE_MAP[nextStep];
+}

--- a/src/features/auth/application/selectors/authSelectors.ts
+++ b/src/features/auth/application/selectors/authSelectors.ts
@@ -15,3 +15,17 @@ export const accessTokenAtom = atom((get) => {
     const auth = get(authAtom);
     return auth.status === "AUTHENTICATED" ? auth.accessToken : null;
 });
+
+export const onboardingAtom = atom((get) => {
+    const auth = get(authAtom);
+    return auth.status === "AUTHENTICATED" ? auth.onboarding : null;
+});
+
+export const isOnboardingReadyAtom = atom((get) => {
+    const auth = get(authAtom);
+
+    return (
+        auth.status === "AUTHENTICATED" &&
+        auth.onboarding.nextStep === "READY"
+    );
+});

--- a/src/features/auth/application/store/authStore.ts
+++ b/src/features/auth/application/store/authStore.ts
@@ -1,14 +1,30 @@
 import { authAtom } from "@/features/auth/application/atom/authAtom";
 import { jotaiStore } from "@/shared/lib/jotaiStore";
+import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
 
 export function setAuthLoading() {
     jotaiStore.set(authAtom, { status: "LOADING" });
 }
 
-export function setAuthenticated(accessToken: string) {
+export function setAuthenticated(
+    accessToken: string,
+    onboarding: OnboardingState,
+) {
     jotaiStore.set(authAtom, {
         status: "AUTHENTICATED",
         accessToken,
+        onboarding,
+    });
+}
+
+export function updateOnboarding(onboarding: OnboardingState) {
+    const auth = jotaiStore.get(authAtom);
+
+    if (auth.status !== "AUTHENTICATED") return;
+
+    jotaiStore.set(authAtom, {
+        ...auth,
+        onboarding,
     });
 }
 

--- a/src/features/auth/application/usecase/exchangeOAuthCode.ts
+++ b/src/features/auth/application/usecase/exchangeOAuthCode.ts
@@ -10,14 +10,18 @@ export async function exchangeOAuthCode(
     provider: AuthProvider,
     code: string,
 ) {
+    console.log("🚀 exchangeOAuthCode 호출:", { provider, code });
     setAuthLoading();
 
     try {
         const response = await authApi.exchangeCode(provider, code);
+        console.log("✅ exchange 응답:", response);
         const accessToken = response.data.accessToken;
+        const onboarding = response.data.onboarding;
 
-        setAuthenticated(accessToken);
+        setAuthenticated(accessToken, onboarding);
         console.log("accessToken 저장 완료:", accessToken);
+        console.log("onboarding:", onboarding);
 
         return response;
     } catch (error) {

--- a/src/features/auth/application/usecase/login.ts
+++ b/src/features/auth/application/usecase/login.ts
@@ -9,8 +9,9 @@ export async function login(request: LoginRequest) {
     try {
         const response = await authApi.login(request);
         const accessToken = response.data.accessToken;
+        const onboarding = response.data.onboarding;
 
-        setAuthenticated(accessToken);
+        setAuthenticated(accessToken, onboarding);
 
         return response;
     } catch (error) {

--- a/src/features/auth/domain/model/OAuthExchangeData.ts
+++ b/src/features/auth/domain/model/OAuthExchangeData.ts
@@ -1,10 +1,14 @@
+import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
+
 // OAuth 로그인 성공 시 실제 데이터 내용
 export interface OAuthExchangeData {
-    accessToken: string;
-    refreshToken: string | null;
-    expiresIn: number;
-    member: {
-        id: number;
-        role: string;
+    readonly accessToken: string;
+    readonly refreshToken: string | null;
+    readonly expiresIn: number;
+    readonly member: {
+        readonly id: number;
+        readonly role: string;
+        readonly nickname: string;
     };
+    readonly onboarding: OnboardingState;
 }

--- a/src/features/auth/domain/model/Onboarding.ts
+++ b/src/features/auth/domain/model/Onboarding.ts
@@ -1,0 +1,12 @@
+// 서버가 내려주는 onboarding 구조를 타입으로 정의
+export type OnboardingNextStep =
+    | "REQUIRED_AGREEMENTS"
+    | "REQUIRED_NICKNAME"
+    | "READY";
+
+export interface OnboardingState {
+    readonly requiredAgreementsCompleted: boolean;
+    readonly nicknameCompleted: boolean;
+    readonly completed: boolean;
+    readonly nextStep: OnboardingNextStep;
+}

--- a/src/features/auth/domain/state/AuthState.ts
+++ b/src/features/auth/domain/state/AuthState.ts
@@ -1,16 +1,10 @@
+import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
+
 export type AuthState =
     | { readonly status: "LOADING" } // 로그인 시작
     | { readonly status: "UNAUTHENTICATED" } // 실패
     | {
           readonly status: "AUTHENTICATED"; // 성공
           readonly accessToken: string;
+          readonly onboarding: OnboardingState;
       };
-
-/**
- * 추후 소셜 회원가입 분기 필요 시 예시:
- * | {
- *     readonly status: "SIGNUP_REQUIRED";
- *     readonly tempToken: string;
- *     readonly provider: AuthProvider;
- *   }
- */

--- a/src/features/auth/infrastructure/api/authApi.ts
+++ b/src/features/auth/infrastructure/api/authApi.ts
@@ -5,6 +5,8 @@ import type { RefreshResponse } from "@/features/auth/infrastructure/api/dto/Ref
 import type { LogoutResponse } from "@/features/auth/infrastructure/api/dto/LogoutResponse";
 import type { LoginRequest } from "@/features/auth/domain/model/LoginRequest";
 import type { LoginResponse } from "@/features/auth/infrastructure/api/dto/LoginResponse";
+import type { SubmitAgreementsResponse } from "@/features/auth/infrastructure/api/dto/SubmitAgreementsResponse";
+import type { UpdateNicknameResponse } from "@/features/auth/infrastructure/api/dto/UpdateNicknameResponse";
 
 interface LoginIdExistsResponse {
     success: boolean;
@@ -13,6 +15,17 @@ interface LoginIdExistsResponse {
         exists: boolean;
     };
     error: null;
+}
+
+interface SubmitAgreementsRequest {
+    agreements: {
+        agreementType: string;
+        agreementVersion: string;
+    }[];
+}
+
+interface UpdateNicknameRequest {
+    nickname: string;
 }
 
 interface NickNameExistsResponse {
@@ -78,6 +91,20 @@ export const authApi = {
     signup(payload: SignupRequest) {
         return httpClient.post<SignupResponse>(
             "/api/v1/members/signup",
+            payload,
+        );
+    },
+
+    submitRequiredAgreements(payload: SubmitAgreementsRequest) {
+        return httpClient.post<SubmitAgreementsResponse>(
+            "/api/v1/member-agreements/consents",
+            payload,
+        );
+    },
+
+    updateOnboardingNickname(payload: UpdateNicknameRequest) {
+        return httpClient.patch<UpdateNicknameResponse>(
+            "/api/v1/members/me",
             payload,
         );
     },

--- a/src/features/auth/infrastructure/api/dto/LoginResponse.ts
+++ b/src/features/auth/infrastructure/api/dto/LoginResponse.ts
@@ -1,12 +1,14 @@
 // 일반 로그인 성공 응답 타입
 import type { ApiResponse } from "@/features/auth/domain/model/ApiResponse";
 import type { LoginMember } from "@/features/auth/domain/model/LoginMember";
+import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
 
 export interface LoginResponseData {
     readonly accessToken: string;
     readonly refreshToken: string | null;
     readonly expiresIn: number;
     readonly member: LoginMember;
+    readonly onboarding: OnboardingState;
 }
 
 export type LoginResponse = ApiResponse<LoginResponseData>;

--- a/src/features/auth/infrastructure/api/dto/RefreshResponse.ts
+++ b/src/features/auth/infrastructure/api/dto/RefreshResponse.ts
@@ -1,7 +1,9 @@
 import type { ApiResponse } from "@/features/auth/domain/model/ApiResponse";
+import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
 
 export interface RefreshData {
     accessToken: string;
+    onboarding: OnboardingState;
 }
 
 export type RefreshResponse = ApiResponse<RefreshData>;

--- a/src/features/auth/infrastructure/api/dto/SubmitAgreementsResponse.ts
+++ b/src/features/auth/infrastructure/api/dto/SubmitAgreementsResponse.ts
@@ -1,0 +1,12 @@
+import type { ApiResponse } from "@/features/auth/domain/model/ApiResponse";
+import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
+
+export interface SubmitAgreementsResponseData {
+    readonly requiredAgreementsCompleted: boolean;
+    readonly missingAgreementTypes: readonly string[];
+    readonly onboarding: OnboardingState;
+    readonly accessToken: string;
+    readonly expiresIn: number;
+}
+
+export type SubmitAgreementsResponse = ApiResponse<SubmitAgreementsResponseData>;

--- a/src/features/auth/infrastructure/api/dto/UpdateNicknameResponse.ts
+++ b/src/features/auth/infrastructure/api/dto/UpdateNicknameResponse.ts
@@ -1,0 +1,11 @@
+// 소셜 온보딩 중 닉네임 변경 API 응답 타입 정의
+import type { ApiResponse } from "@/features/auth/domain/model/ApiResponse";
+import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
+
+export interface UpdateNicknameResponseData {
+    readonly id: number;
+    readonly updatedAt: string;
+    readonly onboarding: OnboardingState;
+}
+
+export type UpdateNicknameResponse = ApiResponse<UpdateNicknameResponseData>;

--- a/src/infrastructure/http/httpClient.ts
+++ b/src/infrastructure/http/httpClient.ts
@@ -4,36 +4,67 @@ import {
     getAccessToken,
     setAuthenticated,
 } from "@/features/auth/application/store/authStore";
+import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
 
 class HttpError extends Error {
     constructor(
         public readonly status: number,
-        public readonly statusText: string
+        public readonly statusText: string,
     ) {
         super(`[httpClient] ${status} ${statusText}`);
         this.name = "HttpError";
     }
 }
 
-// refresh token API
-async function refreshAccessToken(): Promise<string> {
+interface RefreshResult {
+    accessToken: string;
+    onboarding: OnboardingState;
+}
+
+const NO_REFRESH_PATHS = [
+    "/api/v1/auth/oauth2/exchange",
+    "/api/v1/auth/login",
+    "/api/v1/auth/refresh",
+    "/api/v1/members/signup",
+];
+
+function shouldTryRefresh(path: string, isRetry: boolean) {
+    if (isRetry) return false;
+    if (NO_REFRESH_PATHS.includes(path)) return false;
+
+    return true;
+}
+
+async function refreshAccessToken(): Promise<RefreshResult> {
     const response = await fetch(`${clientEnv.apiBaseUrl}/api/v1/auth/refresh`, {
         method: "POST",
         credentials: "include",
     });
 
     if (!response.ok) {
+        const errorBody = await response.json().catch(() => null);
+
+        console.error("[httpClient] refresh 실패 응답:", {
+            status: response.status,
+            statusText: response.statusText,
+            body: errorBody,
+        });
+
         throw new Error("Refresh failed");
     }
 
-    const data = await response.json();
-    return data.data.accessToken;
+    const body = await response.json();
+
+    return {
+        accessToken: body.data.accessToken,
+        onboarding: body.data.onboarding,
+    };
 }
 
 async function request<T>(
     path: string,
     options?: RequestInit,
-    isRetry = false
+    isRetry = false,
 ): Promise<T> {
     const accessToken = getAccessToken();
 
@@ -49,29 +80,34 @@ async function request<T>(
         },
     });
 
-    // 401 처리
-    if (response.status === 401 && !isRetry) {
+    if (response.status === 401 && shouldTryRefresh(path, isRetry)) {
         try {
-            console.log("[httpClient] accessToken 만료 → refresh 시도");
+            const refreshed = await refreshAccessToken();
 
-            const newToken = await refreshAccessToken();
-            setAuthenticated(newToken);
-            console.log("[httpClient] 새 accessToken 발급 완료");
+            setAuthenticated(refreshed.accessToken, refreshed.onboarding);
 
             return request<T>(path, options, true);
         } catch (error) {
-            console.warn("httpClient] refresh 실패 → 인증 상태 해제", error);
+            console.warn("[httpClient] refresh 실패 → 인증 상태 해제", error);
             clearAuth();
             throw new HttpError(401, "Unauthorized");
         }
     }
 
-    // 일반 에러 처리
     if (!response.ok) {
+        const errorBody = await response.json().catch(() => null);
+        //  refresh는 로그 안 찍음
+        if (path !== "/api/v1/auth/refresh") {
+            console.error("[httpClient] 요청 실패 응답:", {
+                path,
+                status: response.status,
+                statusText: response.statusText,
+                body: errorBody,
+            });
+        }
         throw new HttpError(response.status, response.statusText);
     }
 
-    // response 파싱
     const text = await response.text();
     return text ? JSON.parse(text) : (undefined as T);
 }

--- a/src/ui/components/Navbar.tsx
+++ b/src/ui/components/Navbar.tsx
@@ -7,6 +7,7 @@ import { UserRound, LogOut } from "lucide-react";
 import {
   isAuthenticatedAtom,
   isAuthLoadingAtom,
+  isOnboardingReadyAtom,
 } from "@/features/auth/application/selectors/authSelectors";
 import { useLogout } from "@/features/auth/application/hooks/useLogout";
 
@@ -18,8 +19,13 @@ import {
 export default function Navbar() {
   const isAuthenticated = useAtomValue(isAuthenticatedAtom);
   const isAuthLoading = useAtomValue(isAuthLoadingAtom);
+  const isOnboardingReady = useAtomValue(isOnboardingReadyAtom);
+
   const [open, setOpen] = useState(false);
   const { isSubmitting, handleLogout } = useLogout();
+
+  const showAuthenticatedUI =
+    !isAuthLoading && isAuthenticated && isOnboardingReady;
 
   const onClickLogout = async () => {
     setOpen(false);
@@ -29,10 +35,10 @@ export default function Navbar() {
   return (
     <nav
       className={`${navbarStyles.nav} ${
-        !isAuthLoading && isAuthenticated ? "left-[280px]" : "left-0"
+        showAuthenticatedUI ? "left-[280px]" : "left-0"
       }`}
     >
-      {!isAuthLoading && !isAuthenticated && (
+      {!showAuthenticatedUI && (
         <Link href="/" className={navbarStyles.logo}>
           Matchuri
         </Link>
@@ -40,7 +46,7 @@ export default function Navbar() {
 
       <div
         className={
-          !isAuthLoading && isAuthenticated
+          showAuthenticatedUI
             ? navbarStyles.authRightOnly
             : navbarStyles.rightGroup
         }
@@ -54,7 +60,7 @@ export default function Navbar() {
           </Link>
         )}
 
-        {!isAuthLoading && isAuthenticated && (
+        {showAuthenticatedUI && (
           <div className={navbarStyles.profileWrapper}>
             <button
               type="button"

--- a/src/ui/layout/AppLayout.tsx
+++ b/src/ui/layout/AppLayout.tsx
@@ -8,6 +8,7 @@ import AuthInitializer from "@/features/auth/ui/components/AuthInitializer";
 import {
     isAuthenticatedAtom,
     isAuthLoadingAtom,
+    isOnboardingReadyAtom,
 } from "@/features/auth/application/selectors/authSelectors";
 
 import Navbar from "@/ui/components/Navbar";
@@ -16,16 +17,24 @@ import Sidebar from "@/ui/components/Sidebar";
 function AppContent({ children }: { children: ReactNode }) {
     const isAuthenticated = useAtomValue(isAuthenticatedAtom);
     const isAuthLoading = useAtomValue(isAuthLoadingAtom);
+    const isOnboardingReady = useAtomValue(isOnboardingReadyAtom);
+
+    const showMemberLayout =
+      !isAuthLoading && isAuthenticated && isOnboardingReady;
+
+    if (isAuthLoading) {
+        return null;
+    }
 
     return (
         <>
             <Navbar />
-            {!isAuthLoading && isAuthenticated && <Sidebar />}
+            {showMemberLayout && <Sidebar />}
 
             <main
                 className={[
                     "h-screen overflow-y-auto",
-                    !isAuthLoading && isAuthenticated ? "ml-[280px]" : "",
+                    showMemberLayout ? "ml-[280px]" : "",
                 ].join(" ")}
             >
             {children}


### PR DESCRIPTION
## 관련 이슈
Closes #33 

## 요약
소셜 로그인 후 서버가 반환한 온보딩 상태에 따라 약관 동의 및 닉네임 설정 흐름으로 분기

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
