### PR TITLE
[Refactor] 인증 및 회원가입 API 책임 분리 (#81)

### DIFF
--- a/src/app/signup/nickname/page.tsx
+++ b/src/app/signup/nickname/page.tsx
@@ -7,7 +7,7 @@ import { useAtomValue } from "jotai";
 import { nicknamePageStyles } from "@/ui/styles/nicknamePageStyles";
 import { accountStorage } from "@/features/auth/infrastructure/storage/accountStorage";
 import { termsStorage } from "@/features/terms/infrastructure/storage/termsStorage";
-import { authApi } from "@/features/auth/infrastructure/api/authApi";
+import { signupApi } from "@/features/signup/infrastructure/api/signupApi"
 
 import { onboardingAtom } from "@/features/auth/application/selectors/authSelectors";
 import { useSubmitMyNickname } from "@/features/auth/application/hooks/useSubmitMyNickname";
@@ -88,7 +88,7 @@ export default function NicknamePage() {
                     })),
             };
 
-            const response = await authApi.signup(payload);
+            const response = await signupApi.signup(payload);
 
             if (response.success) {
                 accountStorage.clear();

--- a/src/features/auth/application/hooks/useSubmitMyNickname.ts
+++ b/src/features/auth/application/hooks/useSubmitMyNickname.ts
@@ -3,10 +3,8 @@
 import { useCallback, useState } from "react";
 import { useRouter } from "next/navigation";
 
-import { authApi } from "@/features/auth/infrastructure/api/authApi";
-import {
-    updateOnboarding,
-} from "@/features/auth/application/store/authStore";
+import { onboardingApi } from "@/features/auth/infrastructure/api/onboardingApi";
+import { updateOnboarding } from "@/features/auth/application/store/authStore";
 import { getOnboardingRoute } from "@/features/auth/application/onboarding/getOnboardingRoute";
 
 export function useSubmitMyNickname() {
@@ -20,7 +18,7 @@ export function useSubmitMyNickname() {
             setIsSubmitting(true);
 
             try {
-                const response = await authApi.updateOnboardingNickname({
+                const response = await onboardingApi.updateOnboardingNickname({
                     nickname,
                 });
 

--- a/src/features/auth/application/hooks/useSubmitRequiredAgreements.ts
+++ b/src/features/auth/application/hooks/useSubmitRequiredAgreements.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { useRouter } from "next/navigation";
-import { authApi } from "@/features/auth/infrastructure/api/authApi";
+import { onboardingApi } from "@/features/auth/infrastructure/api/onboardingApi";
 import {
     setAuthenticated,
     updateOnboarding,
@@ -25,7 +25,7 @@ export function useSubmitRequiredAgreements() {
             setIsSubmitting(true);
 
             try {
-                const response = await authApi.submitRequiredAgreements({ agreements });
+                const response = await onboardingApi.submitRequiredAgreements({ agreements });
 
                 if (response.data.accessToken) {
                     setAuthenticated(response.data.accessToken, response.data.onboarding);

--- a/src/features/auth/infrastructure/api/authApi.ts
+++ b/src/features/auth/infrastructure/api/authApi.ts
@@ -5,53 +5,6 @@ import type { RefreshResponse } from "@/features/auth/infrastructure/api/dto/Ref
 import type { LogoutResponse } from "@/features/auth/infrastructure/api/dto/LogoutResponse";
 import type { LoginRequest } from "@/features/auth/domain/model/LoginRequest";
 import type { LoginResponse } from "@/features/auth/infrastructure/api/dto/LoginResponse";
-import type { SubmitAgreementsResponse } from "@/features/auth/infrastructure/api/dto/SubmitAgreementsResponse";
-import type { UpdateNicknameResponse } from "@/features/auth/infrastructure/api/dto/UpdateNicknameResponse";
-
-interface LoginIdExistsResponse {
-    success: boolean;
-    data: {
-        loginId: string;
-        exists: boolean;
-    };
-    error: null;
-}
-
-interface SubmitAgreementsRequest {
-    agreements: {
-        agreementType: string;
-        agreementVersion: string;
-    }[];
-}
-
-interface UpdateNicknameRequest {
-    nickname: string;
-}
-
-interface NickNameExistsResponse {
-    success: boolean;
-    data: {
-        nickname: string;
-        exists: boolean;
-    };
-    error: null;
-}
-
-interface SignupRequest {
-    loginId: string;
-    password: string;
-    nickname: string;
-    agreements: {
-        agreementType: string;
-        agreementVersion: string;
-    }[];
-}
-
-interface SignupResponse {
-    success: boolean;
-    data: null;
-    error: null;
-}
 
 export const authApi = {
     exchangeCode(provider: AuthProvider, code: string) {
@@ -74,38 +27,5 @@ export const authApi = {
 
     login(payload: LoginRequest) {
         return httpClient.post<LoginResponse>("/api/v1/auth/login", payload);
-    },
-
-    checkLoginIdExists(loginId: string) {
-        return httpClient.get<LoginIdExistsResponse>(
-            `/api/v1/members/exists/${loginId}`,
-        );
-    },
-
-    checkNicknameExists(nickname: string) {
-        return httpClient.get<NickNameExistsResponse>(
-            `/api/v1/members/exists/nickname/${nickname}`,
-        );
-    },
-
-    signup(payload: SignupRequest) {
-        return httpClient.post<SignupResponse>(
-            "/api/v1/members/signup",
-            payload,
-        );
-    },
-
-    submitRequiredAgreements(payload: SubmitAgreementsRequest) {
-        return httpClient.post<SubmitAgreementsResponse>(
-            "/api/v1/member-agreements/consents",
-            payload,
-        );
-    },
-
-    updateOnboardingNickname(payload: UpdateNicknameRequest) {
-        return httpClient.patch<UpdateNicknameResponse>(
-            "/api/v1/members/me",
-            payload,
-        );
     },
 } as const;

--- a/src/features/auth/infrastructure/api/onboardingApi.ts
+++ b/src/features/auth/infrastructure/api/onboardingApi.ts
@@ -1,0 +1,30 @@
+import { httpClient } from "@/infrastructure/http/httpClient";
+import type { SubmitAgreementsResponse } from "@/features/auth/infrastructure/api/dto/SubmitAgreementsResponse";
+import type { UpdateNicknameResponse } from "@/features/auth/infrastructure/api/dto/UpdateNicknameResponse";
+
+interface SubmitAgreementsRequest {
+    agreements: {
+        agreementType: string;
+        agreementVersion: string;
+    }[];
+}
+
+interface UpdateNicknameRequest {
+    nickname: string;
+}
+
+export const onboardingApi = {
+    submitRequiredAgreements(payload: SubmitAgreementsRequest) {
+        return httpClient.post<SubmitAgreementsResponse>(
+            "/api/v1/member-agreements/consents",
+            payload,
+        );
+    },
+
+    updateOnboardingNickname(payload: UpdateNicknameRequest) {
+        return httpClient.patch<UpdateNicknameResponse>(
+            "/api/v1/members/me",
+            payload,
+        );
+    },
+} as const;

--- a/src/features/signup/application/hooks/useLoginIdValidation.ts
+++ b/src/features/signup/application/hooks/useLoginIdValidation.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { existsLoginId } from "@/features/signup/infrastructure/api/signupApi";
+import { signupApi } from "@/features/signup/infrastructure/api/signupApi";
 
 type LoginIdValidationStatus =
     | "IDLE"
@@ -35,10 +35,17 @@ export function useLoginIdValidation() {
             clearTimeout(debounceRef.current);
         }
 
-        if (!trimmedLoginId) {
+        if (!nextLoginId) {
             setStatus("IDLE");
             setMessage("");
             return;
+        }
+
+        // 공백 체크
+        if (/\s/.test(nextLoginId)) {
+          setStatus("INVALID");
+          setMessage("공백을 사용할 수 없습니다.");
+          return;
         }
 
         if (!LOGIN_ID_REGEX.test(trimmedLoginId)) {
@@ -52,9 +59,10 @@ export function useLoginIdValidation() {
 
         debounceRef.current = setTimeout(async () => {
             try {
-                const exists = await existsLoginId(trimmedLoginId);
+                const response = await signupApi.checkLoginIdExists(trimmedLoginId);
+                console.log("아이디 뭐 들어와?:", response);
 
-                if (exists) {
+                if (response.data.exists) {
                     setStatus("DUPLICATED");
                     setMessage("이미 사용 중인 ID입니다.");
                     return;

--- a/src/features/signup/infrastructure/api/signupApi.ts
+++ b/src/features/signup/infrastructure/api/signupApi.ts
@@ -17,18 +17,35 @@ interface LoginIdExistsResponse {
     readonly error: ApiError | null;
 }
 
-export async function existsLoginId(loginId: string): Promise<boolean> {
-    const encodedLoginId = encodeURIComponent(loginId);
-
-    const response = await httpClient.get<LoginIdExistsResponse>(
-        `/api/v1/members/exists/${encodedLoginId}`,
-    );
-
-    if (!response.success) {
-        throw new Error(
-            response.error?.message || "아이디 중복 확인에 실패했습니다.",
-        );
-    }
-
-    return response.data.exists;
+interface SignupRequest {
+    readonly loginId: string;
+    readonly password: string;
+    readonly nickname: string;
+    readonly agreements: {
+        readonly agreementType: string;
+        readonly agreementVersion: string;
+    }[];
 }
+
+interface SignupResponse {
+    readonly success: boolean;
+    readonly data: null;
+    readonly error: ApiError | null;
+}
+
+export const signupApi = {
+    checkLoginIdExists(loginId: string) {
+        const encodedLoginId = encodeURIComponent(loginId);
+
+        return httpClient.get<LoginIdExistsResponse>(
+            `/api/v1/members/exists/${encodedLoginId}`,
+        );
+    },
+
+    signup(payload: SignupRequest) {
+        return httpClient.post<SignupResponse>(
+            "/api/v1/members/signup",
+            payload,
+        );
+    },
+} as const;


### PR DESCRIPTION
## 관련 이슈
Closes #81 

## 요약
- 무엇을 변경했나요?
인증 및 회원가입 관련 API를 역할에 따라 분리
기존 authApi에 포함되어 있던 회원가입, 닉네임 검증, 소셜 온보딩 관련 API를 각각 signupApi, nicknameApi, onboardingApi로 분리 authApi는 로그인/토큰/OAuth 인증 관련 API만 담당하도록 정리

- 왜 이 변경이 필요한가요?
기존 authApi는 다양한 책임이 혼재되어 있어 파일 규모가 커지고 유지보수가 어려운 구조
API를 기능 단위로 분리함으로써 책임을 명확히 하고, 코드 가독성과 확장성을 개선하기 위해 변경

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
