### PR TITLE
[Feat] 일반 회원가입 이메일 인증 API 연동 (#77)

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { signupPageStyles } from "@/ui/styles/signupPageStyles";
@@ -10,14 +9,12 @@ import SocialLoginButton from "@/features/auth/ui/components/SocialLoginButton";
 import { accountStorage } from "@/features/auth/infrastructure/storage/accountStorage";
 import { useLoginIdValidation } from "@/features/signup/application/hooks/useLoginIdValidation";
 import { usePasswordValidation } from "@/features/signup/application/hooks/usePasswordValidation";
+import { useEmailVerification } from "@/features/emailVerification/application/hooks/useEmailVerification";
 
 const providers: AuthProvider[] = ["GOOGLE", "KAKAO", "NAVER"];
 
 export default function SignupPage() {
     const router = useRouter();
-
-    const [email, setEmail] = useState("");
-    const [verificationCode, setVerificationCode] = useState("");
 
     const {
         loginId,
@@ -33,7 +30,22 @@ export default function SignupPage() {
         handlePasswordChange,
     } = usePasswordValidation();
 
-    const canSubmit = canUseLoginId && isPasswordValid;
+    const {
+        email,
+        code: verificationCode,
+        message: emailVerificationMessage,
+        isVerified: isEmailVerified,
+        canSendVerificationEmail,
+        canConfirmVerificationEmail,
+        handleEmailChange,
+        handleCodeChange,
+        sendVerificationEmail,
+        confirmVerificationEmail,
+    } = useEmailVerification({
+        purpose: "SIGNUP",
+    });
+
+    const canSubmit = canUseLoginId && isPasswordValid && isEmailVerified;
 
     const handleSubmit = () => {
         if (!canSubmit) return;
@@ -136,13 +148,19 @@ export default function SignupPage() {
                                 type="email"
                                 className={signupPageStyles.input}
                                 value={email}
-                                onChange={(e) => setEmail(e.target.value)}
+                                onChange={(e) => handleEmailChange(e.target.value)}
                                 placeholder="이메일을 입력하세요"
                             />
 
                             <button
                                 type="button"
-                                className={`${signupPageStyles.nextButton} whitespace-nowrap`}
+                                onClick={sendVerificationEmail}
+                                disabled={!canSendVerificationEmail || isEmailVerified}
+                                className={
+                                    canSendVerificationEmail && !isEmailVerified
+                                        ? `${signupPageStyles.nextButton} whitespace-nowrap`
+                                        : `${signupPageStyles.nextButton} whitespace-nowrap opacity-50 cursor-not-allowed`
+                                }
                             >
                                 인증
                             </button>
@@ -157,17 +175,34 @@ export default function SignupPage() {
                                 type="text"
                                 className={signupPageStyles.input}
                                 value={verificationCode}
-                                onChange={(e) => setVerificationCode(e.target.value)}
+                                onChange={(e) => handleCodeChange(e.target.value)}
                                 placeholder="인증 코드를 입력하세요"
+                                disabled={isEmailVerified}
                             />
 
                             <button
                                 type="button"
-                                className={`${signupPageStyles.nextButton} whitespace-nowrap`}
+                                onClick={confirmVerificationEmail}
+                                disabled={!canConfirmVerificationEmail || isEmailVerified}
+                                className={
+                                    canConfirmVerificationEmail && !isEmailVerified
+                                        ? `${signupPageStyles.nextButton} whitespace-nowrap`
+                                        : `${signupPageStyles.nextButton} whitespace-nowrap opacity-50 cursor-not-allowed`
+                                }
                             >
                                 확인
                             </button>
                         </div>
+
+                        {emailVerificationMessage && (
+                            <p
+                                className={`mt-2 text-sm ${
+                                    isEmailVerified ? "text-blue-500" : "text-gray-500"
+                                }`}
+                            >
+                                {emailVerificationMessage}
+                            </p>
+                        )}
                     </div>
 
                     {/* 계속 버튼 */}

--- a/src/features/emailVerification/application/hooks/useEmailVerification.ts
+++ b/src/features/emailVerification/application/hooks/useEmailVerification.ts
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { emailVerificationApi } from "@/features/emailVerification/infrastructure/api/emailVerificationApi";
+import type { EmailVerificationPurpose } from "@/features/emailVerification/domain/model/EmailVerificationPurpose";
+
+type EmailVerificationStatus =
+    | "IDLE"
+    | "SENDING"
+    | "SENT"
+    | "VERIFYING"
+    | "VERIFIED"
+    | "ERROR";
+
+interface UseEmailVerificationParams {
+    purpose: EmailVerificationPurpose;
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const VERIFICATION_CODE_REGEX = /^\d{6}$/;
+
+export function useEmailVerification({
+    purpose,
+}: UseEmailVerificationParams) {
+    const [email, setEmail] = useState("");
+    const [code, setCode] = useState("");
+    const [status, setStatus] = useState<EmailVerificationStatus>("IDLE");
+    const [message, setMessage] = useState("");
+    const [emailVerificationToken, setEmailVerificationToken] =
+        useState<string | null>(null);
+    const [resendAvailableAfterSeconds, setResendAvailableAfterSeconds] =
+        useState<number | null>(null);
+
+    const validateEmail = (nextEmail: string) => {
+        const trimmedEmail = nextEmail.trim();
+
+        if (!trimmedEmail) {
+            setStatus("ERROR");
+            setMessage("이메일을 입력해주세요.");
+            return null;
+        }
+
+        if (!EMAIL_REGEX.test(trimmedEmail)) {
+            setStatus("ERROR");
+            setMessage("올바른 이메일 형식을 입력하세요.");
+            return null;
+        }
+
+        return trimmedEmail;
+    };
+
+    const sendVerificationEmail = async () => {
+        const trimmedEmail = validateEmail(email);
+
+        if (!trimmedEmail) return;
+
+        setStatus("SENDING");
+        setMessage("인증 코드를 발송하는 중입니다.");
+
+        try {
+            const response = await emailVerificationApi.sendVerificationEmail({
+                email: trimmedEmail,
+                purpose,
+            });
+
+            if (!response.success) {
+                setStatus("ERROR");
+                setMessage(response.error?.message || "인증 코드 발송에 실패했습니다.");
+                return;
+            }
+
+            setStatus("SENT");
+            setMessage("인증 코드가 발송되었습니다.");
+            setResendAvailableAfterSeconds(
+                response.data.resendAvailableAfterSeconds,
+            );
+        } catch {
+            setStatus("ERROR");
+            setMessage("인증 코드 발송에 실패했습니다.");
+        }
+    };
+
+    const confirmVerificationEmail = async () => {
+        const trimmedEmail = validateEmail(email);
+        const trimmedCode = code.trim();
+
+        if (!trimmedEmail) return;
+
+        if (!VERIFICATION_CODE_REGEX.test(trimmedCode)) {
+            setStatus("ERROR");
+            setMessage("인증 코드는 6자리 숫자여야 합니다.");
+            return;
+        }
+
+        setStatus("VERIFYING");
+        setMessage("인증 코드를 확인하는 중입니다.");
+
+        try {
+            const response = await emailVerificationApi.confirmVerificationEmail({
+                email: trimmedEmail,
+                purpose,
+                code: trimmedCode,
+            });
+
+            if (!response.success || !response.data.verified) {
+                setStatus("ERROR");
+                setMessage(response.error?.message || "이메일 인증에 실패했습니다.");
+                return;
+            }
+
+            setStatus("VERIFIED");
+            setMessage("이메일 인증이 완료되었습니다.");
+            setEmailVerificationToken(response.data.emailVerificationToken);
+        } catch {
+            setStatus("ERROR");
+            setMessage("이메일 인증에 실패했습니다.");
+        }
+    };
+
+    const handleEmailChange = (nextEmail: string) => {
+        setEmail(nextEmail);
+        setCode("");
+        setStatus("IDLE");
+        setMessage("");
+        setEmailVerificationToken(null);
+        setResendAvailableAfterSeconds(null);
+    };
+
+    const handleCodeChange = (nextCode: string) => {
+        setCode(nextCode);
+    };
+
+    const canSendVerificationEmail =
+        email.trim().length > 0 && status !== "SENDING";
+
+    const canConfirmVerificationEmail =
+        code.trim().length === 6 && status !== "VERIFYING";
+
+    const isVerified = status === "VERIFIED" && !!emailVerificationToken;
+
+    return {
+        email,
+        code,
+        status,
+        message,
+        emailVerificationToken,
+        resendAvailableAfterSeconds,
+        canSendVerificationEmail,
+        canConfirmVerificationEmail,
+        isVerified,
+        handleEmailChange,
+        handleCodeChange,
+        sendVerificationEmail,
+        confirmVerificationEmail,
+    };
+}

--- a/src/features/emailVerification/domain/model/EmailVerificationPurpose.ts
+++ b/src/features/emailVerification/domain/model/EmailVerificationPurpose.ts
@@ -1,0 +1,4 @@
+export type EmailVerificationPurpose =
+    | "SIGNUP"
+    | "FIND_LOGIN_ID"
+    | "RESET_PASSWORD";

--- a/src/features/emailVerification/infrastructure/api/dto/ConfirmEmailVerificationRequest.ts
+++ b/src/features/emailVerification/infrastructure/api/dto/ConfirmEmailVerificationRequest.ts
@@ -1,0 +1,8 @@
+import type { EmailVerificationPurpose } from "@/features/emailVerification/domain/model/EmailVerificationPurpose";
+
+export interface ConfirmEmailVerificationRequest {
+    readonly email: string;
+    readonly purpose: EmailVerificationPurpose;
+    readonly code: string;
+    readonly loginId?: string;
+}

--- a/src/features/emailVerification/infrastructure/api/dto/ConfirmEmailVerificationResponse.ts
+++ b/src/features/emailVerification/infrastructure/api/dto/ConfirmEmailVerificationResponse.ts
@@ -1,0 +1,24 @@
+interface ApiErrorDetail {
+    readonly source: string;
+    readonly field: string;
+    readonly reason: string;
+}
+
+interface ApiError {
+    readonly status: number;
+    readonly code: string;
+    readonly message: string;
+    readonly details?: ApiErrorDetail[];
+}
+
+interface ConfirmEmailVerificationData {
+    readonly verified: boolean;
+    readonly emailVerificationToken: string;
+    readonly expiresIn: number;
+}
+
+export interface ConfirmEmailVerificationResponse {
+    readonly success: boolean;
+    readonly data: ConfirmEmailVerificationData;
+    readonly error: ApiError | null;
+}

--- a/src/features/emailVerification/infrastructure/api/dto/SendEmailVerificationRequest.ts
+++ b/src/features/emailVerification/infrastructure/api/dto/SendEmailVerificationRequest.ts
@@ -1,0 +1,7 @@
+import type { EmailVerificationPurpose } from "@/features/emailVerification/domain/model/EmailVerificationPurpose";
+
+export interface SendEmailVerificationRequest {
+    readonly email: string;
+    readonly purpose: EmailVerificationPurpose;
+    readonly loginId?: string;
+}

--- a/src/features/emailVerification/infrastructure/api/dto/SendEmailVerificationResponse.ts
+++ b/src/features/emailVerification/infrastructure/api/dto/SendEmailVerificationResponse.ts
@@ -1,0 +1,23 @@
+interface ApiErrorDetail {
+    readonly source: string;
+    readonly field: string;
+    readonly reason: string;
+}
+
+interface ApiError {
+    readonly status: number;
+    readonly code: string;
+    readonly message: string;
+    readonly details?: ApiErrorDetail[];
+}
+
+interface SendEmailVerificationData {
+    readonly accepted: boolean;
+    readonly resendAvailableAfterSeconds: number;
+}
+
+export interface SendEmailVerificationResponse {
+    readonly success: boolean;
+    readonly data: SendEmailVerificationData;
+    readonly error: ApiError | null;
+}

--- a/src/features/emailVerification/infrastructure/api/emailVerificationApi.ts
+++ b/src/features/emailVerification/infrastructure/api/emailVerificationApi.ts
@@ -1,0 +1,22 @@
+import { httpClient } from "@/infrastructure/http/httpClient";
+
+import type { SendEmailVerificationRequest } from "@/features/emailVerification/infrastructure/api/dto/SendEmailVerificationRequest";
+import type { SendEmailVerificationResponse } from "@/features/emailVerification/infrastructure/api/dto/SendEmailVerificationResponse";
+import type { ConfirmEmailVerificationRequest } from "@/features/emailVerification/infrastructure/api/dto/ConfirmEmailVerificationRequest";
+import type { ConfirmEmailVerificationResponse } from "@/features/emailVerification/infrastructure/api/dto/ConfirmEmailVerificationResponse";
+
+export const emailVerificationApi = {
+    sendVerificationEmail(payload: SendEmailVerificationRequest) {
+        return httpClient.post<SendEmailVerificationResponse>(
+            "/api/v1/auth/email",
+            payload,
+        );
+    },
+
+    confirmVerificationEmail(payload: ConfirmEmailVerificationRequest) {
+        return httpClient.post<ConfirmEmailVerificationResponse>(
+            "/api/v1/auth/email/confirm",
+            payload,
+        );
+    },
+} as const;


### PR DESCRIPTION
## 관련 이슈
Closes #77 

## 요약
일반 회원가입 화면에서 이메일 인증 코드 발송 및 인증 코드 확인 API 연동

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
