### PR TITLE
[Refactor] 일반 회원가입 입력 검증 로직 분리  (#76)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -39,7 +39,8 @@ export default function LoginPage() {
   }, [isAuthLoading, isAuthenticated, router]);
 
   const handleSignupClick = () => {
-    alert("준비 중인 기능입니다.");
+//     alert("준비 중인 기능입니다.");
+    router.replace("/signup");
   };
 
   if (isAuthLoading) {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { signupPageStyles } from "@/ui/styles/signupPageStyles";
@@ -8,250 +7,140 @@ import type { AuthProvider } from "@/features/auth/domain/model/AuthProvider";
 import SocialLoginButton from "@/features/auth/ui/components/SocialLoginButton";
 
 import { accountStorage } from "@/features/auth/infrastructure/storage/accountStorage";
-import { authApi } from "@/features/auth/infrastructure/api/authApi";
+import { useLoginIdValidation } from "@/features/signup/application/hooks/useLoginIdValidation";
+import { usePasswordValidation } from "@/features/signup/application/hooks/usePasswordValidation";
 
 const providers: AuthProvider[] = ["GOOGLE", "KAKAO", "NAVER"];
 
-// 영문/숫자/._- 허용, 1~50자
-const ID_REGEX = /^[A-Za-z0-9._-]{1,50}$/;
-
-// 비밀번호 조건: 8자 이상 100자 이하
-const PASSWORD_MIN = 8;
-const PASSWORD_MAX = 100;
-
-type IdStatus = "idle" | "invalid" | "checking" | "duplicate" | "available";
-
 export default function SignupPage() {
-  const router = useRouter();
+    const router = useRouter();
 
-  const [id, setId] = useState("");
-  const [password, setPassword] = useState("");
+    const {
+        loginId,
+        message: loginIdMessage,
+        canUseLoginId,
+        handleLoginIdChange,
+    } = useLoginIdValidation();
 
-  const [idStatus, setIdStatus] = useState<IdStatus>("idle");
-  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+    const {
+        password,
+        isPasswordValid,
+        message: passwordMessage,
+        handlePasswordChange,
+    } = usePasswordValidation();
 
-  /**
-   * 아이디 입력 처리
-   * - 즉시 형식 검증
-   * - 서버 호출은 하지 않음
-   */
-  const handleChangeId = (value: string) => {
-    setId(value);
+    const canSubmit = canUseLoginId && isPasswordValid;
 
-    const loginId = value.trim();
+    const handleSubmit = () => {
+        if (!canSubmit) return;
 
-    // 이전 타이머 제거
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-    }
+        accountStorage.save({
+            id: loginId.trim(),
+            password: password.trim(),
+            isSocial: false,
+        });
 
-    if (!loginId) {
-      setIdStatus("idle");
-      return;
-    }
-
-    // 프론트 1차 형식검사
-    if (!ID_REGEX.test(loginId)) {
-      setIdStatus("invalid");
-      return;
-    }
-
-    // 형식 통과 → 중복확인 대기 상태
-    setIdStatus("checking");
-  };
-
-  // 아이디 자동 중복 확인
-  useEffect(() => {
-    const loginId = id.trim();
-
-    if (!loginId) return;
-    if (!ID_REGEX.test(loginId)) return;
-    if (idStatus !== "checking") return;
-
-    debounceRef.current = setTimeout(async () => {
-      try {
-        const response = await authApi.checkLoginIdExists(loginId);
-        console.log("아이디 조회:", response);
-
-        /**
-         * success = true
-         * exists = true  => 중복
-         * exists = false => 사용 가능
-         */
-        if (response.data.exists) {
-          setIdStatus("duplicate");
-          return;
-        }
-
-        setIdStatus("available");
-      } catch (error: unknown) {
-        console.error("아이디 중복 확인 실패:", error);
-
-        const apiError = error as {
-          status?: number;
-          code?: string;
-        };
-
-        if (
-          apiError.status === 400 &&
-          apiError.code === "COMMON_INVALID_PATH_VARIABLE"
-        ) {
-          setIdStatus("invalid");
-          return;
-        }
-
-        setIdStatus("invalid");
-      }
-    }, 500);
-
-    return () => {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
+        router.push("/terms");
     };
-  }, [id, idStatus]);
 
-  // 비밀번호 유효성
-  const isPasswordValid =
-    password.length >= PASSWORD_MIN &&
-    password.length <= PASSWORD_MAX;
+    const getLoginIdMessageColor = () => {
+        if (!loginIdMessage) return "";
 
-   // 계속 버튼 활성화 조건
-  const canSubmit =
-    idStatus === "available" &&
-    isPasswordValid;
+        if (canUseLoginId) {
+            return "text-blue-500";
+        }
 
-  const handleSubmit = () => {
-    if (!canSubmit) return;
+         if (loginIdMessage === "확인 중...") {
+            return "text-gray-400";
+         }
 
-    accountStorage.save({
-      id: id.trim(),
-      password: password.trim(),
-      isSocial: false,
-    });
-
-    router.push("/terms");
-  };
-
-  const getIdMessage = () => {
-    switch (idStatus) {
-      case "invalid":
-        return "영문, 숫자, ., _, - 만 사용 가능하며 1~50자여야 합니다.";
-      case "checking":
-        return "확인 중...";
-      case "duplicate":
-        return "이미 사용 중인 ID입니다.";
-      case "available":
-        return "사용 가능한 ID입니다.";
-      default:
-        return "";
-    }
-  };
-
-  const getIdMessageColor = () => {
-    switch (idStatus) {
-      case "available":
-        return "text-blue-500";
-      case "duplicate":
-      case "invalid":
         return "text-red-500";
-      case "checking":
-        return "text-gray-400";
-      default:
-        return "";
-    }
-  };
+    };
 
-  const getPasswordMessage = () => {
-    if (!password) return "";
-    if (isPasswordValid) return "";
-    return "비밀번호는 8자 이상 100자 이하로 입력해주세요.";
-  };
+    return (
+        <div className={signupPageStyles.container}>
+            {/* 로고 */}
+            <div className="absolute top-20 flex items-center gap-2 text-2xl font-semibold text-black">
+                <span>Matchuri</span>
+            </div>
 
-  return (
-    <div className={signupPageStyles.container}>
-      {/* 로고 */}
-      <div className="absolute top-20 flex items-center gap-2 text-2xl font-semibold text-black">
-        <span>Matchuri</span>
-      </div>
+            <div className={signupPageStyles.card}>
+                {/* 제목 */}
+                <div className="flex flex-col gap-1 w-full">
+                    <h1 className={signupPageStyles.title}>계정 만들기</h1>
+                </div>
 
-      <div className={signupPageStyles.card}>
-        {/* 제목 */}
-        <div className="flex flex-col gap-1 w-full">
-          <h1 className={signupPageStyles.title}>계정 만들기</h1>
-        </div>
+                {/* 소셜 로그인 */}
+                <div className={signupPageStyles.socialGroup}>
+                    {providers.map((provider) => (
+                        <SocialLoginButton key={provider} provider={provider} />
+                    ))}
+                </div>
 
-        {/* 소셜 로그인 */}
-        <div className={signupPageStyles.socialGroup}>
-          {providers.map((provider) => (
-            <SocialLoginButton key={provider} provider={provider} />
-          ))}
-        </div>
+                {/* divider */}
+                <div className={signupPageStyles.divider}>
+                    <div className={signupPageStyles.dividerLine}></div>
+                        <span>또는</span>
+                    <div className={signupPageStyles.dividerLine}></div>
+                </div>
 
-        {/* divider */}
-        <div className={signupPageStyles.divider}>
-          <div className={signupPageStyles.dividerLine}></div>
-          <span>또는</span>
-          <div className={signupPageStyles.dividerLine}></div>
-        </div>
+                {/* 입력 영역 */}
+                <div className={signupPageStyles.formGroup}>
+                    {/* 아이디 */}
+                    <div className={signupPageStyles.inputGroup}>
+                        <label className={signupPageStyles.label}>아이디</label>
 
-        {/* 입력 영역 */}
-        <div className={signupPageStyles.formGroup}>
-          {/* 아이디 */}
-          <div className={signupPageStyles.inputGroup}>
-            <label className={signupPageStyles.label}>아이디</label>
+                        <input
+                            type="text"
+                            className={signupPageStyles.input}
+                            value={loginId}
+                            onChange={(e) => handleLoginIdChange(e.target.value)}
+                            placeholder="아이디를 입력하세요"
+                        />
 
-            <input
-              type="text"
-              className={signupPageStyles.input}
-              value={id}
-              onChange={(e) => handleChangeId(e.target.value)}
-              placeholder="아이디를 입력하세요"
-            />
+                        {loginIdMessage && (
+                            <p className={`mt-2 text-sm ${getLoginIdMessageColor()}`}>
+                                {loginIdMessage}
+                            </p>
+                        )}
+                    </div>
 
-            {getIdMessage() && (
-              <p className={`mt-2 text-sm ${getIdMessageColor()}`}>
-                {getIdMessage()}
-              </p>
-            )}
-          </div>
+                    {/* 비밀번호 */}
+                    <div className={signupPageStyles.inputGroup}>
+                        <label className={signupPageStyles.label}>비밀번호</label>
 
-          {/* 비밀번호 */}
-          <div className={signupPageStyles.inputGroup}>
-            <label className={signupPageStyles.label}>비밀번호</label>
+                        <input
+                            type="password"
+                            className={signupPageStyles.input}
+                            value={password}
+                            onChange={(e) => handlePasswordChange(e.target.value)}
+                            placeholder="비밀번호를 입력하세요"
+                        />
 
-            <input
-              type="password"
-              className={signupPageStyles.input}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="비밀번호를 입력하세요"
-            />
+                        {passwordMessage && (
+                            <p className="mt-2 text-sm text-red-500">
+                                {passwordMessage}
+                            </p>
+                        )}
+                    </div>
 
-            {getPasswordMessage() && (
-              <p className="mt-2 text-sm text-red-500">
-                {getPasswordMessage()}
-              </p>
-            )}
-          </div>
-
-          {/* 버튼 */}
-          <div className="flex justify-end">
-            <button
-              type="button"
-              onClick={handleSubmit}
-              disabled={!canSubmit}
-              className={
-                canSubmit
-                  ? signupPageStyles.nextButton
-                  : `${signupPageStyles.nextButton} opacity-50 cursor-not-allowed`
-              }
-            >
-              계속
-            </button>
+                    {/* 계속 버튼 */}
+                    <div className="flex justify-end">
+                        <button
+                            type="button"
+                            onClick={handleSubmit}
+                            disabled={!canSubmit}
+                            className={
+                                canSubmit
+                                    ? signupPageStyles.nextButton
+                                    : `${signupPageStyles.nextButton} opacity-50 cursor-not-allowed`
+                            }
+                        >
+                        계속
+                        </button>
+                    </div>
+                </div>
           </div>
         </div>
-      </div>
-    </div>
-  );
+    );
 }

--- a/src/features/signup/application/hooks/useLoginIdValidation.ts
+++ b/src/features/signup/application/hooks/useLoginIdValidation.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { existsLoginId } from "@/features/signup/infrastructure/api/signupApi";
+
+type LoginIdValidationStatus =
+    | "IDLE"
+    | "CHECKING"
+    | "AVAILABLE"
+    | "DUPLICATED"
+    | "INVALID"
+    | "ERROR";
+
+const LOGIN_ID_REGEX = /^[A-Za-z0-9._-]{1,50}$/;
+
+export function useLoginIdValidation() {
+    const [loginId, setLoginId] = useState("");
+    const [status, setStatus] = useState<LoginIdValidationStatus>("IDLE");
+    const [message, setMessage] = useState("");
+
+    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (debounceRef.current) {
+                clearTimeout(debounceRef.current);
+            }
+        };
+    }, []);
+
+    const validateLoginId = useCallback((nextLoginId: string) => {
+        const trimmedLoginId = nextLoginId.trim();
+
+        if (debounceRef.current) {
+            clearTimeout(debounceRef.current);
+        }
+
+        if (!trimmedLoginId) {
+            setStatus("IDLE");
+            setMessage("");
+            return;
+        }
+
+        if (!LOGIN_ID_REGEX.test(trimmedLoginId)) {
+            setStatus("INVALID");
+            setMessage("영문, 숫자, ., _, - 만 사용 가능하며 1~50자여야 합니다.");
+            return;
+        }
+
+        setStatus("CHECKING");
+        setMessage("확인 중...");
+
+        debounceRef.current = setTimeout(async () => {
+            try {
+                const exists = await existsLoginId(trimmedLoginId);
+
+                if (exists) {
+                    setStatus("DUPLICATED");
+                    setMessage("이미 사용 중인 ID입니다.");
+                    return;
+                }
+
+                setStatus("AVAILABLE");
+                setMessage("사용 가능한 ID입니다.");
+            } catch {
+                setStatus("ERROR");
+                setMessage("아이디 중복 확인에 실패했습니다.");
+            }
+        }, 500);
+    }, []);
+
+    const handleLoginIdChange = (nextLoginId: string) => {
+        setLoginId(nextLoginId);
+        validateLoginId(nextLoginId);
+    };
+
+    const canUseLoginId = status === "AVAILABLE";
+
+    return {
+        loginId,
+        status,
+        message,
+        canUseLoginId,
+        handleLoginIdChange,
+        validateLoginId,
+    };
+}

--- a/src/features/signup/application/hooks/usePasswordValidation.ts
+++ b/src/features/signup/application/hooks/usePasswordValidation.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState } from "react";
+
+const PASSWORD_MIN = 8;
+const PASSWORD_MAX = 100;
+
+export function usePasswordValidation() {
+    const [password, setPassword] = useState("");
+
+    const isPasswordValid =
+        password.length >= PASSWORD_MIN && password.length <= PASSWORD_MAX;
+
+    const message =
+        password && !isPasswordValid
+            ? "비밀번호는 8자 이상 100자 이하로 입력해주세요."
+            : "";
+
+    const handlePasswordChange = (nextPassword: string) => {
+        setPassword(nextPassword);
+    };
+
+    return {
+        password,
+        isPasswordValid,
+        message,
+        handlePasswordChange,
+    };
+}

--- a/src/features/signup/infrastructure/api/signupApi.ts
+++ b/src/features/signup/infrastructure/api/signupApi.ts
@@ -1,0 +1,34 @@
+import { httpClient } from "@/infrastructure/http/httpClient";
+
+interface ApiError {
+    readonly status: number;
+    readonly code: string;
+    readonly message: string;
+}
+
+interface LoginIdExistsData {
+    readonly loginId: string;
+    readonly exists: boolean;
+}
+
+interface LoginIdExistsResponse {
+    readonly success: boolean;
+    readonly data: LoginIdExistsData;
+    readonly error: ApiError | null;
+}
+
+export async function existsLoginId(loginId: string): Promise<boolean> {
+    const encodedLoginId = encodeURIComponent(loginId);
+
+    const response = await httpClient.get<LoginIdExistsResponse>(
+        `/api/v1/members/exists/${encodedLoginId}`,
+    );
+
+    if (!response.success) {
+        throw new Error(
+            response.error?.message || "아이디 중복 확인에 실패했습니다.",
+        );
+    }
+
+    return response.data.exists;
+}


### PR DESCRIPTION
## 관련 이슈
Closes #76 

## 요약
- 무엇을 변경했나요?
일반 회원가입 화면(signup/page.tsx)에 포함되어 있던 아이디 중복 확인, 아이디 형식 검사, 비밀번호 유효성 검사 로직을 각각 useLoginIdValidation, usePasswordValidation 훅으로 분리 
아이디 중복 확인 API도 signupApi로 분리 
페이지에서는 검증 결과만 사용하도록 구조를 단순화

- 왜 이 변경이 필요한가요?
기존에는 검증 로직과 API 호출이 페이지에 직접 포함되어 있어 코드가 복잡하고 재사용이 어려웠음
검증 로직을 분리함으로써 관심사를 명확히 하고, 코드 재사용성과 유지보수성을 높이며, 입력 검증 흐름을 일관되게 관리하기 위해 변경

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
