### PR TITLE
[Feat] 취향 관리 화면에 대한 API 연동 및 기능 구현 

### DIFF
--- a/src/app/preference/page.tsx
+++ b/src/app/preference/page.tsx
@@ -19,7 +19,15 @@ export default function PreferencePage() {
     const { isAuthLoading, canAccess } = useAuthGuard();
     const { preferenceState } = usePreferenceList();
     const { togglePreference } = usePreferenceSelection();
-    const { keyword, results, search, addFood, removeFood } = useDislikedFoodSearch();
+    const {
+        keyword,
+        results,
+        isSearching,
+        searchErrorMessage,
+        search,
+        addFood,
+        removeFood
+    } = useDislikedFoodSearch();
     const { isSaving, savePreference } = useSavePreference();
 
     if (isAuthLoading || !canAccess) {
@@ -93,6 +101,8 @@ export default function PreferencePage() {
                 keyword={keyword}
                 results={results}
                 selectedFoods={preferenceState.data.dislikedFoods}
+                isSearching={isSearching}
+                searchErrorMessage={searchErrorMessage}
                 onSearch={search}
                 onSelect={addFood}
                 onRemove={removeFood}

--- a/src/app/preference/page.tsx
+++ b/src/app/preference/page.tsx
@@ -2,6 +2,7 @@
 
 import { preferencePageStyles } from "@/ui/styles/preferencePageStyles";
 
+import { useAuthGuard } from "@/features/auth/application/hooks/useAuthGuard";
 import { usePreferenceList } from "@/features/preference/application/hooks/usePreferenceList";
 import { usePreferenceSelection } from "@/features/preference/application/hooks/usePreferenceSelection";
 import { useDislikedFoodSearch } from "@/features/preference/application/hooks/useDislikedFoodSearch";
@@ -15,10 +16,19 @@ import {
 } from "@/features/preference/ui/config/preferenceOptions";
 
 export default function PreferencePage() {
+    const { isAuthLoading, canAccess } = useAuthGuard();
     const { preferenceState } = usePreferenceList();
     const { togglePreference } = usePreferenceSelection();
     const { keyword, results, search, addFood, removeFood } = useDislikedFoodSearch();
     const { isSaving, savePreference } = useSavePreference();
+
+    if (isAuthLoading || !canAccess) {
+        return (
+            <div className={preferencePageStyles.loadingBox}>
+                <p>인증 상태 확인 중...</p>
+            </div>
+        );
+    }
 
     if (preferenceState.status === "LOADING") {
         return (

--- a/src/app/preference/page.tsx
+++ b/src/app/preference/page.tsx
@@ -4,6 +4,7 @@ import { preferencePageStyles } from "@/ui/styles/preferencePageStyles";
 
 import { useAuthGuard } from "@/features/auth/application/hooks/useAuthGuard";
 import { usePreferenceList } from "@/features/preference/application/hooks/usePreferenceList";
+import { usePreferenceOptionList } from "@/features/preference/application/hooks/usePreferenceOptionList";
 import { usePreferenceSelection } from "@/features/preference/application/hooks/usePreferenceSelection";
 import { useDislikedFoodSearch } from "@/features/preference/application/hooks/useDislikedFoodSearch";
 import { useSavePreference } from "@/features/preference/application/hooks/useSavePreference";
@@ -11,13 +12,15 @@ import { useSavePreference } from "@/features/preference/application/hooks/useSa
 import PreferenceSection from "@/features/preference/ui/components/PreferenceSection";
 import DislikedFoodSearch from "@/features/preference/ui/components/DislikedFoodSearch";
 import {
-    optionalPreferenceGroups,
-    requiredPreferenceGroups,
+    createPreferenceGroups,
+    optionalPreferenceGroupMeta,
+    requiredPreferenceGroupMeta,
 } from "@/features/preference/ui/config/preferenceOptions";
 
 export default function PreferencePage() {
     const { isAuthLoading, canAccess } = useAuthGuard();
     const { preferenceState } = usePreferenceList();
+    const { preferenceOptionState } = usePreferenceOptionList();
     const { togglePreference } = usePreferenceSelection();
     const {
         keyword,
@@ -26,7 +29,7 @@ export default function PreferencePage() {
         searchErrorMessage,
         search,
         addFood,
-        removeFood
+        removeFood,
     } = useDislikedFoodSearch();
     const { isSaving, savePreference } = useSavePreference();
 
@@ -38,86 +41,113 @@ export default function PreferencePage() {
         );
     }
 
-    if (preferenceState.status === "LOADING") {
+    if (
+        preferenceState.status === "LOADING" ||
+        preferenceOptionState.status === "LOADING"
+    ) {
         return (
-          <div className={preferencePageStyles.loadingBox}>
-            <p>취향 정보를 불러오는 중...</p>
-          </div>
+            <div className={preferencePageStyles.loadingBox}>
+                <p>취향 정보를 불러오는 중...</p>
+            </div>
         );
     }
 
     if (preferenceState.status === "ERROR") {
         return (
-          <div className={preferencePageStyles.errorBox}>
-            <p className={preferencePageStyles.errorText}>
-              {preferenceState.message}
-            </p>
-          </div>
+            <div className={preferencePageStyles.errorBox}>
+                <p className={preferencePageStyles.errorText}>
+                    {preferenceState.message}
+                </p>
+            </div>
         );
     }
 
+    if (preferenceOptionState.status === "ERROR") {
+        return (
+            <div className={preferencePageStyles.errorBox}>
+                <p className={preferencePageStyles.errorText}>
+                    {preferenceOptionState.message}
+                </p>
+            </div>
+        );
+    }
+
+    const requiredPreferenceGroups = createPreferenceGroups(
+        requiredPreferenceGroupMeta,
+        preferenceOptionState.data,
+    );
+
+    const optionalPreferenceGroups = createPreferenceGroups(
+        optionalPreferenceGroupMeta,
+        preferenceOptionState.data,
+    );
+
     return (
         <main className={preferencePageStyles.container}>
-          <div className={preferencePageStyles.content}>
-            <header className={preferencePageStyles.header}>
-              <h1 className={preferencePageStyles.title}>취향 관리</h1>
-              <p className={preferencePageStyles.description}>
-                메뉴 추천에 사용할 취향 정보를 선택해 주세요.
-              </p>
-            </header>
+            <div className={preferencePageStyles.content}>
+                <header className={preferencePageStyles.header}>
+                    <h1 className={preferencePageStyles.title}>취향 관리</h1>
+                    <p className={preferencePageStyles.description}>
+                        메뉴 추천에 사용할 취향 정보를 선택해 주세요.
+                    </p>
+                </header>
 
-            <div className={preferencePageStyles.sectionGroup}>
-              <h2 className={preferencePageStyles.sectionTitle}>필수 선택</h2>
+                <div className={preferencePageStyles.sectionGroup}>
+                    <h2 className={preferencePageStyles.sectionTitle}>필수 선택</h2>
 
-              {requiredPreferenceGroups.map((group) => (
-                <PreferenceSection
-                  key={group.category}
-                  title={group.title}
-                  description={group.description}
-                  category={group.category}
-                  options={group.options}
-                  selectedValues={preferenceState.data.selections[group.category]}
-                  onToggle={togglePreference}
-                />
-              ))}
+                    {requiredPreferenceGroups.map((group) => (
+                        <PreferenceSection
+                            key={group.category}
+                            title={group.title}
+                            description={group.description}
+                            category={group.category}
+                            options={group.options}
+                            selectedValues={
+                                preferenceState.data.selections[group.category] ?? []
+                            }
+                            onToggle={togglePreference}
+                        />
+                    ))}
+                </div>
+
+                <div className={preferencePageStyles.sectionGroup}>
+                    <h2 className={preferencePageStyles.sectionTitle}>추가 선택</h2>
+
+                    {optionalPreferenceGroups.map((group) => (
+                        <PreferenceSection
+                            key={group.category}
+                            title={group.title}
+                            description={group.description}
+                            category={group.category}
+                            options={group.options}
+                            selectedValues={
+                                preferenceState.data.selections[group.category] ?? []
+                            }
+                            onToggle={togglePreference}
+                        />
+                    ))}
+
+                    <DislikedFoodSearch
+                        keyword={keyword}
+                        results={results}
+                        selectedFoods={preferenceState.data.dislikedFoods}
+                        isSearching={isSearching}
+                        searchErrorMessage={searchErrorMessage}
+                        onSearch={search}
+                        onSelect={addFood}
+                        onRemove={removeFood}
+                    />
+                </div>
+
+                <button
+                    type="button"
+                    onClick={savePreference}
+                    disabled={isSaving}
+                    className={preferencePageStyles.saveButton}
+                >
+                    {isSaving ? "저장 중..." : "저장하기"}
+                </button>
             </div>
-
-            <div className={preferencePageStyles.sectionGroup}>
-              <h2 className={preferencePageStyles.sectionTitle}>추가 선택</h2>
-
-              {optionalPreferenceGroups.map((group) => (
-                <PreferenceSection
-                  key={group.category}
-                  title={group.title}
-                  description={group.description}
-                  category={group.category}
-                  options={group.options}
-                  selectedValues={preferenceState.data.selections[group.category]}
-                  onToggle={togglePreference}
-                />
-              ))}
-
-              <DislikedFoodSearch
-                keyword={keyword}
-                results={results}
-                selectedFoods={preferenceState.data.dislikedFoods}
-                isSearching={isSearching}
-                searchErrorMessage={searchErrorMessage}
-                onSearch={search}
-                onSelect={addFood}
-                onRemove={removeFood}
-              />
-            </div>
-
-            <button
-              type="button"
-              onClick={savePreference}
-              disabled={isSaving}
-              className={preferencePageStyles.saveButton}
-            >
-              {isSaving ? "저장 중..." : "저장하기"}
-            </button>
-          </div>
         </main>
     );
 }

--- a/src/features/auth/application/hooks/useAuthGuard.ts
+++ b/src/features/auth/application/hooks/useAuthGuard.ts
@@ -7,6 +7,7 @@ import { useAtomValue } from "jotai";
 import {
     isAuthenticatedAtom,
     isAuthLoadingAtom,
+    isOnboardingReadyAtom,
 } from "@/features/auth/application/selectors/authSelectors";
 
 export function useAuthGuard(redirectPath: string = "/login") {
@@ -14,6 +15,7 @@ export function useAuthGuard(redirectPath: string = "/login") {
 
     const isAuthenticated = useAtomValue(isAuthenticatedAtom);
     const isAuthLoading = useAtomValue(isAuthLoadingAtom);
+    const isOnboardingReady = useAtomValue(isOnboardingReadyAtom);
 
     useEffect(() => {
         // 아직 인증 상태 확인 중이면 아무것도 안 함
@@ -23,10 +25,22 @@ export function useAuthGuard(redirectPath: string = "/login") {
         if (!isAuthenticated) {
             router.replace(redirectPath);
         }
-    }, [isAuthLoading, isAuthenticated, router, redirectPath]);
+
+        if (!isOnboardingReady) {
+          router.replace(redirectPath);
+        }
+    }, [
+        isAuthLoading,
+        isAuthenticated,
+        isOnboardingReady,
+        router,
+        redirectPath
+    ]);
 
     return {
         isAuthenticated,
         isAuthLoading,
+        isOnboardingReady,
+        canAccess: isAuthenticated && isOnboardingReady,
     };
 }

--- a/src/features/preference/application/atoms/preferenceAtom.ts
+++ b/src/features/preference/application/atoms/preferenceAtom.ts
@@ -1,6 +1,9 @@
 import { atom } from "jotai";
 import type { PreferenceState } from "@/features/preference/domain/state/PreferenceState";
+import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
 
 export const preferenceAtom = atom<PreferenceState>({
     status: "LOADING",
 });
+
+export const originalPreferenceAtom = atom<UserPreference | null>(null);

--- a/src/features/preference/application/atoms/preferenceOptionAtom.ts
+++ b/src/features/preference/application/atoms/preferenceOptionAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from "jotai";
+import type { PreferenceOptionState } from "@/features/preference/domain/state/PreferenceOptionState";
+
+export const preferenceOptionAtom = atom<PreferenceOptionState>({
+    status: "LOADING",
+});

--- a/src/features/preference/application/hooks/useDislikedFoodSearch.ts
+++ b/src/features/preference/application/hooks/useDislikedFoodSearch.ts
@@ -5,13 +5,14 @@ import { useSetAtom } from "jotai";
 
 import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
 import { preferenceApi } from "@/features/preference/infrastructure/api/preferenceApi";
+import type { DislikedFood } from "@/features/preference/domain/model/UserPreference";
 
 // 비선호 음식 검색, 추가, 삭제
 export function useDislikedFoodSearch() {
     const setPreferenceState = useSetAtom(preferenceAtom);
 
     const [keyword, setKeyword] = useState("");
-    const [results, setResults] = useState<string[]>([]);
+    const [results, setResults] = useState<DislikedFood[]>([]);
     const [isSearching, setIsSearching] = useState(false);
     const [searchErrorMessage, setSearchErrorMessage] = useState<string | null>(null);
 
@@ -21,14 +22,15 @@ export function useDislikedFoodSearch() {
 
         const trimmedKeyword = value.trim();
 
+        if (trimmedKeyword.length === 0) {
+            setResults([]);
+            setIsSearching(false);
+            return;
+        }
+
+        setIsSearching(true);
+
         try {
-            if (trimmedKeyword.length === 0) {
-                setResults([]);
-                return;
-            }
-
-            setIsSearching(true);
-
             const searchedFoods = await preferenceApi.searchDislikedFoods(trimmedKeyword);
             setResults(searchedFoods);
         } catch {
@@ -40,10 +42,15 @@ export function useDislikedFoodSearch() {
     }, []);
 
     const addFood = useCallback(
-        (food: string) => {
+        (food: DislikedFood) => {
             setPreferenceState((prev) => {
                 if (prev.status !== "SUCCESS") return prev;
-                if (prev.data.dislikedFoods.includes(food)) return prev;
+
+                const alreadySelected = prev.data.dislikedFoods.some(
+                    (item) => item.type === food.type && item.id === food.id,
+                );
+
+                if (alreadySelected) return prev;
 
                 return {
                     status: "SUCCESS",
@@ -62,7 +69,7 @@ export function useDislikedFoodSearch() {
     );
 
     const removeFood = useCallback(
-        (food: string) => {
+        (food: DislikedFood) => {
             setPreferenceState((prev) => {
                 if (prev.status !== "SUCCESS") return prev;
 
@@ -71,7 +78,7 @@ export function useDislikedFoodSearch() {
                     data: {
                         ...prev.data,
                         dislikedFoods: prev.data.dislikedFoods.filter(
-                            (item) => item !== food,
+                            (item) => !(item.type === food.type && item.id === food.id),
                         ),
                     },
                 };

--- a/src/features/preference/application/hooks/useDislikedFoodSearch.ts
+++ b/src/features/preference/application/hooks/useDislikedFoodSearch.ts
@@ -9,19 +9,34 @@ import { preferenceApi } from "@/features/preference/infrastructure/api/preferen
 // 비선호 음식 검색, 추가, 삭제
 export function useDislikedFoodSearch() {
     const setPreferenceState = useSetAtom(preferenceAtom);
+
     const [keyword, setKeyword] = useState("");
     const [results, setResults] = useState<string[]>([]);
+    const [isSearching, setIsSearching] = useState(false);
+    const [searchErrorMessage, setSearchErrorMessage] = useState<string | null>(null);
 
     const search = useCallback(async (value: string) => {
         setKeyword(value);
+        setSearchErrorMessage(null);
 
-        if (value.trim().length === 0) {
+        const trimmedKeyword = value.trim();
+
+        try {
+            if (trimmedKeyword.length === 0) {
+                setResults([]);
+                return;
+            }
+
+            setIsSearching(true);
+
+            const searchedFoods = await preferenceApi.searchDislikedFoods(trimmedKeyword);
+            setResults(searchedFoods);
+        } catch {
             setResults([]);
-            return;
+            setSearchErrorMessage("검색 결과를 불러오는데 실패했습니다.");
+        } finally {
+            setIsSearching(false);
         }
-
-        const searchedFoods = await preferenceApi.searchDislikedFoods(value.trim());
-        setResults(searchedFoods);
     }, []);
 
     const addFood = useCallback(
@@ -41,6 +56,7 @@ export function useDislikedFoodSearch() {
 
             setKeyword("");
             setResults([]);
+            setSearchErrorMessage(null);
         },
         [setPreferenceState],
     );
@@ -67,6 +83,8 @@ export function useDislikedFoodSearch() {
     return {
         keyword,
         results,
+        isSearching,
+        searchErrorMessage,
         search,
         addFood,
         removeFood,

--- a/src/features/preference/application/hooks/usePreferenceList.ts
+++ b/src/features/preference/application/hooks/usePreferenceList.ts
@@ -1,16 +1,17 @@
 "use client";
 
 import { useCallback, useEffect } from "react";
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import { useRouter } from "next/navigation";
 
-import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
+import { originalPreferenceAtom, preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
 import { preferenceApi } from "@/features/preference/infrastructure/api/preferenceApi";
 import { HttpError } from "@/infrastructure/http/httpClient";
 
 // 기존 취향 조회
 export function usePreferenceList() {
     const [preferenceState, setPreferenceState] = useAtom(preferenceAtom);
+    const setOriginalPreference = useSetAtom(originalPreferenceAtom);
     const router = useRouter();
 
     const fetchPreference = useCallback(async () => {
@@ -19,8 +20,12 @@ export function usePreferenceList() {
         try {
             const data = await preferenceApi.fetchMyPreference();
             console.log("취향 정보: ", data);
+
+            // 현재 화면에서 수정할 데이터
             setPreferenceState({ status: "SUCCESS", data });
 
+            // 조회 시점의 원본 데이터
+            setOriginalPreference(data);
         } catch (error) {
             if (error instanceof HttpError) {
                 // 401 → 로그인
@@ -42,7 +47,7 @@ export function usePreferenceList() {
                 message: "취향 정보를 불러오는데 실패했습니다.",
             });
         }
-    }, [setPreferenceState, router]);
+    }, [setPreferenceState, setOriginalPreference, router]);
 
     useEffect(() => {
         fetchPreference();

--- a/src/features/preference/application/hooks/usePreferenceList.ts
+++ b/src/features/preference/application/hooks/usePreferenceList.ts
@@ -2,27 +2,47 @@
 
 import { useCallback, useEffect } from "react";
 import { useAtom } from "jotai";
+import { useRouter } from "next/navigation";
 
 import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
 import { preferenceApi } from "@/features/preference/infrastructure/api/preferenceApi";
+import { HttpError } from "@/infrastructure/http/httpClient";
 
 // 기존 취향 조회
 export function usePreferenceList() {
     const [preferenceState, setPreferenceState] = useAtom(preferenceAtom);
+    const router = useRouter();
 
     const fetchPreference = useCallback(async () => {
         setPreferenceState({ status: "LOADING" });
 
         try {
             const data = await preferenceApi.fetchMyPreference();
+            console.log("취향 정보: ", data);
             setPreferenceState({ status: "SUCCESS", data });
-        } catch {
+
+        } catch (error) {
+            if (error instanceof HttpError) {
+                // 401 → 로그인
+                if (error.status === 401) {
+                    alert("세션이 만료되었습니다. 다시 로그인해 주세요.");
+                    router.replace("/login");
+                    return;
+                }
+
+                // 403 → 온보딩
+                if (error.status === 403) {
+                    router.replace("/terms");
+                    return;
+                }
+            }
+
             setPreferenceState({
                 status: "ERROR",
                 message: "취향 정보를 불러오는데 실패했습니다.",
             });
         }
-    }, [setPreferenceState]);
+    }, [setPreferenceState, router]);
 
     useEffect(() => {
         fetchPreference();

--- a/src/features/preference/application/hooks/usePreferenceOptionList.ts
+++ b/src/features/preference/application/hooks/usePreferenceOptionList.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { useAtom } from "jotai";
+
+import { preferenceOptionAtom } from "@/features/preference/application/atoms/preferenceOptionAtom";
+import { preferenceApi } from "@/features/preference/infrastructure/api/preferenceApi";
+
+export function usePreferenceOptionList() {
+    const [preferenceOptionState, setPreferenceOptionState] = useAtom(preferenceOptionAtom);
+
+    const fetchPreferenceOptions = useCallback(async () => {
+        setPreferenceOptionState({ status: "LOADING" });
+
+        try {
+            const data = await preferenceApi.fetchPreferenceOptions();
+
+            setPreferenceOptionState({
+                status: "SUCCESS",
+                data,
+            });
+        } catch {
+            setPreferenceOptionState({
+                status: "ERROR",
+                message: "취향 선택 옵션을 불러오는데 실패했습니다.",
+            });
+        }
+    }, [setPreferenceOptionState]);
+
+    useEffect(() => {
+        fetchPreferenceOptions();
+    }, [fetchPreferenceOptions]);
+
+    return {
+        preferenceOptionState,
+        refetchPreferenceOptions: fetchPreferenceOptions,
+    };
+}

--- a/src/features/preference/application/hooks/usePreferenceSelection.ts
+++ b/src/features/preference/application/hooks/usePreferenceSelection.ts
@@ -5,18 +5,20 @@ import { useSetAtom } from "jotai";
 
 import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
 import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
+import type { PreferenceOption } from "@/features/preference/domain/model/UserPreference";
 
-// 취향 칩 선택/해제
 export function usePreferenceSelection() {
     const setPreferenceState = useSetAtom(preferenceAtom);
 
     const togglePreference = useCallback(
-        (category: PreferenceCategory, value: string) => {
+        (category: PreferenceCategory, value: PreferenceOption) => {
             setPreferenceState((prev) => {
                 if (prev.status !== "SUCCESS") return prev;
 
                 const selectedValues = prev.data.selections[category];
-                const isSelected = selectedValues.includes(value);
+                const isSelected = selectedValues.some(
+                    (item) => item.code === value.code,
+                );
 
                 return {
                     status: "SUCCESS",
@@ -25,7 +27,9 @@ export function usePreferenceSelection() {
                         selections: {
                             ...prev.data.selections,
                             [category]: isSelected
-                                ? selectedValues.filter((item) => item !== value)
+                                ? selectedValues.filter(
+                                      (item) => item.code !== value.code,
+                                  )
                                 : [...selectedValues, value],
                         },
                     },

--- a/src/features/preference/application/hooks/useSavePreference.ts
+++ b/src/features/preference/application/hooks/useSavePreference.ts
@@ -5,7 +5,7 @@ import { useAtomValue } from "jotai";
 
 import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
 import { preferenceApi } from "@/features/preference/infrastructure/api/preferenceApi";
-import { requiredPreferenceGroups } from "@/features/preference/ui/config/preferenceOptions";
+import { requiredPreferenceGroupMeta } from "@/features/preference/ui/config/preferenceOptions";
 
 export function useSavePreference() {
     const preferenceState = useAtomValue(preferenceAtom);
@@ -17,7 +17,7 @@ export function useSavePreference() {
         const selections = preferenceState.data.selections;
 
         // 필수 카테고리 검증
-        for (const group of requiredPreferenceGroups) {
+        for (const group of requiredPreferenceGroupMeta) {
             const values = selections[group.category];
 
             if (!values || values.length === 0) {

--- a/src/features/preference/application/hooks/useSavePreference.ts
+++ b/src/features/preference/application/hooks/useSavePreference.ts
@@ -1,14 +1,16 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 
 import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
 import { preferenceApi } from "@/features/preference/infrastructure/api/preferenceApi";
 import { requiredPreferenceGroupMeta } from "@/features/preference/ui/config/preferenceOptions";
+import { mapUserPreferenceToUpdateRequest } from "@/features/preference/infrastructure/api/mapper/preferenceUpdateRequestMapper";
 
 export function useSavePreference() {
     const preferenceState = useAtomValue(preferenceAtom);
+    const setPreferenceState = useSetAtom(preferenceAtom);
     const [isSaving, setIsSaving] = useState(false);
 
     const validateRequiredSelections = useCallback((): boolean => {
@@ -31,9 +33,7 @@ export function useSavePreference() {
     const savePreference = useCallback(async () => {
         if (preferenceState.status !== "SUCCESS") return;
 
-        const isValid = validateRequiredSelections();
-
-        if (!isValid) {
+        if (!validateRequiredSelections()) {
             alert("필수 취향 항목을 모두 선택해 주세요.");
             return;
         }
@@ -41,14 +41,21 @@ export function useSavePreference() {
         setIsSaving(true);
 
         try {
-            await preferenceApi.savePreference(preferenceState.data);
+            const request = mapUserPreferenceToUpdateRequest(preferenceState.data);
+            const response = await preferenceApi.savePreference(request);
+
+            setPreferenceState({
+                status: "SUCCESS",
+                data: response,
+            });
+
             alert("취향 정보가 저장되었습니다.");
         } catch {
             alert("취향 정보 저장에 실패했습니다.");
         } finally {
             setIsSaving(false);
         }
-    }, [preferenceState, validateRequiredSelections]);
+    }, [preferenceState, validateRequiredSelections, setPreferenceState]);
 
     return {
         isSaving,

--- a/src/features/preference/application/hooks/useSavePreference.ts
+++ b/src/features/preference/application/hooks/useSavePreference.ts
@@ -3,14 +3,16 @@
 import { useCallback, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 
-import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
+import { originalPreferenceAtom, preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
 import { preferenceApi } from "@/features/preference/infrastructure/api/preferenceApi";
 import { requiredPreferenceGroupMeta } from "@/features/preference/ui/config/preferenceOptions";
 import { mapUserPreferenceToUpdateRequest } from "@/features/preference/infrastructure/api/mapper/preferenceUpdateRequestMapper";
+import { isSamePreference } from "@/features/preference/application/utils/preferenceCompare";
 
 export function useSavePreference() {
     const preferenceState = useAtomValue(preferenceAtom);
-    const setPreferenceState = useSetAtom(preferenceAtom);
+    const originalPreference = useAtomValue(originalPreferenceAtom);
+    const setOriginalPreference = useSetAtom(originalPreferenceAtom);
     const [isSaving, setIsSaving] = useState(false);
 
     const validateRequiredSelections = useCallback((): boolean => {
@@ -38,16 +40,22 @@ export function useSavePreference() {
             return;
         }
 
+        if (
+            originalPreference &&
+            isSamePreference(originalPreference, preferenceState.data)
+        ) {
+            alert("변경된 취향 정보가 없습니다.");
+            return;
+        }
+
         setIsSaving(true);
 
         try {
             const request = mapUserPreferenceToUpdateRequest(preferenceState.data);
-            const response = await preferenceApi.savePreference(request);
 
-            setPreferenceState({
-                status: "SUCCESS",
-                data: response,
-            });
+            await preferenceApi.savePreference(request);
+
+            setOriginalPreference(preferenceState.data);
 
             alert("취향 정보가 저장되었습니다.");
         } catch {
@@ -55,7 +63,11 @@ export function useSavePreference() {
         } finally {
             setIsSaving(false);
         }
-    }, [preferenceState, validateRequiredSelections, setPreferenceState]);
+    }, [preferenceState,
+        originalPreference,
+        validateRequiredSelections,
+        setOriginalPreference,
+    ]);
 
     return {
         isSaving,

--- a/src/features/preference/application/hooks/useSavePreference.ts
+++ b/src/features/preference/application/hooks/useSavePreference.ts
@@ -5,13 +5,38 @@ import { useAtomValue } from "jotai";
 
 import { preferenceAtom } from "@/features/preference/application/atoms/preferenceAtom";
 import { preferenceApi } from "@/features/preference/infrastructure/api/preferenceApi";
+import { requiredPreferenceGroups } from "@/features/preference/ui/config/preferenceOptions";
 
 export function useSavePreference() {
     const preferenceState = useAtomValue(preferenceAtom);
     const [isSaving, setIsSaving] = useState(false);
 
+    const validateRequiredSelections = useCallback((): boolean => {
+        if (preferenceState.status !== "SUCCESS") return false;
+
+        const selections = preferenceState.data.selections;
+
+        // 필수 카테고리 검증
+        for (const group of requiredPreferenceGroups) {
+            const values = selections[group.category];
+
+            if (!values || values.length === 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }, [preferenceState]);
+
     const savePreference = useCallback(async () => {
         if (preferenceState.status !== "SUCCESS") return;
+
+        const isValid = validateRequiredSelections();
+
+        if (!isValid) {
+            alert("필수 취향 항목을 모두 선택해 주세요.");
+            return;
+        }
 
         setIsSaving(true);
 
@@ -23,7 +48,7 @@ export function useSavePreference() {
         } finally {
             setIsSaving(false);
         }
-    }, [preferenceState]);
+    }, [preferenceState, validateRequiredSelections]);
 
     return {
         isSaving,

--- a/src/features/preference/application/utils/preferenceCompare.ts
+++ b/src/features/preference/application/utils/preferenceCompare.ts
@@ -1,0 +1,68 @@
+import type {
+    DislikedFood,
+    PreferenceOption,
+    UserPreference,
+} from "@/features/preference/domain/model/UserPreference";
+import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
+
+const preferenceCategories: readonly PreferenceCategory[] = [
+    "FLAVOR",
+    "COOKING_METHOD",
+    "MEAL_SITUATION",
+    "FOOD_CATEGORY",
+    "TEXTURE",
+    "TEMPERATURE",
+];
+
+function normalizePreferenceOptions(
+    options: readonly PreferenceOption[],
+): readonly string[] {
+    return options.map((option) => option.code).sort();
+}
+
+function normalizeDislikedFoods(
+    foods: readonly DislikedFood[],
+): readonly string[] {
+    return foods
+        .map((food) => `${food.type}:${food.id}`)
+        .sort();
+}
+
+export function isSamePreference(
+    original: UserPreference,
+    current: UserPreference,
+): boolean {
+    for (const category of preferenceCategories) {
+        const originalCodes = normalizePreferenceOptions(
+            original.selections[category] ?? [],
+        );
+        const currentCodes = normalizePreferenceOptions(
+            current.selections[category] ?? [],
+        );
+
+        if (originalCodes.length !== currentCodes.length) {
+            return false;
+        }
+
+        for (let index = 0; index < originalCodes.length; index += 1) {
+            if (originalCodes[index] !== currentCodes[index]) {
+                return false;
+            }
+        }
+    }
+
+    const originalFoods = normalizeDislikedFoods(original.dislikedFoods);
+    const currentFoods = normalizeDislikedFoods(current.dislikedFoods);
+
+    if (originalFoods.length !== currentFoods.length) {
+        return false;
+    }
+
+    for (let index = 0; index < originalFoods.length; index += 1) {
+        if (originalFoods[index] !== currentFoods[index]) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/features/preference/domain/model/UserPreference.ts
+++ b/src/features/preference/domain/model/UserPreference.ts
@@ -1,8 +1,26 @@
 import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
 
-export type PreferenceSelections = Record<PreferenceCategory, readonly string[]>;
+export interface PreferenceOption {
+    readonly id: number;
+    readonly categoryType: PreferenceCategory;
+    readonly code: string;
+    readonly name: string;
+    readonly sortOrder?: number;
+}
+
+export interface DislikedFood {
+    readonly id: number;
+    readonly code: string;
+    readonly name: string;
+    readonly type: "RESTRICTION_INGREDIENT" | "MENU_ITEM";
+}
+
+export type PreferenceSelections = Record<
+    PreferenceCategory,
+    readonly PreferenceOption[]
+>;
 
 export interface UserPreference {
     readonly selections: PreferenceSelections;
-    readonly dislikedFoods: readonly string[];
+    readonly dislikedFoods: readonly DislikedFood[];
 }

--- a/src/features/preference/domain/state/PreferenceOptionState.ts
+++ b/src/features/preference/domain/state/PreferenceOptionState.ts
@@ -1,0 +1,6 @@
+import type { PreferenceOption } from "@/features/preference/domain/model/UserPreference";
+
+export type PreferenceOptionState =
+    | { readonly status: "LOADING" }
+    | { readonly status: "SUCCESS"; readonly data: readonly PreferenceOption[] }
+    | { readonly status: "ERROR"; readonly message: string };

--- a/src/features/preference/infrastructure/api/dto/AttributeCategoriesResponse.ts
+++ b/src/features/preference/infrastructure/api/dto/AttributeCategoriesResponse.ts
@@ -1,0 +1,20 @@
+import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
+
+export interface AttributeCategoryItem {
+    readonly id: number;
+    readonly categoryType: PreferenceCategory;
+    readonly code: string;
+    readonly name: string;
+    readonly sortOrder: number;
+}
+
+export interface AttributeCategoriesResponse {
+    readonly success: boolean;
+    readonly data: readonly AttributeCategoryItem[];
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/preference/infrastructure/api/dto/MenuItemsResponse.ts
+++ b/src/features/preference/infrastructure/api/dto/MenuItemsResponse.ts
@@ -1,0 +1,16 @@
+export interface MenuItem {
+    readonly id: number;
+    readonly code: string;
+    readonly name: string;
+}
+
+export interface MenuItemsResponse {
+    readonly success: boolean;
+    readonly data: readonly MenuItem[];
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/preference/infrastructure/api/dto/PreferenceProfileResponse.ts
+++ b/src/features/preference/infrastructure/api/dto/PreferenceProfileResponse.ts
@@ -1,4 +1,4 @@
-export interface TasteProfileAttributeCategory {
+export interface PreferenceProfileAttributeCategory {
     readonly id: number;
     readonly categoryType: string;
     readonly code: string;
@@ -6,7 +6,7 @@ export interface TasteProfileAttributeCategory {
     readonly sortOrder: number;
 }
 
-export interface TasteProfileRestrictionIngredient {
+export interface PreferenceProfileRestrictionIngredient {
     readonly id: number;
     readonly code: string;
     readonly name: string;
@@ -14,24 +14,24 @@ export interface TasteProfileRestrictionIngredient {
     readonly sortOrder: number;
 }
 
-export interface TasteProfileDislikedMenuItem {
+export interface PreferenceProfileDislikedMenuItem {
     readonly id: number;
     readonly code: string;
     readonly name: string;
 }
 
-export interface TasteProfileData {
+export interface PreferenceProfileData {
     readonly memberId: number;
     readonly profileVersion: string;
-    readonly attributeCategories: readonly TasteProfileAttributeCategory[];
-    readonly restrictionIngredients: readonly TasteProfileRestrictionIngredient[];
-    readonly dislikedMenuItems: readonly TasteProfileDislikedMenuItem[];
+    readonly attributeCategories: readonly PreferenceProfileAttributeCategory[];
+    readonly restrictionIngredients: readonly PreferenceProfileRestrictionIngredient[];
+    readonly dislikedMenuItems: readonly PreferenceProfileDislikedMenuItem[];
     readonly updatedAt: string | null;
 }
 
-export interface TasteProfileResponse {
+export interface PreferenceProfileResponse {
     readonly success: boolean;
-    readonly data: TasteProfileData | null;
+    readonly data: PreferenceProfileData | null;
     readonly error: {
         readonly status: number;
         readonly code: string;

--- a/src/features/preference/infrastructure/api/dto/PreferenceUpdateRequest.ts
+++ b/src/features/preference/infrastructure/api/dto/PreferenceUpdateRequest.ts
@@ -1,0 +1,5 @@
+export interface PreferenceUpdateRequest {
+    readonly attributeCategoryIds: readonly number[];
+    readonly restrictionIngredientIds: readonly number[];
+    readonly dislikedMenuItemIds: readonly number[];
+}

--- a/src/features/preference/infrastructure/api/dto/RestrictionIngredientsResponse.ts
+++ b/src/features/preference/infrastructure/api/dto/RestrictionIngredientsResponse.ts
@@ -1,0 +1,18 @@
+export interface RestrictionIngredientItem {
+    readonly id: number;
+    readonly code: string;
+    readonly name: string;
+    readonly allergen: boolean;
+    readonly sortOrder: number;
+}
+
+export interface RestrictionIngredientsResponse {
+    readonly success: boolean;
+    readonly data: readonly RestrictionIngredientItem[];
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/preference/infrastructure/api/dto/TasteProfileResponse.ts
+++ b/src/features/preference/infrastructure/api/dto/TasteProfileResponse.ts
@@ -1,0 +1,41 @@
+export interface TasteProfileAttributeCategory {
+    readonly id: number;
+    readonly categoryType: string;
+    readonly code: string;
+    readonly name: string;
+    readonly sortOrder: number;
+}
+
+export interface TasteProfileRestrictionIngredient {
+    readonly id: number;
+    readonly code: string;
+    readonly name: string;
+    readonly allergen: boolean;
+    readonly sortOrder: number;
+}
+
+export interface TasteProfileDislikedMenuItem {
+    readonly id: number;
+    readonly code: string;
+    readonly name: string;
+}
+
+export interface TasteProfileData {
+    readonly memberId: number;
+    readonly profileVersion: string;
+    readonly attributeCategories: readonly TasteProfileAttributeCategory[];
+    readonly restrictionIngredients: readonly TasteProfileRestrictionIngredient[];
+    readonly dislikedMenuItems: readonly TasteProfileDislikedMenuItem[];
+    readonly updatedAt: string | null;
+}
+
+export interface TasteProfileResponse {
+    readonly success: boolean;
+    readonly data: TasteProfileData | null;
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/preference/infrastructure/api/mapper/attributeCategoryMapper.ts
+++ b/src/features/preference/infrastructure/api/mapper/attributeCategoryMapper.ts
@@ -1,0 +1,14 @@
+import type { PreferenceOption } from "@/features/preference/domain/model/UserPreference";
+import type { AttributeCategoryItem } from "@/features/preference/infrastructure/api/dto/AttributeCategoriesResponse";
+
+export function mapAttributeCategoriesToPreferenceOptions(
+    data: readonly AttributeCategoryItem[],
+): readonly PreferenceOption[] {
+    return data.map((item) => ({
+        id: item.id,
+        categoryType: item.categoryType,
+        code: item.code,
+        name: item.name,
+        sortOrder: item.sortOrder,
+    }));
+}

--- a/src/features/preference/infrastructure/api/mapper/preferenceProfileMapper.ts
+++ b/src/features/preference/infrastructure/api/mapper/preferenceProfileMapper.ts
@@ -1,5 +1,9 @@
 import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
-import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
+import type {
+    DislikedFood,
+    PreferenceOption,
+    UserPreference,
+} from "@/features/preference/domain/model/UserPreference";
 import type { PreferenceProfileData } from "@/features/preference/infrastructure/api/dto/PreferenceProfileResponse";
 
 const preferenceCategories: readonly PreferenceCategory[] = [
@@ -34,17 +38,38 @@ export function mapPreferenceProfileToUserPreference(
     data.attributeCategories.forEach((attribute) => {
         if (!isPreferenceCategory(attribute.categoryType)) return;
 
+        const option: PreferenceOption = {
+            id: attribute.id,
+            categoryType: attribute.categoryType,
+            code: attribute.code,
+            name: attribute.name,
+            sortOrder: attribute.sortOrder,
+        };
+
         selections[attribute.categoryType] = [
             ...selections[attribute.categoryType],
-            attribute.name,
+            option,
         ];
     });
 
+    const restrictionFoods: DislikedFood[] = data.restrictionIngredients.map(
+        (ingredient) => ({
+            id: ingredient.id,
+            code: ingredient.code,
+            name: ingredient.name,
+            type: "RESTRICTION_INGREDIENT",
+        }),
+    );
+
+    const menuFoods: DislikedFood[] = data.dislikedMenuItems.map((menuItem) => ({
+        id: menuItem.id,
+        code: menuItem.code,
+        name: menuItem.name,
+        type: "MENU_ITEM",
+    }));
+
     return {
         selections,
-        dislikedFoods: [
-            ...data.restrictionIngredients.map((ingredient) => ingredient.name),
-            ...data.dislikedMenuItems.map((menuItem) => menuItem.name),
-        ],
+        dislikedFoods: [...restrictionFoods, ...menuFoods],
     };
 }

--- a/src/features/preference/infrastructure/api/mapper/preferenceProfileMapper.ts
+++ b/src/features/preference/infrastructure/api/mapper/preferenceProfileMapper.ts
@@ -1,6 +1,6 @@
 import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
 import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
-import type { TasteProfileData } from "@/features/preference/infrastructure/api/dto/TasteProfileResponse";
+import type { PreferenceProfileData } from "@/features/preference/infrastructure/api/dto/PreferenceProfileResponse";
 
 const preferenceCategories: readonly PreferenceCategory[] = [
     "FLAVOR",
@@ -26,8 +26,8 @@ function isPreferenceCategory(value: string): value is PreferenceCategory {
     return preferenceCategories.includes(value as PreferenceCategory);
 }
 
-export function mapTasteProfileToUserPreference(
-    data: TasteProfileData,
+export function mapPreferenceProfileToUserPreference(
+    data: PreferenceProfileData,
 ): UserPreference {
     const selections = createEmptySelections();
 

--- a/src/features/preference/infrastructure/api/mapper/preferenceUpdateRequestMapper.ts
+++ b/src/features/preference/infrastructure/api/mapper/preferenceUpdateRequestMapper.ts
@@ -1,0 +1,24 @@
+import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
+import type { PreferenceUpdateRequest } from "@/features/preference/infrastructure/api/dto/PreferenceUpdateRequest";
+
+export function mapUserPreferenceToUpdateRequest(
+    preference: UserPreference,
+): PreferenceUpdateRequest {
+    const attributeCategoryIds = Object.entries(preference.selections)
+        .filter(([category]) => category !== "MEAL_SITUATION")
+        .flatMap(([, options]) => options.map((option) => option.id));
+
+    const restrictionIngredientIds = preference.dislikedFoods
+        .filter((food) => food.type === "RESTRICTION_INGREDIENT")
+        .map((food) => food.id);
+
+    const dislikedMenuItemIds = preference.dislikedFoods
+        .filter((food) => food.type === "MENU_ITEM")
+        .map((food) => food.id);
+
+    return {
+        attributeCategoryIds: Array.from(new Set(attributeCategoryIds)),
+        restrictionIngredientIds: Array.from(new Set(restrictionIngredientIds)),
+        dislikedMenuItemIds: Array.from(new Set(dislikedMenuItemIds)),
+    };
+}

--- a/src/features/preference/infrastructure/api/mapper/tasteProfileMapper.ts
+++ b/src/features/preference/infrastructure/api/mapper/tasteProfileMapper.ts
@@ -1,0 +1,50 @@
+import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
+import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
+import type { TasteProfileData } from "@/features/preference/infrastructure/api/dto/TasteProfileResponse";
+
+const preferenceCategories: readonly PreferenceCategory[] = [
+    "FLAVOR",
+    "COOKING_METHOD",
+    "MEAL_SITUATION",
+    "FOOD_CATEGORY",
+    "TEXTURE",
+    "TEMPERATURE",
+];
+
+function createEmptySelections(): UserPreference["selections"] {
+    return {
+        FLAVOR: [],
+        COOKING_METHOD: [],
+        MEAL_SITUATION: [],
+        FOOD_CATEGORY: [],
+        TEXTURE: [],
+        TEMPERATURE: [],
+    };
+}
+
+function isPreferenceCategory(value: string): value is PreferenceCategory {
+    return preferenceCategories.includes(value as PreferenceCategory);
+}
+
+export function mapTasteProfileToUserPreference(
+    data: TasteProfileData,
+): UserPreference {
+    const selections = createEmptySelections();
+
+    data.attributeCategories.forEach((attribute) => {
+        if (!isPreferenceCategory(attribute.categoryType)) return;
+
+        selections[attribute.categoryType] = [
+            ...selections[attribute.categoryType],
+            attribute.name,
+        ];
+    });
+
+    return {
+        selections,
+        dislikedFoods: [
+            ...data.restrictionIngredients.map((ingredient) => ingredient.name),
+            ...data.dislikedMenuItems.map((menuItem) => menuItem.name),
+        ],
+    };
+}

--- a/src/features/preference/infrastructure/api/preferenceApi.ts
+++ b/src/features/preference/infrastructure/api/preferenceApi.ts
@@ -1,19 +1,9 @@
 import { httpClient } from "@/infrastructure/http/httpClient";
 import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
 import type { PreferenceProfileResponse } from "@/features/preference/infrastructure/api/dto/PreferenceProfileResponse";
+import type { RestrictionIngredientsResponse } from "@/features/preference/infrastructure/api/dto/RestrictionIngredientsResponse";
+import type { MenuItemsResponse } from "@/features/preference/infrastructure/api/dto/MenuItemsResponse";
 import { mapPreferenceProfileToUserPreference } from "@/features/preference/infrastructure/api/mapper/preferenceProfileMapper";
-
-const mockDislikedFoods = [
-    "땅콩",
-    "우유",
-    "계란",
-    "새우",
-    "게",
-    "밀",
-    "대두",
-    "복숭아",
-    "토마토",
-];
 
 export const preferenceApi = {
     async fetchMyPreference(): Promise<UserPreference> {
@@ -29,7 +19,25 @@ export const preferenceApi = {
     },
 
     async searchDislikedFoods(keyword: string): Promise<string[]> {
-        return mockDislikedFoods.filter((food) => food.includes(keyword));
+        const query = encodeURIComponent(keyword);
+
+        const [restrictionResponse, menuResponse] = await Promise.all([
+            httpClient.get<RestrictionIngredientsResponse>(
+                `/api/v1/restriction-ingredients?query=${query}`,
+            ),
+            httpClient.get<MenuItemsResponse>(
+                `/api/v1/menu-items?query=${query}`,
+            ),
+        ]);
+
+        if (!restrictionResponse.success || !menuResponse.success) {
+            throw new Error("알레르기/비선호 음식 검색 실패");
+        }
+
+        const restrictionNames = restrictionResponse.data.map((item) => item.name);
+        const menuNames = menuResponse.data.map((item) => item.name);
+
+        return Array.from(new Set([...restrictionNames, ...menuNames]));
     },
 
     async savePreference(preference: UserPreference): Promise<void> {

--- a/src/features/preference/infrastructure/api/preferenceApi.ts
+++ b/src/features/preference/infrastructure/api/preferenceApi.ts
@@ -1,7 +1,7 @@
 import { httpClient } from "@/infrastructure/http/httpClient";
 import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
-import type { TasteProfileResponse } from "@/features/preference/infrastructure/api/dto/TasteProfileResponse";
-import { mapTasteProfileToUserPreference } from "@/features/preference/infrastructure/api/mapper/tasteProfileMapper";
+import type { PreferenceProfileResponse } from "@/features/preference/infrastructure/api/dto/PreferenceProfileResponse";
+import { mapPreferenceProfileToUserPreference } from "@/features/preference/infrastructure/api/mapper/preferenceProfileMapper";
 
 const mockDislikedFoods = [
     "땅콩",
@@ -17,7 +17,7 @@ const mockDislikedFoods = [
 
 export const preferenceApi = {
     async fetchMyPreference(): Promise<UserPreference> {
-        const response = await httpClient.get<TasteProfileResponse>(
+        const response = await httpClient.get<PreferenceProfileResponse>(
             "/api/v1/members/me/taste-profile",
         );
 
@@ -25,7 +25,7 @@ export const preferenceApi = {
             throw new Error(response.error?.message ?? "취향 정보 조회 실패");
         }
 
-        return mapTasteProfileToUserPreference(response.data);
+        return mapPreferenceProfileToUserPreference(response.data);
     },
 
     async searchDislikedFoods(keyword: string): Promise<string[]> {

--- a/src/features/preference/infrastructure/api/preferenceApi.ts
+++ b/src/features/preference/infrastructure/api/preferenceApi.ts
@@ -8,6 +8,7 @@ import type { AttributeCategoriesResponse } from "@/features/preference/infrastr
 import type { PreferenceProfileResponse } from "@/features/preference/infrastructure/api/dto/PreferenceProfileResponse";
 import type { RestrictionIngredientsResponse } from "@/features/preference/infrastructure/api/dto/RestrictionIngredientsResponse";
 import type { MenuItemsResponse } from "@/features/preference/infrastructure/api/dto/MenuItemsResponse";
+import type { PreferenceUpdateRequest } from "@/features/preference/infrastructure/api/dto/PreferenceUpdateRequest";
 
 import { mapPreferenceProfileToUserPreference } from "@/features/preference/infrastructure/api/mapper/preferenceProfileMapper";
 import { mapAttributeCategoriesToPreferenceOptions } from "@/features/preference/infrastructure/api/mapper/attributeCategoryMapper";
@@ -72,7 +73,16 @@ export const preferenceApi = {
         return [...restrictionFoods, ...menuFoods];
     },
 
-    async savePreference(preference: UserPreference): Promise<void> {
-        console.log("save preference", preference);
+    async savePreference(request: PreferenceUpdateRequest): Promise<UserPreference> {
+        const response = await httpClient.patch<PreferenceProfileResponse>(
+            "/api/v1/members/me/taste-profile",
+            request,
+        );
+
+        if (!response.success || !response.data) {
+            throw new Error(response.error?.message ?? "취향 정보 저장 실패");
+        }
+
+        return mapPreferenceProfileToUserPreference(response.data);
     },
 };

--- a/src/features/preference/infrastructure/api/preferenceApi.ts
+++ b/src/features/preference/infrastructure/api/preferenceApi.ts
@@ -1,16 +1,7 @@
+import { httpClient } from "@/infrastructure/http/httpClient";
 import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
-
-const mockPreference: UserPreference = {
-    selections: {
-        FLAVOR: ["매콤", "고소"],
-        COOKING_METHOD: [],
-        MEAL_SITUATION: [],
-        FOOD_CATEGORY: [],
-        TEXTURE: [],
-        TEMPERATURE: [],
-    },
-    dislikedFoods: ["땅콩"],
-};
+import type { TasteProfileResponse } from "@/features/preference/infrastructure/api/dto/TasteProfileResponse";
+import { mapTasteProfileToUserPreference } from "@/features/preference/infrastructure/api/mapper/tasteProfileMapper";
 
 const mockDislikedFoods = [
     "땅콩",
@@ -26,7 +17,15 @@ const mockDislikedFoods = [
 
 export const preferenceApi = {
     async fetchMyPreference(): Promise<UserPreference> {
-        return mockPreference;
+        const response = await httpClient.get<TasteProfileResponse>(
+            "/api/v1/members/me/taste-profile",
+        );
+
+        if (!response.success || !response.data) {
+            throw new Error(response.error?.message ?? "취향 정보 조회 실패");
+        }
+
+        return mapTasteProfileToUserPreference(response.data);
     },
 
     async searchDislikedFoods(keyword: string): Promise<string[]> {

--- a/src/features/preference/infrastructure/api/preferenceApi.ts
+++ b/src/features/preference/infrastructure/api/preferenceApi.ts
@@ -1,11 +1,30 @@
 import { httpClient } from "@/infrastructure/http/httpClient";
-import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
+import type {
+    DislikedFood,
+    PreferenceOption,
+    UserPreference,
+} from "@/features/preference/domain/model/UserPreference";
+import type { AttributeCategoriesResponse } from "@/features/preference/infrastructure/api/dto/AttributeCategoriesResponse";
 import type { PreferenceProfileResponse } from "@/features/preference/infrastructure/api/dto/PreferenceProfileResponse";
 import type { RestrictionIngredientsResponse } from "@/features/preference/infrastructure/api/dto/RestrictionIngredientsResponse";
 import type { MenuItemsResponse } from "@/features/preference/infrastructure/api/dto/MenuItemsResponse";
+
 import { mapPreferenceProfileToUserPreference } from "@/features/preference/infrastructure/api/mapper/preferenceProfileMapper";
+import { mapAttributeCategoriesToPreferenceOptions } from "@/features/preference/infrastructure/api/mapper/attributeCategoryMapper";
 
 export const preferenceApi = {
+    async fetchPreferenceOptions(): Promise<readonly PreferenceOption[]> {
+        const response = await httpClient.get<AttributeCategoriesResponse>(
+            "/api/v1/attribute-categories",
+        );
+
+        if (!response.success) {
+            throw new Error(response.error?.message ?? "취향 선택 옵션 조회 실패");
+        }
+
+        return mapAttributeCategoriesToPreferenceOptions(response.data);
+    },
+
     async fetchMyPreference(): Promise<UserPreference> {
         const response = await httpClient.get<PreferenceProfileResponse>(
             "/api/v1/members/me/taste-profile",
@@ -18,7 +37,7 @@ export const preferenceApi = {
         return mapPreferenceProfileToUserPreference(response.data);
     },
 
-    async searchDislikedFoods(keyword: string): Promise<string[]> {
+    async searchDislikedFoods(keyword: string): Promise<DislikedFood[]> {
         const query = encodeURIComponent(keyword);
 
         const [restrictionResponse, menuResponse] = await Promise.all([
@@ -34,10 +53,23 @@ export const preferenceApi = {
             throw new Error("알레르기/비선호 음식 검색 실패");
         }
 
-        const restrictionNames = restrictionResponse.data.map((item) => item.name);
-        const menuNames = menuResponse.data.map((item) => item.name);
+        const restrictionFoods: DislikedFood[] = restrictionResponse.data.map(
+            (item) => ({
+                id: item.id,
+                code: item.code,
+                name: item.name,
+                type: "RESTRICTION_INGREDIENT",
+            }),
+        );
 
-        return Array.from(new Set([...restrictionNames, ...menuNames]));
+        const menuFoods: DislikedFood[] = menuResponse.data.map((item) => ({
+            id: item.id,
+            code: item.code,
+            name: item.name,
+            type: "MENU_ITEM",
+        }));
+
+        return [...restrictionFoods, ...menuFoods];
     },
 
     async savePreference(preference: UserPreference): Promise<void> {

--- a/src/features/preference/ui/components/DislikedFoodSearch.tsx
+++ b/src/features/preference/ui/components/DislikedFoodSearch.tsx
@@ -1,14 +1,15 @@
+import type { DislikedFood } from "@/features/preference/domain/model/UserPreference";
 import { dislikedFoodSearchStyles } from "@/ui/styles/dislikedFoodSearchStyles";
 
 interface DislikedFoodSearchProps {
     readonly keyword: string;
-    readonly results: readonly string[];
-    readonly selectedFoods: readonly string[];
+    readonly results: readonly DislikedFood[];
+    readonly selectedFoods: readonly DislikedFood[];
     readonly isSearching: boolean;
     readonly searchErrorMessage: string | null;
     readonly onSearch: (keyword: string) => void;
-    readonly onSelect: (food: string) => void;
-    readonly onRemove: (food: string) => void;
+    readonly onSelect: (food: DislikedFood) => void;
+    readonly onRemove: (food: DislikedFood) => void;
 }
 
 export default function DislikedFoodSearch({
@@ -69,12 +70,12 @@ export default function DislikedFoodSearch({
                             !searchErrorMessage &&
                             results.map((food) => (
                                 <button
-                                    key={food}
+                                    key={`${food.type}-${food.id}`}
                                     type="button"
                                     onClick={() => onSelect(food)}
                                     className={dislikedFoodSearchStyles.resultItem}
                                 >
-                                    {food}
+                                    {food.name}
                                 </button>
                             ))}
                     </div>
@@ -85,10 +86,10 @@ export default function DislikedFoodSearch({
                 <div className={dislikedFoodSearchStyles.selectedList}>
                     {selectedFoods.map((food) => (
                         <div
-                            key={food}
+                            key={`${food.type}-${food.id}`}
                             className={dislikedFoodSearchStyles.selectedTag}
                         >
-                            <span>{food}</span>
+                            <span>{food.name}</span>
                             <button
                                 type="button"
                                 onClick={() => onRemove(food)}

--- a/src/features/preference/ui/components/DislikedFoodSearch.tsx
+++ b/src/features/preference/ui/components/DislikedFoodSearch.tsx
@@ -4,6 +4,8 @@ interface DislikedFoodSearchProps {
     readonly keyword: string;
     readonly results: readonly string[];
     readonly selectedFoods: readonly string[];
+    readonly isSearching: boolean;
+    readonly searchErrorMessage: string | null;
     readonly onSearch: (keyword: string) => void;
     readonly onSelect: (food: string) => void;
     readonly onRemove: (food: string) => void;
@@ -13,62 +15,91 @@ export default function DislikedFoodSearch({
     keyword,
     results,
     selectedFoods,
+    isSearching,
+    searchErrorMessage,
     onSearch,
     onSelect,
     onRemove,
 }: DislikedFoodSearchProps) {
+    const hasKeyword = keyword.trim().length > 0;
+    const showEmptyMessage =
+        hasKeyword && !isSearching && !searchErrorMessage && results.length === 0;
+
     return (
         <section className={dislikedFoodSearchStyles.container}>
-          <div className={dislikedFoodSearchStyles.header}>
-            <h3 className={dislikedFoodSearchStyles.title}>
-              알레르기 / 비선호 음식
-            </h3>
-            <p className={dislikedFoodSearchStyles.description}>
-              피하고 싶은 음식을 검색 후 선택해 주세요.
-            </p>
-          </div>
-
-          <div className={dislikedFoodSearchStyles.searchWrapper}>
-            <input
-              type="text"
-              value={keyword}
-              onChange={(e) => onSearch(e.target.value)}
-              placeholder="예: 땅콩, 우유, 새우"
-              className={dislikedFoodSearchStyles.input}
-            />
-
-            {keyword && results.length > 0 && (
-              <div className={dislikedFoodSearchStyles.resultList}>
-                {results.map((food) => (
-                  <button
-                    key={food}
-                    type="button"
-                    onClick={() => onSelect(food)}
-                    className={dislikedFoodSearchStyles.resultItem}
-                  >
-                    {food}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {selectedFoods.length > 0 && (
-            <div className={dislikedFoodSearchStyles.selectedList}>
-              {selectedFoods.map((food) => (
-                <div key={food} className={dislikedFoodSearchStyles.selectedTag}>
-                  <span>{food}</span>
-                  <button
-                    type="button"
-                    onClick={() => onRemove(food)}
-                    className={dislikedFoodSearchStyles.removeButton}
-                  >
-                    ×
-                  </button>
-                </div>
-              ))}
+            <div className={dislikedFoodSearchStyles.header}>
+                <h3 className={dislikedFoodSearchStyles.title}>
+                    알레르기 / 비선호 음식
+                </h3>
+                <p className={dislikedFoodSearchStyles.description}>
+                    피하고 싶은 음식을 검색 후 선택해 주세요.
+                </p>
             </div>
-          )}
+
+            <div className={dislikedFoodSearchStyles.searchWrapper}>
+                <input
+                    type="text"
+                    value={keyword}
+                    onChange={(e) => onSearch(e.target.value)}
+                    placeholder="예: 땅콩, 우유, 돈까스"
+                    className={dislikedFoodSearchStyles.input}
+                />
+
+                {hasKeyword && (
+                    <div className={dislikedFoodSearchStyles.resultList}>
+                        {isSearching && (
+                            <p className={dislikedFoodSearchStyles.resultMessage}>
+                                검색 중...
+                            </p>
+                        )}
+
+                        {searchErrorMessage && (
+                            <p className={dislikedFoodSearchStyles.errorMessage}>
+                                {searchErrorMessage}
+                            </p>
+                        )}
+
+                        {showEmptyMessage && (
+                            <p className={dislikedFoodSearchStyles.resultMessage}>
+                                검색 결과가 없습니다.
+                            </p>
+                        )}
+
+                        {!isSearching &&
+                            !searchErrorMessage &&
+                            results.map((food) => (
+                                <button
+                                    key={food}
+                                    type="button"
+                                    onClick={() => onSelect(food)}
+                                    className={dislikedFoodSearchStyles.resultItem}
+                                >
+                                    {food}
+                                </button>
+                            ))}
+                    </div>
+                )}
+            </div>
+
+            {selectedFoods.length > 0 && (
+                <div className={dislikedFoodSearchStyles.selectedList}>
+                    {selectedFoods.map((food) => (
+                        <div
+                            key={food}
+                            className={dislikedFoodSearchStyles.selectedTag}
+                        >
+                            <span>{food}</span>
+                            <button
+                                type="button"
+                                onClick={() => onRemove(food)}
+                                className={dislikedFoodSearchStyles.removeButton}
+                            >
+                                ×
+                            </button>
+                        </div>
+                    ))}
+                </div>
+            )}
         </section>
     );
 }

--- a/src/features/preference/ui/components/PreferenceSection.tsx
+++ b/src/features/preference/ui/components/PreferenceSection.tsx
@@ -1,13 +1,17 @@
 import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
+import type { PreferenceOption } from "@/features/preference/domain/model/UserPreference";
 import { preferenceSectionStyles } from "@/ui/styles/preferenceSectionStyles";
 
 interface PreferenceSectionProps {
     readonly title: string;
     readonly description?: string;
     readonly category: PreferenceCategory;
-    readonly options: readonly string[];
-    readonly selectedValues: readonly string[];
-    readonly onToggle: (category: PreferenceCategory, value: string) => void;
+    readonly options: readonly PreferenceOption[];
+    readonly selectedValues: readonly PreferenceOption[];
+    readonly onToggle: (
+        category: PreferenceCategory,
+        value: PreferenceOption,
+    ) => void;
 }
 
 export default function PreferenceSection({
@@ -20,33 +24,37 @@ export default function PreferenceSection({
 }: PreferenceSectionProps) {
     return (
         <section className={preferenceSectionStyles.container}>
-          <div className={preferenceSectionStyles.header}>
-            <h3 className={preferenceSectionStyles.title}>{title}</h3>
-            {description && (
-              <p className={preferenceSectionStyles.description}>{description}</p>
-            )}
-          </div>
+            <div className={preferenceSectionStyles.header}>
+                <h3 className={preferenceSectionStyles.title}>{title}</h3>
+                {description && (
+                    <p className={preferenceSectionStyles.description}>
+                        {description}
+                    </p>
+                )}
+            </div>
 
-          <div className={preferenceSectionStyles.chipGroup}>
-            {options.map((option) => {
-              const selected = selectedValues.includes(option);
+            <div className={preferenceSectionStyles.chipGroup}>
+                {options.map((option) => {
+                    const selected = selectedValues.some(
+                        (selectedValue) => selectedValue.code === option.code,
+                    );
 
-              return (
-                <button
-                  key={option}
-                  type="button"
-                  onClick={() => onToggle(category, option)}
-                  className={
-                    selected
-                      ? preferenceSectionStyles.selectedChip
-                      : preferenceSectionStyles.chip
-                  }
-                >
-                  {option}
-                </button>
-              );
-            })}
-          </div>
+                    return (
+                        <button
+                            key={option.code}
+                            type="button"
+                            onClick={() => onToggle(category, option)}
+                            className={
+                                selected
+                                    ? preferenceSectionStyles.selectedChip
+                                    : preferenceSectionStyles.chip
+                            }
+                        >
+                            {option.name}
+                        </button>
+                    );
+                })}
+            </div>
         </section>
     );
 }

--- a/src/features/preference/ui/config/preferenceOptions.ts
+++ b/src/features/preference/ui/config/preferenceOptions.ts
@@ -21,7 +21,7 @@ export const requiredPreferenceGroups: readonly PreferenceOptionGroup[] = [
     {
         category: "MEAL_SITUATION",
         title: "시간/상황",
-        options: ["아침", "점심", "저녁", "야식", "주말", "더운 날", "비 오는 날"],
+        options: ["아침", "점심", "저녁", "야식"],
     },
 ];
 

--- a/src/features/preference/ui/config/preferenceOptions.ts
+++ b/src/features/preference/ui/config/preferenceOptions.ts
@@ -1,44 +1,95 @@
 import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
+import type { PreferenceOption } from "@/features/preference/domain/model/UserPreference";
 
 export interface PreferenceOptionGroup {
     readonly category: PreferenceCategory;
     readonly title: string;
     readonly description?: string;
-    readonly options: readonly string[];
+    readonly options: readonly PreferenceOption[];
 }
 
-export const requiredPreferenceGroups: readonly PreferenceOptionGroup[] = [
+export interface PreferenceGroupMeta {
+    readonly category: PreferenceCategory;
+    readonly title: string;
+    readonly description?: string;
+}
+
+export const requiredPreferenceGroupMeta: readonly PreferenceGroupMeta[] = [
     {
         category: "FLAVOR",
         title: "맛",
-        options: ["매콤", "달콤", "짭짤", "고소", "상큼", "진한/묵직한"],
     },
     {
         category: "COOKING_METHOD",
         title: "조리 방식",
-        options: ["국물/탕", "구이", "튀김", "볶음", "찜", "생식/샐러드", "면/비빔"],
     },
     {
         category: "MEAL_SITUATION",
         title: "시간/상황",
-        options: ["아침", "점심", "저녁", "야식"],
     },
 ];
 
-export const optionalPreferenceGroups: readonly PreferenceOptionGroup[] = [
+export const optionalPreferenceGroupMeta: readonly PreferenceGroupMeta[] = [
     {
         category: "FOOD_CATEGORY",
         title: "음식 종류",
-        options: ["한식", "중식", "일식", "양식", "분식", "패스트푸드", "아시안"],
     },
     {
         category: "TEXTURE",
         title: "식감",
-        options: ["바삭", "쫄깃", "아삭", "부드러움"],
     },
     {
         category: "TEMPERATURE",
         title: "온도",
-        options: ["뜨거움", "차가움"],
     },
 ];
+
+// TODO: 서버에 MEAL_SITUATION 추가되면 없애기
+const mealSituationOptions: readonly PreferenceOption[] = [
+    {
+        id: -1,
+        categoryType: "MEAL_SITUATION",
+        code: "BREAKFAST",
+        name: "아침",
+    },
+    {
+        id: -2,
+        categoryType: "MEAL_SITUATION",
+        code: "LUNCH",
+        name: "점심",
+    },
+    {
+        id: -3,
+        categoryType: "MEAL_SITUATION",
+        code: "DINNER",
+        name: "저녁",
+    },
+    {
+        id: -4,
+        categoryType: "MEAL_SITUATION",
+        code: "LATE_NIGHT",
+        name: "야식",
+    },
+];
+
+function getOptionsByCategory(
+    options: readonly PreferenceOption[],
+    category: PreferenceCategory,
+): readonly PreferenceOption[] {
+    // TODO: 서버에 MEAL_SITUATION 추가되면 없애기
+    if (category === "MEAL_SITUATION") {
+        return mealSituationOptions;
+    }
+
+    return options.filter((option) => option.categoryType === category);
+}
+
+export function createPreferenceGroups(
+    metaList: readonly PreferenceGroupMeta[],
+    options: readonly PreferenceOption[],
+): readonly PreferenceOptionGroup[] {
+    return metaList.map((meta) => ({
+        ...meta,
+        options: getOptionsByCategory(options, meta.category),
+    }));
+}

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -20,7 +20,7 @@ const MENUS = [
   { href: "/home", label: "홈", icon: Home, enabled: true },
   { href: "/personal", label: "개인 메뉴 추천", icon: User, enabled: false },
   { href: "/group", label: "그룹 메뉴 추천", icon: Users, enabled: false },
-  { href: "/preference", label: "취향 관리", icon: UtensilsCrossed, enabled: false },
+  { href: "/preference", label: "취향 관리", icon: UtensilsCrossed, enabled: true },
   { href: "/location", label: "위치 설정", icon: MapPin, enabled: false },
   { href: "/settings", label: "설정", icon: Settings, enabled: true },
 ];

--- a/src/ui/styles/dislikedFoodSearchStyles.ts
+++ b/src/ui/styles/dislikedFoodSearchStyles.ts
@@ -10,6 +10,8 @@ export const dislikedFoodSearchStyles = {
   resultList:
     "absolute left-0 top-11 z-10 flex w-full flex-col overflow-hidden rounded-md border border-zinc-200 bg-white shadow-md",
   resultItem: "px-3 py-2 text-left text-sm text-zinc-700 hover:bg-zinc-100",
+  resultMessage: "px-3 py-2 text-sm text-zinc-500",
+  errorMessage: "px-3 py-2 text-sm text-red-500",
   selectedList: "flex flex-wrap gap-2 pt-1",
   selectedTag:
     "flex items-center gap-2 rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700",


### PR DESCRIPTION
## 관련 이슈
Closes #60
Closes #61
Closes #62
Closes #63
Closes #64
Closes #72
Closes #73

## 요약
- 취향 조회 API 연동
- 취향 선택 옵션 참조 데이터 API 연동
- 알레르기/비선호 음식 검색 API 연동
- 취향 저장 API 연동
- 필수 선택 검증 로직 구현
- 취향 변경 여부 감지 및 불필요한 저장 요청 방지

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
