### PR TITLE
[Feat] 일반 회원가입 이메일 인증 완료 후 회원가입 플로우 적용 (#78)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,119 +10,118 @@ import SocialLoginButton from "@/features/auth/ui/components/SocialLoginButton";
 import type { AuthProvider } from "@/features/auth/domain/model/AuthProvider";
 import { useLogin } from "@/features/auth/application/hooks/useLogin";
 import {
-  isAuthenticatedAtom,
-  isAuthLoadingAtom,
+    isAuthenticatedAtom,
+    isAuthLoadingAtom,
 } from "@/features/auth/application/selectors/authSelectors";
 
 const providers: AuthProvider[] = ["GOOGLE", "KAKAO", "NAVER"];
 
 export default function LoginPage() {
-  const router = useRouter();
-  const isAuthenticated = useAtomValue(isAuthenticatedAtom);
-  const isAuthLoading = useAtomValue(isAuthLoadingAtom);
+    const router = useRouter();
+    const isAuthenticated = useAtomValue(isAuthenticatedAtom);
+    const isAuthLoading = useAtomValue(isAuthLoadingAtom);
 
-  const {
-    loginId,
-    setLoginId,
-    password,
-    setPassword,
-    errorMessage,
-    isSubmitting,
-    isValid,
-    submit,
-  } = useLogin();
+    const {
+        loginId,
+        setLoginId,
+        password,
+        setPassword,
+        errorMessage,
+        isSubmitting,
+        isValid,
+        submit,
+    } = useLogin();
 
-  useEffect(() => {
-    if (!isAuthLoading && isAuthenticated) {
-      router.replace("/home");
+    useEffect(() => {
+        if (!isAuthLoading && isAuthenticated) {
+            router.replace("/home");
+        }
+    }, [isAuthLoading, isAuthenticated, router]);
+
+    const handleSignupClick = () => {
+        router.replace("/signup");
+    };
+
+    if (isAuthLoading) {
+        return (
+            <div className="flex h-screen items-center justify-center">
+                <p>인증 상태 확인 중...</p>
+            </div>
+        );
     }
-  }, [isAuthLoading, isAuthenticated, router]);
 
-  const handleSignupClick = () => {
-    alert("준비 중인 기능입니다.");
-//     router.replace("/signup");
-  };
-
-  if (isAuthLoading) {
     return (
-      <div className="flex h-screen items-center justify-center">
-        <p>인증 상태 확인 중...</p>
-      </div>
+        <div className={loginPageStyles.container}>
+            <div className={loginPageStyles.card}>
+                <div className="flex w-full flex-col gap-1">
+                    <h1 className={loginPageStyles.title}>로그인</h1>
+                </div>
+
+                <div className={loginPageStyles.formGroup}>
+                    <div className={loginPageStyles.inputGroup}>
+                        <label className={loginPageStyles.label}>아이디</label>
+                        <input
+                            type="text"
+                            value={loginId}
+                            onChange={(e) => setLoginId(e.target.value)}
+                            className={loginPageStyles.input}
+                        />
+                    </div>
+
+                    <div className={loginPageStyles.inputGroup}>
+                        <label className={loginPageStyles.label}>비밀번호</label>
+                        <input
+                            type="password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            className={loginPageStyles.input}
+                        />
+                    </div>
+
+                    {errorMessage && (
+                        <p className="text-sm text-red-500">{errorMessage}</p>
+                    )}
+
+                    <button
+                        type="button"
+                        onClick={submit}
+                        disabled={!isValid || isSubmitting}
+                        className={loginPageStyles.loginButton}
+                    >
+                        {isSubmitting ? "로그인 중..." : "로그인"}
+                    </button>
+                </div>
+
+                <div className={loginPageStyles.divider}>
+                    <div className={loginPageStyles.dividerLine} />
+                    <span>또는</span>
+                    <div className={loginPageStyles.dividerLine} />
+                </div>
+
+                <div className={loginPageStyles.buttonGroup}>
+                    {providers.map((provider) => (
+                        <SocialLoginButton key={provider} provider={provider} />
+                    ))}
+                </div>
+
+                <div className={loginPageStyles.helperLinks}>
+                    <Link href="/" className={loginPageStyles.helperLink}>
+                        아이디 찾기
+                    </Link>
+                    <span className={loginPageStyles.separator}>|</span>
+                    <Link href="/" className={loginPageStyles.helperLink}>
+                        비밀번호 찾기
+                    </Link>
+                    <span className={loginPageStyles.separator}>|</span>
+                    <button
+                        type="button"
+                        onClick={handleSignupClick}
+                        className={loginPageStyles.signupLink}
+                    >
+                        회원가입
+                    </button>
+                </div>
+            </div>
+        </div>
     );
-  }
-
-  return (
-    <div className={loginPageStyles.container}>
-      <div className={loginPageStyles.card}>
-        <div className="flex w-full flex-col gap-1">
-          <h1 className={loginPageStyles.title}>로그인</h1>
-        </div>
-
-        <div className={loginPageStyles.formGroup}>
-          <div className={loginPageStyles.inputGroup}>
-            <label className={loginPageStyles.label}>아이디</label>
-            <input
-              type="text"
-              value={loginId}
-              onChange={(e) => setLoginId(e.target.value)}
-              className={loginPageStyles.input}
-            />
-          </div>
-
-          <div className={loginPageStyles.inputGroup}>
-            <label className={loginPageStyles.label}>비밀번호</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className={loginPageStyles.input}
-            />
-          </div>
-
-          {errorMessage && (
-            <p className="text-sm text-red-500">{errorMessage}</p>
-          )}
-
-          <button
-            type="button"
-            onClick={submit}
-            disabled={!isValid || isSubmitting}
-            className={loginPageStyles.loginButton}
-          >
-            {isSubmitting ? "로그인 중..." : "로그인"}
-          </button>
-        </div>
-
-        <div className={loginPageStyles.divider}>
-          <div className={loginPageStyles.dividerLine} />
-          <span>또는</span>
-          <div className={loginPageStyles.dividerLine} />
-        </div>
-
-        <div className={loginPageStyles.buttonGroup}>
-          {providers.map((provider) => (
-            <SocialLoginButton key={provider} provider={provider} />
-          ))}
-        </div>
-
-        <div className={loginPageStyles.helperLinks}>
-          <Link href="/" className={loginPageStyles.helperLink}>
-            아이디 찾기
-          </Link>
-          <span className={loginPageStyles.separator}>|</span>
-          <Link href="/" className={loginPageStyles.helperLink}>
-            비밀번호 찾기
-          </Link>
-          <span className={loginPageStyles.separator}>|</span>
-          <button
-            type="button"
-            onClick={handleSignupClick}
-            className={loginPageStyles.signupLink}
-          >
-            회원가입
-          </button>
-        </div>
-      </div>
-    </div>
-  );
 }

--- a/src/app/signup/nickname/page.tsx
+++ b/src/app/signup/nickname/page.tsx
@@ -5,7 +5,7 @@ import { useEffect } from "react";
 import { useAtomValue } from "jotai";
 
 import { nicknamePageStyles } from "@/ui/styles/nicknamePageStyles";
-import { accountStorage } from "@/features/auth/infrastructure/storage/accountStorage";
+import { accountStorage } from "@/features/signup/infrastructure/storage/accountStorage";
 import { termsStorage } from "@/features/terms/infrastructure/storage/termsStorage";
 import { signupApi } from "@/features/signup/infrastructure/api/signupApi"
 
@@ -36,7 +36,11 @@ export default function NicknamePage() {
         const savedAgreements = termsStorage.load();
 
         const isGeneralSignup =
-            !!account && !!savedAgreements && savedAgreements.length > 0;
+            !!account &&
+            !!account.email &&
+            !!account.emailVerificationToken &&
+            !!savedAgreements &&
+            savedAgreements.length > 0;
 
         if (isGeneralSignup) return;
 
@@ -80,6 +84,8 @@ export default function NicknamePage() {
                 loginId: account.id,
                 password: account.password,
                 nickname: nickname.trim(),
+                email: account.email,
+                emailVerificationToken: account.emailVerificationToken,
                 agreements: savedAgreements
                     .filter((item) => item.agreed)
                     .map((item) => ({

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -6,7 +6,7 @@ import { signupPageStyles } from "@/ui/styles/signupPageStyles";
 import type { AuthProvider } from "@/features/auth/domain/model/AuthProvider";
 import SocialLoginButton from "@/features/auth/ui/components/SocialLoginButton";
 
-import { accountStorage } from "@/features/auth/infrastructure/storage/accountStorage";
+import { accountStorage } from "@/features/signup/infrastructure/storage/accountStorage";
 import { useLoginIdValidation } from "@/features/signup/application/hooks/useLoginIdValidation";
 import { usePasswordValidation } from "@/features/signup/application/hooks/usePasswordValidation";
 import { useEmailVerification } from "@/features/emailVerification/application/hooks/useEmailVerification";
@@ -34,6 +34,7 @@ export default function SignupPage() {
         email,
         code: verificationCode,
         message: emailVerificationMessage,
+        emailVerificationToken,
         isVerified: isEmailVerified,
         canSendVerificationEmail,
         canConfirmVerificationEmail,
@@ -45,7 +46,11 @@ export default function SignupPage() {
         purpose: "SIGNUP",
     });
 
-    const canSubmit = canUseLoginId && isPasswordValid && isEmailVerified;
+    const canSubmit =
+        canUseLoginId &&
+        isPasswordValid &&
+        isEmailVerified &&
+        !!emailVerificationToken;
 
     const handleSubmit = () => {
         if (!canSubmit) return;
@@ -53,6 +58,8 @@ export default function SignupPage() {
         accountStorage.save({
             id: loginId.trim(),
             password: password.trim(),
+            email: email.trim(),
+            emailVerificationToken,
             isSocial: false,
         });
 

--- a/src/features/signup/infrastructure/api/signupApi.ts
+++ b/src/features/signup/infrastructure/api/signupApi.ts
@@ -21,15 +21,25 @@ interface SignupRequest {
     readonly loginId: string;
     readonly password: string;
     readonly nickname: string;
+    readonly email: string;
+    readonly emailVerificationToken: string;
     readonly agreements: {
         readonly agreementType: string;
         readonly agreementVersion: string;
     }[];
 }
 
+interface SignupData {
+    readonly memberId: number;
+    readonly loginId: string;
+    readonly email: string;
+    readonly nickname: string;
+    readonly createdAt: string;
+}
+
 interface SignupResponse {
     readonly success: boolean;
-    readonly data: null;
+    readonly data: SignupData;
     readonly error: ApiError | null;
 }
 

--- a/src/features/signup/infrastructure/storage/accountStorage.ts
+++ b/src/features/signup/infrastructure/storage/accountStorage.ts
@@ -3,6 +3,8 @@ const KEY = "signup_account";
 export interface AccountData {
     id: string;
     password: string;
+    email: string;
+    emailVerificationToken: string;
     isSocial?: boolean;
 }
 


### PR DESCRIPTION
## 관련 이슈
Closes #78 

## 요약
일반 회원가입에서 이메일 인증이 완료된 사용자만 약관 동의 단계로 이동할 수 있도록 플로우를 변경

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
