### PR TITLE
[Refactor] 회원가입 닉네임 검증 로직 공통 훅 적용 (#75)

### DIFF
--- a/src/app/signup/nickname/page.tsx
+++ b/src/app/signup/nickname/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import { useAtomValue } from "jotai";
 
 import { nicknamePageStyles } from "@/ui/styles/nicknamePageStyles";
@@ -11,255 +11,161 @@ import { authApi } from "@/features/auth/infrastructure/api/authApi";
 
 import { onboardingAtom } from "@/features/auth/application/selectors/authSelectors";
 import { useSubmitMyNickname } from "@/features/auth/application/hooks/useSubmitMyNickname";
-
-type NicknameStatus =
-  | "idle"
-  | "invalid"
-  | "checking"
-  | "duplicate"
-  | "available";
+import { useNicknameValidation } from "@/features/nickname/application/hooks/useNicknameValidation";
 
 export default function NicknamePage() {
-  const router = useRouter();
-  const onboarding = useAtomValue(onboardingAtom);
+    const router = useRouter();
+    const onboarding = useAtomValue(onboardingAtom);
 
-  const { submit: submitMyNickname, isSubmitting } = useSubmitMyNickname();
-  const isSocialOnboarding = onboarding?.nextStep === "REQUIRED_NICKNAME";
+    const { submit: submitMyNickname, isSubmitting } = useSubmitMyNickname();
+    const isSocialOnboarding = onboarding?.nextStep === "REQUIRED_NICKNAME";
 
-  // 닉네임
-  const [nickname, setNickname] = useState("");
-  const [nicknameStatus, setNicknameStatus] = useState<NicknameStatus>("idle");
+    const {
+        nickname,
+        status: nicknameStatus,
+        message: nicknameMessage,
+        canSaveNickname,
+        handleNicknameChange,
+        validateNickname,
+    } = useNicknameValidation();
 
-  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+    const canSubmit = canSaveNickname && !isSubmitting;
 
-  // 가입 버튼 활성화: 닉네임 사용 가능 + 제출 중 아님
-  const canSubmit = nicknameStatus === "available" && !isSubmitting;
+    useEffect(() => {
+        const account = accountStorage.load();
+        const savedAgreements = termsStorage.load();
 
-  // 일반 회원가입 데이터 로딩
-  useEffect(() => {
-    const account = accountStorage.load();
-    const savedAgreements = termsStorage.load();
+        const isGeneralSignup =
+            !!account && !!savedAgreements && savedAgreements.length > 0;
 
-    const isGeneralSignup =
-      !!account && !!savedAgreements && savedAgreements.length > 0;
+        if (isGeneralSignup) return;
 
-    // 1. 일반 회원가입 흐름
-    if (isGeneralSignup) return;
+        if (onboarding?.nextStep === "REQUIRED_NICKNAME") return;
 
-    // 2. 소셜 온보딩: 닉네임 단계
-    if (onboarding?.nextStep === "REQUIRED_NICKNAME") return;
-
-    // 3. 소셜 온보딩: 약관 단계로 돌아가야 하는 상태
-    if (onboarding?.nextStep === "REQUIRED_AGREEMENTS") {
-      router.replace("/terms");
-      return;
-    }
-
-    // 4. 소셜 온보딩 완료 상태
-    if (onboarding?.nextStep === "READY") {
-      router.replace("/home");
-      return;
-    }
-
-    // 5. onboarding이 아직 null이면 auth 초기화/상태 반영 대기
-    if (onboarding === null) {
-      return;
-    }
-
-    // 6. 여기까지 왔으면 일반 회원가입 데이터도 없고 온보딩 상태도 맞지 않는 비정상 접근
-    router.replace("/signup");
-
-  }, [router, onboarding]);
-
-   // 닉네임 입력 시 즉시 유효성 검사
-  const handleChangeNickname = (value: string) => {
-    setNickname(value);
-
-    const trimmed = value.trim();
-
-    // 이전 타이머 제거
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-    }
-
-    // 빈 값
-    if (value.length === 0) {
-      setNicknameStatus("idle");
-      return;
-    }
-
-    // 최대 100자 && 공백만 있는 값 방지
-    if (trimmed.length === 0 || trimmed.length > 100) {
-      setNicknameStatus("invalid");
-      return;
-    }
-
-    // 유효성 통과 → 중복확인 시작 준비
-    setNicknameStatus("checking");
-  };
-
-   // 닉네임 중복 검사
-  useEffect(() => {
-    const trimmed = nickname.trim();
-
-    if (!trimmed) return;
-    if (trimmed.length > 100) return;
-    if (nicknameStatus !== "checking") return;
-
-    debounceRef.current = setTimeout(async () => {
-      try {
-        const response = await authApi.checkNicknameExists(trimmed);
-        console.log("닉네임 확인:", response.data);
-
-        if (response.data.exists) {
-          setNicknameStatus("duplicate");
-          return;
+        if (onboarding?.nextStep === "REQUIRED_AGREEMENTS") {
+            router.replace("/terms");
+            return;
         }
 
-        setNicknameStatus("available");
-      } catch (error) {
-        console.error("닉네임 확인 실패:", error);
-        setNicknameStatus("invalid");
-      }
-    }, 500);
+        if (onboarding?.nextStep === "READY") {
+            router.replace("/home");
+            return;
+        }
 
-    return () => {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-    };
-  }, [nickname, nicknameStatus]);
+        if (onboarding === null) {
+            return;
+        }
 
-  const handleSubmit = async () => {
-    if (!canSubmit) return;
-
-    try {
-      // 소셜 온보딩
-      if (isSocialOnboarding) {
-        await submitMyNickname(nickname.trim());
-        return;
-      }
-
-      const account = accountStorage.load();
-      const savedAgreements = termsStorage.load();
-
-      if (!account || !savedAgreements || savedAgreements.length === 0) {
         router.replace("/signup");
-        return;
-      }
+    }, [router, onboarding]);
 
-      // 일반 회원가입
-      const payload = {
-        loginId: account.id,
-        password: account.password,
-        nickname: nickname.trim(),
-        agreements: savedAgreements
-          .filter((item) => item.agreed)
-          .map((item) => ({
-            agreementType: item.agreementType,
-            agreementVersion: item.agreementVersion,
-          })),
-      };
+    const handleSubmit = async () => {
+        if (!canSubmit) return;
 
-      console.log("회원가입 요청:", payload);
+        try {
+            if (isSocialOnboarding) {
+                await submitMyNickname(nickname.trim());
+                return;
+            }
 
-      const response = await authApi.signup(payload);
+            const account = accountStorage.load();
+            const savedAgreements = termsStorage.load();
 
-      if (response.success) {
-        accountStorage.clear();
-        termsStorage.clear();
+            if (!account || !savedAgreements || savedAgreements.length === 0) {
+                router.replace("/signup");
+                return;
+            }
 
-        router.push("/");
-        return;
-      }
+            const payload = {
+                loginId: account.id,
+                password: account.password,
+                nickname: nickname.trim(),
+                agreements: savedAgreements
+                    .filter((item) => item.agreed)
+                    .map((item) => ({
+                        agreementType: item.agreementType,
+                        agreementVersion: item.agreementVersion,
+                    })),
+            };
 
-      router.push("/login");
-    } catch (error) {
-      console.error("회원가입 실패:", error);
-      router.push("/login");
-    }
-  };
+            const response = await authApi.signup(payload);
 
-  const getMessage = () => {
-    switch (nicknameStatus) {
-      case "invalid":
-        return "닉네임은 공백만 입력할 수 없고 최대 100자까지 가능합니다.";
-      case "checking":
-        return "확인 중...";
-      case "duplicate":
-        return "이미 사용 중인 닉네임입니다.";
-      case "available":
-        return "사용 가능한 닉네임입니다.";
-      default:
-        return "";
-    }
-  };
+            if (response.success) {
+                accountStorage.clear();
+                termsStorage.clear();
 
-  const getMessageColor = () => {
-    switch (nicknameStatus) {
-      case "available":
-        return "text-blue-500";
-      case "duplicate":
-      case "invalid":
-        return "text-red-500";
-      case "checking":
-        return "text-gray-400";
-      default:
-        return "";
-    }
-  };
+                router.push("/");
+                return;
+            }
 
-  return (
-    <div className={nicknamePageStyles.container}>
-      <div className={nicknamePageStyles.card}>
+            router.push("/login");
+        } catch (error) {
+            console.error("회원가입 실패:", error);
+            router.push("/login");
+        }
+    };
 
-        {/* 타이틀 영역 */}
-        <div className="flex flex-col gap-1 w-full">
-          <h1 className={nicknamePageStyles.title}>닉네임 설정</h1>
+    const getMessageColor = () => {
+        switch (nicknameStatus) {
+            case "AVAILABLE":
+                return "text-blue-500";
+            case "DUPLICATED":
+            case "INVALID":
+            case "ERROR":
+                return "text-red-500";
+            case "CHECKING":
+                return "text-gray-400";
+            default:
+                return "";
+        }
+    };
+
+    return (
+        <div className={nicknamePageStyles.container}>
+            <div className={nicknamePageStyles.card}>
+                <div className="flex flex-col gap-1 w-full">
+                    <h1 className={nicknamePageStyles.title}>닉네임 설정</h1>
+                </div>
+
+                <div className={nicknamePageStyles.formGroup}>
+                    <div className={nicknamePageStyles.inputGroup}>
+                        <label className={nicknamePageStyles.label}>닉네임</label>
+
+                        <input
+                            type="text"
+                            className={nicknamePageStyles.input}
+                            value={nickname}
+                            onChange={(e) => {
+                                const nextNickname = e.target.value;
+                                handleNicknameChange(nextNickname);
+                                validateNickname(nextNickname);
+                            }}
+                            placeholder="닉네임을 입력하세요"
+                        />
+
+                        {nicknameMessage && (
+                            <p className={`mt-2 text-sm ${getMessageColor()}`}>
+                                {nicknameMessage}
+                            </p>
+                        )}
+                    </div>
+
+                    <div className="flex justify-end">
+                        <button
+                            type="button"
+                            onClick={handleSubmit}
+                            disabled={!canSubmit}
+                            className={
+                                canSubmit
+                                    ? nicknamePageStyles.button
+                                    : `${nicknamePageStyles.button} opacity-50 cursor-not-allowed`
+                            }
+                        >
+                            가입
+                        </button>
+                    </div>
+                </div>
+            </div>
         </div>
-
-        {/* 입력 폼 */}
-        <div className={nicknamePageStyles.formGroup}>
-
-          {/* 닉네임 */}
-          <div className={nicknamePageStyles.inputGroup}>
-            <label className={nicknamePageStyles.label}>닉네임</label>
-            <input
-              type="text"
-              className={nicknamePageStyles.input}
-              value={nickname}
-              onChange={(e) =>
-                handleChangeNickname(e.target.value)
-              }
-              placeholder="닉네임을 입력하세요"
-            />
-
-            {getMessage() && (
-              <p
-                className={`mt-2 text-sm ${getMessageColor()}`}
-              >
-                {getMessage()}
-              </p>
-            )}
-          </div>
-
-          {/* 가입 버튼 */}
-          <div className="flex justify-end">
-            <button
-              type="button"
-              onClick={handleSubmit}
-              disabled={!canSubmit}
-              className={
-                canSubmit
-                  ? nicknamePageStyles.button
-                  : `${nicknamePageStyles.button} opacity-50 cursor-not-allowed`
-              }
-            >
-              가입
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+    );
 }

--- a/src/features/nickname/application/hooks/useNicknameValidation.ts
+++ b/src/features/nickname/application/hooks/useNicknameValidation.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { existsNickname } from "@/features/nickname/infrastructure/api/nicknameApi";
 
 type NicknameValidationStatus =
@@ -26,46 +26,67 @@ export function useNicknameValidation({
         );
     const [message, setMessage] = useState("");
 
+    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (debounceRef.current) {
+                clearTimeout(debounceRef.current);
+            }
+        };
+    }, []);
+
     const validateNickname = useCallback(
-        async (nextNickname: string) => {
+         (nextNickname: string) => {
             const trimmedNickname = nextNickname.trim();
 
+            // debounce 이전 타이머 제거
+            if (debounceRef.current) {
+                clearTimeout(debounceRef.current);
+            }
+
+            // 초기값과 동일
             if (initialNickname && trimmedNickname === initialNickname) {
                 setStatus("UNCHANGED");
                 setMessage("");
                 return;
             }
 
+            // 공백만 입력
             if (trimmedNickname.length === 0) {
                 setStatus("INVALID");
                 setMessage("닉네임은 공백만 입력할 수 없습니다.");
                 return;
             }
 
+            // 길이 초과
             if (trimmedNickname.length > 100) {
                 setStatus("INVALID");
                 setMessage("닉네임은 최대 100자까지 입력할 수 있습니다.");
                 return;
             }
 
+            // 유효성 통과 → debounce 후 API 호출
             setStatus("CHECKING");
             setMessage("닉네임 중복을 확인하는 중입니다.");
 
-            try {
-                const exists = await existsNickname(trimmedNickname);
+            debounceRef.current = setTimeout(async () => {
+                try {
+                    const exists = await existsNickname(trimmedNickname);
 
-                if (exists) {
-                    setStatus("DUPLICATED");
-                    setMessage("이미 사용 중인 닉네임입니다.");
-                    return;
+                    if (exists) {
+                        setStatus("DUPLICATED");
+                        setMessage("이미 사용 중인 닉네임입니다.");
+                        return;
+                    }
+
+                    setStatus("AVAILABLE");
+                    setMessage("사용 가능한 닉네임입니다.");
+                } catch {
+                    setStatus("ERROR");
+                    setMessage("닉네임 중복 확인에 실패했습니다.");
                 }
-
-                setStatus("AVAILABLE");
-                setMessage("사용 가능한 닉네임입니다.");
-            } catch {
-                setStatus("ERROR");
-                setMessage("닉네임 중복 확인에 실패했습니다.");
-            }
+            }, 500);
         },
         [initialNickname],
     );


### PR DESCRIPTION
## 관련 이슈
Closes #75 

## 요약
- 무엇을 변경했나요?
회원가입 닉네임 검증 로직을 공통 훅(useNicknameValidation)으로 통합 
페이지 내 중복된 유효성 검사 및 API 호출 로직을 제거 
debounce를 적용하여 닉네임 입력 시 API 호출 횟수를 줄이도록 개선

- 왜 이 변경이 필요한가요?
기존에는 닉네임 입력 시마다 API가 호출되어 불필요한 요청이 발생하고 UX가 저하될 수 있었으며, 
동일한 검증 로직이 여러 곳에 중복되어 유지보수가 어려웠음. 
이를 공통 훅으로 분리하고 debounce를 적용하여 코드 재사용성과 성능, 사용자 경험을 개선하기 위해 변경

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
