### PR TITLE
[Feat] 로그인 유형별 설정 페이지 UI 렌더링 (#65)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useAtomValue } from "jotai";
+import { settingsAtom } from "@/features/settings/application/atoms/settingsAtom";
+import { isLocalLoginAtom } from "@/features/settings/application/selectors/settingsSelectors";
+import { useSettingsProfile } from "@/features/settings/application/hooks/useSettingsProfile";
+import ProfileManagementSection from "@/features/settings/ui/components/ProfileManagementSection";
+import AccountManagementSection from "@/features/settings/ui/components/AccountManagementSection";
+import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
+
+export default function SettingsPage() {
+    useSettingsProfile();
+
+    const settingsState = useAtomValue(settingsAtom);
+    const isLocalLogin = useAtomValue(isLocalLoginAtom);
+
+    if (settingsState.status === "LOADING") {
+        return (
+            <main className={settingsPageStyles.page}>
+                설정 정보를 불러오는 중...
+            </main>
+        );
+    }
+
+    if (settingsState.status === "ERROR") {
+        return (
+            <main className={settingsPageStyles.page}>
+                {settingsState.message}
+            </main>
+        );
+    }
+
+    const profile = settingsState.data;
+
+    return (
+        <main className={settingsPageStyles.page}>
+            <h1 className={settingsPageStyles.title}>설정</h1>
+            <p className={settingsPageStyles.description}>
+                프로필 정보 및 계정 보안 설정을 관리하세요.
+            </p>
+
+            <ProfileManagementSection nickname={profile.nickname} />
+
+            <AccountManagementSection
+                userId={profile.userId}
+                showPasswordFields={isLocalLogin}
+            />
+        </main>
+    );
+}

--- a/src/features/settings/application/atoms/settingsAtom.ts
+++ b/src/features/settings/application/atoms/settingsAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from "jotai";
+import type { SettingsState } from "@/features/settings/domain/state/SettingsState";
+
+export const settingsAtom = atom<SettingsState>({
+    status: "LOADING",
+});

--- a/src/features/settings/application/hooks/useSettingsProfile.ts
+++ b/src/features/settings/application/hooks/useSettingsProfile.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSetAtom } from "jotai";
+import { settingsAtom } from "@/features/settings/application/atoms/settingsAtom";
+import { fetchSettingsProfile } from "@/features/settings/infrastructure/api/settingsApi";
+
+export function useSettingsProfile() {
+    const setSettings = useSetAtom(settingsAtom);
+
+    useEffect(() => {
+        async function loadSettingsProfile() {
+            setSettings({ status: "LOADING" });
+
+            try {
+                const profile = await fetchSettingsProfile();
+
+                setSettings({
+                    status: "SUCCESS",
+                    data: profile,
+                });
+            } catch {
+                setSettings({
+                    status: "ERROR",
+                    message: "설정 정보를 불러오지 못했습니다.",
+                });
+            }
+        }
+
+        loadSettingsProfile();
+    }, [setSettings]);
+}

--- a/src/features/settings/application/selectors/settingsSelectors.ts
+++ b/src/features/settings/application/selectors/settingsSelectors.ts
@@ -1,0 +1,17 @@
+import { atom } from "jotai";
+import { settingsAtom } from "@/features/settings/application/atoms/settingsAtom";
+
+export const settingsProfileAtom = atom((get) => {
+    const state = get(settingsAtom);
+    return state.status === "SUCCESS" ? state.data : null;
+});
+
+export const isSocialLoginAtom = atom((get) => {
+    const state = get(settingsAtom);
+    return state.status === "SUCCESS" && state.data.loginType === "SOCIAL";
+});
+
+export const isLocalLoginAtom = atom((get) => {
+    const state = get(settingsAtom);
+    return state.status === "SUCCESS" && state.data.loginType === "LOCAL";
+});

--- a/src/features/settings/domain/model/LoginType.ts
+++ b/src/features/settings/domain/model/LoginType.ts
@@ -1,0 +1,1 @@
+export type LoginType = "SOCIAL" | "LOCAL";

--- a/src/features/settings/domain/model/SettingsProfile.ts
+++ b/src/features/settings/domain/model/SettingsProfile.ts
@@ -1,0 +1,7 @@
+import type { LoginType } from "@/features/settings/domain/model/LoginType";
+
+export interface SettingsProfile {
+    readonly nickname: string;
+    readonly loginType: LoginType;
+    readonly userId?: string;
+}

--- a/src/features/settings/domain/state/SettingsState.ts
+++ b/src/features/settings/domain/state/SettingsState.ts
@@ -1,0 +1,6 @@
+import type { SettingsProfile } from "@/features/settings/domain/model/SettingsProfile";
+
+export type SettingsState =
+    | { readonly status: "LOADING" }
+    | { readonly status: "SUCCESS"; readonly data: SettingsProfile }
+    | { readonly status: "ERROR"; readonly message: string };

--- a/src/features/settings/infrastructure/api/settingsApi.ts
+++ b/src/features/settings/infrastructure/api/settingsApi.ts
@@ -1,0 +1,10 @@
+import type { SettingsProfile } from "@/features/settings/domain/model/SettingsProfile";
+
+export async function fetchSettingsProfile(): Promise<SettingsProfile> {
+    // TODO: 추후 실제 API 연동
+    return {
+        nickname: "테스트",
+        loginType: "LOCAL",
+        userId: "test123",
+    };
+}

--- a/src/features/settings/ui/components/AccountManagementSection.tsx
+++ b/src/features/settings/ui/components/AccountManagementSection.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Shield, Save } from "lucide-react";
+import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
+
+interface AccountManagementSectionProps {
+    userId?: string;
+    showPasswordFields: boolean;
+}
+
+export default function AccountManagementSection({
+    userId,
+    showPasswordFields,
+}: AccountManagementSectionProps) {
+    return (
+        <section className={settingsPageStyles.section}>
+            <h2 className={settingsPageStyles.sectionTitle}>
+                <Shield size={20} />
+                계정 관리
+            </h2>
+
+            {showPasswordFields && (
+                <>
+                    <div className={settingsPageStyles.formGroup}>
+                        <div className={settingsPageStyles.disabledInput}>
+                            <p className="mb-2 text-xs font-semibold uppercase">
+                                USER ID
+                            </p>
+                            <p>{userId}</p>
+                        </div>
+
+                        <label className={settingsPageStyles.label}>
+                            새로운 비밀번호
+                        </label>
+                        <input
+                            type="password"
+                            placeholder="••••••••••••"
+                            className={settingsPageStyles.input}
+                        />
+
+                        <label className={settingsPageStyles.label}>
+                            비밀번호 확인
+                        </label>
+                        <input
+                            type="password"
+                            placeholder="••••••••••••"
+                            className={settingsPageStyles.input}
+                        />
+                    </div>
+
+                    <div className={settingsPageStyles.saveButtonWrapper}>
+                        <button type="button" className={settingsPageStyles.saveButton}>
+                            저장
+                            <Save size={18} />
+                        </button>
+                    </div>
+
+                    <div className={settingsPageStyles.divider} />
+                </>
+            )}
+
+            <div className={settingsPageStyles.accountRow}>
+                <div>
+                    <p className={settingsPageStyles.dangerTitle}>회원 탈퇴</p>
+                    <p className={settingsPageStyles.dangerDescription}>
+                        계정과 및 데이터를 영구적으로 삭제합니다.
+                    </p>
+                </div>
+
+                <button type="button" className={settingsPageStyles.dangerButton}>
+                    회원 탈퇴
+                </button>
+            </div>
+        </section>
+    );
+}

--- a/src/features/settings/ui/components/ProfileManagementSection.tsx
+++ b/src/features/settings/ui/components/ProfileManagementSection.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { User, Camera, Check } from "lucide-react";
+import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
+
+interface ProfileManagementSectionProps {
+    nickname: string;
+}
+
+export default function ProfileManagementSection({
+    nickname,
+}: ProfileManagementSectionProps) {
+    return (
+        <section className={settingsPageStyles.section}>
+            <h2 className={settingsPageStyles.sectionTitle}>
+                <User size={20} />
+                프로필 관리
+            </h2>
+
+            {/* 프로필 영역 */}
+            <div className={settingsPageStyles.profileImageWrapper}>
+                <User size={64} className={settingsPageStyles.profileIcon} />
+
+                <button type="button" className={settingsPageStyles.editButton}>
+                    <Camera size={16} />
+                </button>
+            </div>
+
+            {/* 닉네임 */}
+            <div className={settingsPageStyles.formGroup}>
+                <label className={settingsPageStyles.label}>닉네임</label>
+                <input
+                    type="text"
+                    defaultValue={nickname}
+                    className={settingsPageStyles.input}
+                />
+            </div>
+
+            <div className={settingsPageStyles.saveButtonWrapper}>
+                <button type="button" className={settingsPageStyles.saveButton}>
+                    저장
+                    <Check size={18} />
+                </button>
+            </div>
+        </section>
+    );
+}

--- a/src/ui/styles/settingsPageStyles.ts
+++ b/src/ui/styles/settingsPageStyles.ts
@@ -1,0 +1,27 @@
+export const settingsPageStyles = {
+    page: "w-full px-14 py-16 bg-white",
+    title: "text-3xl font-bold text-gray-900",
+    description: "mt-2 text-base text-[#17345f]",
+    section: "mt-10 rounded-[48px] bg-[#e8eef5] px-12 py-10",
+    sectionTitle: "mb-10 flex items-center gap-3 text-xl font-bold text-gray-900",
+    profileImageWrapper:
+        "relative mb-10 flex h-32 w-32 items-center justify-center rounded-full bg-[#d9e2ec]",
+    profileIcon: "text-[#6b7c93]",
+    editButton:
+        "absolute bottom-2 right-2 flex h-8 w-8 items-center justify-center rounded-full bg-[#37639f] text-white shadow-md",
+    formGroup: "flex flex-col gap-3",
+    label: "text-sm font-semibold text-gray-800",
+    input:
+        "h-14 rounded-2xl bg-white px-5 text-sm text-gray-400 outline-none placeholder:text-gray-600",
+    disabledInput:
+        "h-20 rounded-2xl bg-[#d8d8d8] px-5 py-4 text-sm text-gray-500 outline-none",
+    saveButtonWrapper: "mt-10 flex justify-end",
+    saveButton:
+        "flex h-12 w-44 items-center justify-center gap-8 rounded-full bg-[#37639f] text-white",
+    accountRow: "flex items-center justify-between",
+    divider: "my-10 border-t border-gray-300",
+    dangerTitle: "font-bold text-red-500",
+    dangerDescription: "mt-1 text-sm text-gray-600",
+    dangerButton:
+        "h-12 w-40 rounded-full border border-red-500 text-red-500 font-semibold",
+};


### PR DESCRIPTION
## 관련 이슈
Closes #65 

## 요약
로그인 유형에 따라 분기되는 설정 페이지 UI를 구현

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
