### PR TITLE
[Feat] 취향 관리 화면 UI 렌더링 (#58)

### DIFF
--- a/src/app/preference/page.tsx
+++ b/src/app/preference/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { preferencePageStyles } from "@/ui/styles/preferencePageStyles";
+
+import { usePreferenceList } from "@/features/preference/application/hooks/usePreferenceList";
+import { usePreferenceSelection } from "@/features/preference/application/hooks/usePreferenceSelection";
+import { useDislikedFoodSearch } from "@/features/preference/application/hooks/useDislikedFoodSearch";
+import { useSavePreference } from "@/features/preference/application/hooks/useSavePreference";
+
+import PreferenceSection from "@/features/preference/ui/components/PreferenceSection";
+import DislikedFoodSearch from "@/features/preference/ui/components/DislikedFoodSearch";
+import {
+    optionalPreferenceGroups,
+    requiredPreferenceGroups,
+} from "@/features/preference/ui/config/preferenceOptions";
+
+export default function PreferencePage() {
+    const { preferenceState } = usePreferenceList();
+    const { togglePreference } = usePreferenceSelection();
+    const { keyword, results, search, addFood, removeFood } = useDislikedFoodSearch();
+    const { isSaving, savePreference } = useSavePreference();
+
+    if (preferenceState.status === "LOADING") {
+        return (
+          <div className={preferencePageStyles.loadingBox}>
+            <p>취향 정보를 불러오는 중...</p>
+          </div>
+        );
+    }
+
+    if (preferenceState.status === "ERROR") {
+        return (
+          <div className={preferencePageStyles.errorBox}>
+            <p className={preferencePageStyles.errorText}>
+              {preferenceState.message}
+            </p>
+          </div>
+        );
+    }
+
+    return (
+        <main className={preferencePageStyles.container}>
+          <div className={preferencePageStyles.content}>
+            <header className={preferencePageStyles.header}>
+              <h1 className={preferencePageStyles.title}>취향 관리</h1>
+              <p className={preferencePageStyles.description}>
+                메뉴 추천에 사용할 취향 정보를 선택해 주세요.
+              </p>
+            </header>
+
+            <div className={preferencePageStyles.sectionGroup}>
+              <h2 className={preferencePageStyles.sectionTitle}>필수 선택</h2>
+
+              {requiredPreferenceGroups.map((group) => (
+                <PreferenceSection
+                  key={group.category}
+                  title={group.title}
+                  description={group.description}
+                  category={group.category}
+                  options={group.options}
+                  selectedValues={preferenceState.data.selections[group.category]}
+                  onToggle={togglePreference}
+                />
+              ))}
+            </div>
+
+            <div className={preferencePageStyles.sectionGroup}>
+              <h2 className={preferencePageStyles.sectionTitle}>추가 선택</h2>
+
+              {optionalPreferenceGroups.map((group) => (
+                <PreferenceSection
+                  key={group.category}
+                  title={group.title}
+                  description={group.description}
+                  category={group.category}
+                  options={group.options}
+                  selectedValues={preferenceState.data.selections[group.category]}
+                  onToggle={togglePreference}
+                />
+              ))}
+
+              <DislikedFoodSearch
+                keyword={keyword}
+                results={results}
+                selectedFoods={preferenceState.data.dislikedFoods}
+                onSearch={search}
+                onSelect={addFood}
+                onRemove={removeFood}
+              />
+            </div>
+
+            <button
+              type="button"
+              onClick={savePreference}
+              disabled={isSaving}
+              className={preferencePageStyles.saveButton}
+            >
+              {isSaving ? "저장 중..." : "저장하기"}
+            </button>
+          </div>
+        </main>
+    );
+}

--- a/src/features/preference/application/atoms/preferenceAtom.ts
+++ b/src/features/preference/application/atoms/preferenceAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from "jotai";
+import type { PreferenceState } from "@/features/preference/domain/state/PreferenceState";
+
+export const preferenceAtom = atom<PreferenceState>({
+    status: "LOADING",
+});

--- a/src/features/preference/application/hooks/useDislikedFoodSearch.ts
+++ b/src/features/preference/application/hooks/useDislikedFoodSearch.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useSetAtom } from "jotai";
+
+import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
+import { preferenceApi } from "@/features/preference/infrastructure/api/preferenceApi";
+
+// 비선호 음식 검색, 추가, 삭제
+export function useDislikedFoodSearch() {
+    const setPreferenceState = useSetAtom(preferenceAtom);
+    const [keyword, setKeyword] = useState("");
+    const [results, setResults] = useState<string[]>([]);
+
+    const search = useCallback(async (value: string) => {
+        setKeyword(value);
+
+        if (value.trim().length === 0) {
+            setResults([]);
+            return;
+        }
+
+        const searchedFoods = await preferenceApi.searchDislikedFoods(value.trim());
+        setResults(searchedFoods);
+    }, []);
+
+    const addFood = useCallback(
+        (food: string) => {
+            setPreferenceState((prev) => {
+                if (prev.status !== "SUCCESS") return prev;
+                if (prev.data.dislikedFoods.includes(food)) return prev;
+
+                return {
+                    status: "SUCCESS",
+                    data: {
+                        ...prev.data,
+                        dislikedFoods: [...prev.data.dislikedFoods, food],
+                    },
+                };
+            });
+
+            setKeyword("");
+            setResults([]);
+        },
+        [setPreferenceState],
+    );
+
+    const removeFood = useCallback(
+        (food: string) => {
+            setPreferenceState((prev) => {
+                if (prev.status !== "SUCCESS") return prev;
+
+                return {
+                    status: "SUCCESS",
+                    data: {
+                        ...prev.data,
+                        dislikedFoods: prev.data.dislikedFoods.filter(
+                            (item) => item !== food,
+                        ),
+                    },
+                };
+            });
+        },
+        [setPreferenceState],
+    );
+
+    return {
+        keyword,
+        results,
+        search,
+        addFood,
+        removeFood,
+    };
+}

--- a/src/features/preference/application/hooks/usePreferenceList.ts
+++ b/src/features/preference/application/hooks/usePreferenceList.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { useAtom } from "jotai";
+
+import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
+import { preferenceApi } from "@/features/preference/infrastructure/api/preferenceApi";
+
+// 기존 취향 조회
+export function usePreferenceList() {
+    const [preferenceState, setPreferenceState] = useAtom(preferenceAtom);
+
+    const fetchPreference = useCallback(async () => {
+        setPreferenceState({ status: "LOADING" });
+
+        try {
+            const data = await preferenceApi.fetchMyPreference();
+            setPreferenceState({ status: "SUCCESS", data });
+        } catch {
+            setPreferenceState({
+                status: "ERROR",
+                message: "취향 정보를 불러오는데 실패했습니다.",
+            });
+        }
+    }, [setPreferenceState]);
+
+    useEffect(() => {
+        fetchPreference();
+    }, [fetchPreference]);
+
+    return {
+        preferenceState,
+        refetchPreference: fetchPreference,
+    };
+}

--- a/src/features/preference/application/hooks/usePreferenceSelection.ts
+++ b/src/features/preference/application/hooks/usePreferenceSelection.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useCallback } from "react";
+import { useSetAtom } from "jotai";
+
+import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
+import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
+
+// 취향 칩 선택/해제
+export function usePreferenceSelection() {
+    const setPreferenceState = useSetAtom(preferenceAtom);
+
+    const togglePreference = useCallback(
+        (category: PreferenceCategory, value: string) => {
+            setPreferenceState((prev) => {
+                if (prev.status !== "SUCCESS") return prev;
+
+                const selectedValues = prev.data.selections[category];
+                const isSelected = selectedValues.includes(value);
+
+                return {
+                    status: "SUCCESS",
+                    data: {
+                        ...prev.data,
+                        selections: {
+                            ...prev.data.selections,
+                            [category]: isSelected
+                                ? selectedValues.filter((item) => item !== value)
+                                : [...selectedValues, value],
+                        },
+                    },
+                };
+            });
+        },
+        [setPreferenceState],
+    );
+
+    return {
+        togglePreference,
+    };
+}

--- a/src/features/preference/application/hooks/useSavePreference.ts
+++ b/src/features/preference/application/hooks/useSavePreference.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useAtomValue } from "jotai";
+
+import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
+import { preferenceApi } from "@/features/preference/infrastructure/api/preferenceApi";
+
+export function useSavePreference() {
+    const preferenceState = useAtomValue(preferenceAtom);
+    const [isSaving, setIsSaving] = useState(false);
+
+    const savePreference = useCallback(async () => {
+        if (preferenceState.status !== "SUCCESS") return;
+
+        setIsSaving(true);
+
+        try {
+            await preferenceApi.savePreference(preferenceState.data);
+            alert("취향 정보가 저장되었습니다.");
+        } catch {
+            alert("취향 정보 저장에 실패했습니다.");
+        } finally {
+            setIsSaving(false);
+        }
+    }, [preferenceState]);
+
+    return {
+        isSaving,
+        savePreference,
+    };
+}

--- a/src/features/preference/application/selectors/preferenceSelectors.ts
+++ b/src/features/preference/application/selectors/preferenceSelectors.ts
@@ -1,0 +1,26 @@
+import { atom } from "jotai";
+import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
+
+export const userPreferenceAtom = atom((get) => {
+    const state = get(preferenceAtom);
+    return state.status === "SUCCESS" ? state.data : null;
+});
+
+export const preferenceSelectionsAtom = atom((get) => {
+    const state = get(preferenceAtom);
+    return state.status === "SUCCESS" ? state.data.selections : null;
+});
+
+export const dislikedFoodsAtom = atom((get) => {
+    const state = get(preferenceAtom);
+    return state.status === "SUCCESS" ? state.data.dislikedFoods : [];
+});
+
+export const isPreferenceLoadingAtom = atom(
+    (get) => get(preferenceAtom).status === "LOADING",
+);
+
+export const preferenceErrorAtom = atom((get) => {
+    const state = get(preferenceAtom);
+    return state.status === "ERROR" ? state.message : null;
+});

--- a/src/features/preference/domain/model/PreferenceCategory.ts
+++ b/src/features/preference/domain/model/PreferenceCategory.ts
@@ -1,0 +1,7 @@
+export type PreferenceCategory =
+    | "FLAVOR"
+    | "COOKING_METHOD"
+    | "MEAL_SITUATION"
+    | "FOOD_CATEGORY"
+    | "TEXTURE"
+    | "TEMPERATURE";

--- a/src/features/preference/domain/model/UserPreference.ts
+++ b/src/features/preference/domain/model/UserPreference.ts
@@ -1,0 +1,8 @@
+import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
+
+export type PreferenceSelections = Record<PreferenceCategory, readonly string[]>;
+
+export interface UserPreference {
+    readonly selections: PreferenceSelections;
+    readonly dislikedFoods: readonly string[];
+}

--- a/src/features/preference/domain/state/PreferenceState.ts
+++ b/src/features/preference/domain/state/PreferenceState.ts
@@ -1,0 +1,6 @@
+import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
+
+export type PreferenceState =
+    | { readonly status: "LOADING" }
+    | { readonly status: "SUCCESS"; readonly data: UserPreference }
+    | { readonly status: "ERROR"; readonly message: string };

--- a/src/features/preference/infrastructure/api/preferenceApi.ts
+++ b/src/features/preference/infrastructure/api/preferenceApi.ts
@@ -1,0 +1,39 @@
+import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
+
+const mockPreference: UserPreference = {
+    selections: {
+        FLAVOR: ["매콤", "고소"],
+        COOKING_METHOD: [],
+        MEAL_SITUATION: [],
+        FOOD_CATEGORY: [],
+        TEXTURE: [],
+        TEMPERATURE: [],
+    },
+    dislikedFoods: ["땅콩"],
+};
+
+const mockDislikedFoods = [
+    "땅콩",
+    "우유",
+    "계란",
+    "새우",
+    "게",
+    "밀",
+    "대두",
+    "복숭아",
+    "토마토",
+];
+
+export const preferenceApi = {
+    async fetchMyPreference(): Promise<UserPreference> {
+        return mockPreference;
+    },
+
+    async searchDislikedFoods(keyword: string): Promise<string[]> {
+        return mockDislikedFoods.filter((food) => food.includes(keyword));
+    },
+
+    async savePreference(preference: UserPreference): Promise<void> {
+        console.log("save preference", preference);
+    },
+};

--- a/src/features/preference/ui/components/DislikedFoodSearch.tsx
+++ b/src/features/preference/ui/components/DislikedFoodSearch.tsx
@@ -1,0 +1,74 @@
+import { dislikedFoodSearchStyles } from "@/ui/styles/dislikedFoodSearchStyles";
+
+interface DislikedFoodSearchProps {
+    readonly keyword: string;
+    readonly results: readonly string[];
+    readonly selectedFoods: readonly string[];
+    readonly onSearch: (keyword: string) => void;
+    readonly onSelect: (food: string) => void;
+    readonly onRemove: (food: string) => void;
+}
+
+export default function DislikedFoodSearch({
+    keyword,
+    results,
+    selectedFoods,
+    onSearch,
+    onSelect,
+    onRemove,
+}: DislikedFoodSearchProps) {
+    return (
+        <section className={dislikedFoodSearchStyles.container}>
+          <div className={dislikedFoodSearchStyles.header}>
+            <h3 className={dislikedFoodSearchStyles.title}>
+              알레르기 / 비선호 음식
+            </h3>
+            <p className={dislikedFoodSearchStyles.description}>
+              피하고 싶은 음식을 검색 후 선택해 주세요.
+            </p>
+          </div>
+
+          <div className={dislikedFoodSearchStyles.searchWrapper}>
+            <input
+              type="text"
+              value={keyword}
+              onChange={(e) => onSearch(e.target.value)}
+              placeholder="예: 땅콩, 우유, 새우"
+              className={dislikedFoodSearchStyles.input}
+            />
+
+            {keyword && results.length > 0 && (
+              <div className={dislikedFoodSearchStyles.resultList}>
+                {results.map((food) => (
+                  <button
+                    key={food}
+                    type="button"
+                    onClick={() => onSelect(food)}
+                    className={dislikedFoodSearchStyles.resultItem}
+                  >
+                    {food}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {selectedFoods.length > 0 && (
+            <div className={dislikedFoodSearchStyles.selectedList}>
+              {selectedFoods.map((food) => (
+                <div key={food} className={dislikedFoodSearchStyles.selectedTag}>
+                  <span>{food}</span>
+                  <button
+                    type="button"
+                    onClick={() => onRemove(food)}
+                    className={dislikedFoodSearchStyles.removeButton}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+    );
+}

--- a/src/features/preference/ui/components/PreferenceSection.tsx
+++ b/src/features/preference/ui/components/PreferenceSection.tsx
@@ -1,0 +1,52 @@
+import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
+import { preferenceSectionStyles } from "@/ui/styles/preferenceSectionStyles";
+
+interface PreferenceSectionProps {
+    readonly title: string;
+    readonly description?: string;
+    readonly category: PreferenceCategory;
+    readonly options: readonly string[];
+    readonly selectedValues: readonly string[];
+    readonly onToggle: (category: PreferenceCategory, value: string) => void;
+}
+
+export default function PreferenceSection({
+    title,
+    description,
+    category,
+    options,
+    selectedValues,
+    onToggle,
+}: PreferenceSectionProps) {
+    return (
+        <section className={preferenceSectionStyles.container}>
+          <div className={preferenceSectionStyles.header}>
+            <h3 className={preferenceSectionStyles.title}>{title}</h3>
+            {description && (
+              <p className={preferenceSectionStyles.description}>{description}</p>
+            )}
+          </div>
+
+          <div className={preferenceSectionStyles.chipGroup}>
+            {options.map((option) => {
+              const selected = selectedValues.includes(option);
+
+              return (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => onToggle(category, option)}
+                  className={
+                    selected
+                      ? preferenceSectionStyles.selectedChip
+                      : preferenceSectionStyles.chip
+                  }
+                >
+                  {option}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+    );
+}

--- a/src/features/preference/ui/config/preferenceOptions.ts
+++ b/src/features/preference/ui/config/preferenceOptions.ts
@@ -1,0 +1,44 @@
+import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
+
+export interface PreferenceOptionGroup {
+    readonly category: PreferenceCategory;
+    readonly title: string;
+    readonly description?: string;
+    readonly options: readonly string[];
+}
+
+export const requiredPreferenceGroups: readonly PreferenceOptionGroup[] = [
+    {
+        category: "FLAVOR",
+        title: "맛",
+        options: ["매콤", "달콤", "짭짤", "고소", "상큼", "진한/묵직한"],
+    },
+    {
+        category: "COOKING_METHOD",
+        title: "조리 방식",
+        options: ["국물/탕", "구이", "튀김", "볶음", "찜", "생식/샐러드", "면/비빔"],
+    },
+    {
+        category: "MEAL_SITUATION",
+        title: "시간/상황",
+        options: ["아침", "점심", "저녁", "야식", "주말", "더운 날", "비 오는 날"],
+    },
+];
+
+export const optionalPreferenceGroups: readonly PreferenceOptionGroup[] = [
+    {
+        category: "FOOD_CATEGORY",
+        title: "음식 종류",
+        options: ["한식", "중식", "일식", "양식", "분식", "패스트푸드", "아시안"],
+    },
+    {
+        category: "TEXTURE",
+        title: "식감",
+        options: ["바삭", "쫄깃", "아삭", "부드러움"],
+    },
+    {
+        category: "TEMPERATURE",
+        title: "온도",
+        options: ["뜨거움", "차가움"],
+    },
+];

--- a/src/ui/styles/dislikedFoodSearchStyles.ts
+++ b/src/ui/styles/dislikedFoodSearchStyles.ts
@@ -1,0 +1,17 @@
+export const dislikedFoodSearchStyles = {
+  container: "flex flex-col gap-3 rounded-2xl bg-white p-5 shadow-sm",
+  header: "flex flex-col gap-1",
+  title: "text-base font-semibold text-zinc-900",
+  description: "text-sm text-zinc-500",
+  searchWrapper: "relative",
+  // 검색창 테두리
+  input:
+    "w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-600 focus:outline-none focus:ring-2 focus:ring-blue-400",
+  resultList:
+    "absolute left-0 top-11 z-10 flex w-full flex-col overflow-hidden rounded-md border border-zinc-200 bg-white shadow-md",
+  resultItem: "px-3 py-2 text-left text-sm text-zinc-700 hover:bg-zinc-100",
+  selectedList: "flex flex-wrap gap-2 pt-1",
+  selectedTag:
+    "flex items-center gap-2 rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700",
+  removeButton: "text-blue-500 hover:text-blue-700",
+} as const;

--- a/src/ui/styles/preferencePageStyles.ts
+++ b/src/ui/styles/preferencePageStyles.ts
@@ -1,0 +1,14 @@
+export const preferencePageStyles = {
+  container: "min-h-screen bg-sky-100 px-4 py-8",
+  content: "mx-auto flex w-full max-w-3xl flex-col gap-6",
+  header: "flex flex-col gap-2",
+  title: "text-2xl font-bold text-zinc-900",
+  description: "text-sm text-zinc-600",
+  sectionGroup: "flex flex-col gap-4",
+  sectionTitle: "text-lg font-bold text-zinc-900",
+  saveButton:
+    "w-full rounded-md bg-blue-500 py-3 text-sm font-semibold text-white transition hover:bg-blue-600 disabled:bg-zinc-300",
+  loadingBox: "flex min-h-screen items-center justify-center bg-sky-100",
+  errorBox: "flex min-h-screen items-center justify-center bg-sky-100 px-4",
+  errorText: "text-sm font-medium text-red-500",
+} as const;

--- a/src/ui/styles/preferenceSectionStyles.ts
+++ b/src/ui/styles/preferenceSectionStyles.ts
@@ -1,0 +1,10 @@
+export const preferenceSectionStyles = {
+  container: "flex flex-col gap-3 rounded-2xl bg-white p-5 shadow-sm",
+  header: "flex flex-col gap-1",
+  title: "text-base font-semibold text-zinc-900",
+  description: "text-sm text-zinc-500",
+  chipGroup: "flex flex-wrap gap-2",
+  chip: "rounded-full border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-600 hover:bg-zinc-50",
+  selectedChip:
+    "rounded-full border border-blue-500 bg-blue-500 px-4 py-2 text-sm font-medium text-white",
+} as const;


### PR DESCRIPTION
## 관련 이슈
Closes #58 

## 요약
취향 관리 화면 UI 및 선택/검색 상태 관리 로직 구현

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
