### PR TITLE
[Refactor] 취향 카테고리에서 MEAL_SITUATION 제거 (#84)

### DIFF
--- a/src/features/preference/application/utils/preferenceCompare.ts
+++ b/src/features/preference/application/utils/preferenceCompare.ts
@@ -8,7 +8,6 @@ import type { PreferenceCategory } from "@/features/preference/domain/model/Pref
 const preferenceCategories: readonly PreferenceCategory[] = [
     "FLAVOR",
     "COOKING_METHOD",
-    "MEAL_SITUATION",
     "FOOD_CATEGORY",
     "TEXTURE",
     "TEMPERATURE",

--- a/src/features/preference/domain/model/PreferenceCategory.ts
+++ b/src/features/preference/domain/model/PreferenceCategory.ts
@@ -1,7 +1,6 @@
 export type PreferenceCategory =
     | "FLAVOR"
     | "COOKING_METHOD"
-    | "MEAL_SITUATION"
     | "FOOD_CATEGORY"
     | "TEXTURE"
     | "TEMPERATURE";

--- a/src/features/preference/infrastructure/api/mapper/preferenceProfileMapper.ts
+++ b/src/features/preference/infrastructure/api/mapper/preferenceProfileMapper.ts
@@ -9,7 +9,6 @@ import type { PreferenceProfileData } from "@/features/preference/infrastructure
 const preferenceCategories: readonly PreferenceCategory[] = [
     "FLAVOR",
     "COOKING_METHOD",
-    "MEAL_SITUATION",
     "FOOD_CATEGORY",
     "TEXTURE",
     "TEMPERATURE",
@@ -19,7 +18,6 @@ function createEmptySelections(): UserPreference["selections"] {
     return {
         FLAVOR: [],
         COOKING_METHOD: [],
-        MEAL_SITUATION: [],
         FOOD_CATEGORY: [],
         TEXTURE: [],
         TEMPERATURE: [],

--- a/src/features/preference/infrastructure/api/mapper/preferenceUpdateRequestMapper.ts
+++ b/src/features/preference/infrastructure/api/mapper/preferenceUpdateRequestMapper.ts
@@ -5,7 +5,6 @@ export function mapUserPreferenceToUpdateRequest(
     preference: UserPreference,
 ): PreferenceUpdateRequest {
     const attributeCategoryIds = Object.entries(preference.selections)
-        .filter(([category]) => category !== "MEAL_SITUATION")
         .flatMap(([, options]) => options.map((option) => option.id));
 
     const restrictionIngredientIds = preference.dislikedFoods

--- a/src/features/preference/ui/config/preferenceOptions.ts
+++ b/src/features/preference/ui/config/preferenceOptions.ts
@@ -23,10 +23,6 @@ export const requiredPreferenceGroupMeta: readonly PreferenceGroupMeta[] = [
         category: "COOKING_METHOD",
         title: "조리 방식",
     },
-    {
-        category: "MEAL_SITUATION",
-        title: "시간/상황",
-    },
 ];
 
 export const optionalPreferenceGroupMeta: readonly PreferenceGroupMeta[] = [
@@ -44,43 +40,10 @@ export const optionalPreferenceGroupMeta: readonly PreferenceGroupMeta[] = [
     },
 ];
 
-// TODO: 서버에 MEAL_SITUATION 추가되면 없애기
-const mealSituationOptions: readonly PreferenceOption[] = [
-    {
-        id: -1,
-        categoryType: "MEAL_SITUATION",
-        code: "BREAKFAST",
-        name: "아침",
-    },
-    {
-        id: -2,
-        categoryType: "MEAL_SITUATION",
-        code: "LUNCH",
-        name: "점심",
-    },
-    {
-        id: -3,
-        categoryType: "MEAL_SITUATION",
-        code: "DINNER",
-        name: "저녁",
-    },
-    {
-        id: -4,
-        categoryType: "MEAL_SITUATION",
-        code: "LATE_NIGHT",
-        name: "야식",
-    },
-];
-
 function getOptionsByCategory(
     options: readonly PreferenceOption[],
     category: PreferenceCategory,
 ): readonly PreferenceOption[] {
-    // TODO: 서버에 MEAL_SITUATION 추가되면 없애기
-    if (category === "MEAL_SITUATION") {
-        return mealSituationOptions;
-    }
-
     return options.filter((option) => option.categoryType === category);
 }
 


### PR DESCRIPTION
## 관련 이슈
Closes #84 

## 요약
- 무엇을 변경했나요?
취향 카테고리에서 시간/상황(MEAL_SITUATION) 관련 타입, 옵션 메타, UI 렌더링, 저장 요청 및 비교 로직을 제거

- 왜 이 변경이 필요한가요?
더 이상 사용하지 않는 카테고리를 제거하여 코드 복잡도를 낮추고, 취향 관리 로직을 단순화하기 위해 필요

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
