### PR TITLE
[Feat] 일반 회원가입 이메일 인증 유효시간 표시 (#91)

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -33,10 +33,19 @@ export default function SignupPage() {
     const {
         email,
         code: verificationCode,
+        status: emailVerificationStatus,
         message: emailVerificationMessage,
         emailVerificationToken,
+        remainingSeconds,
+        resendSeconds,
+        confirmAttemptCount,
+        maxConfirmAttempts,
+        resendAttemptCount,
+        maxResendAttempts,
+        hasSentVerificationEmail,
         isVerified: isEmailVerified,
         canSendVerificationEmail,
+        canResendVerificationEmail,
         canConfirmVerificationEmail,
         handleEmailChange,
         handleCodeChange,
@@ -78,6 +87,29 @@ export default function SignupPage() {
          }
 
         return "text-red-500";
+    };
+
+    const getEmailVerificationMessageColor = () => {
+        switch (emailVerificationStatus) {
+            case "VERIFIED":
+                return "text-blue-500";
+            case "ERROR":
+            case "EXPIRED":
+                return "text-red-500";
+            case "SENDING":
+            case "VERIFYING":
+            case "SENT":
+                return "text-gray-500";
+            default:
+                return "";
+        }
+    };
+
+    const formatSeconds = (seconds: number) => {
+        const minutes = Math.floor(seconds / 60);
+        const remaining = seconds % 60;
+
+        return `${minutes}:${remaining.toString().padStart(2, "0")}`;
     };
 
     return (
@@ -159,19 +191,50 @@ export default function SignupPage() {
                                 placeholder="이메일을 입력하세요"
                             />
 
-                            <button
-                                type="button"
-                                onClick={sendVerificationEmail}
-                                disabled={!canSendVerificationEmail || isEmailVerified}
-                                className={
-                                    canSendVerificationEmail && !isEmailVerified
-                                        ? `${signupPageStyles.nextButton} whitespace-nowrap`
-                                        : `${signupPageStyles.nextButton} whitespace-nowrap opacity-50 cursor-not-allowed`
-                                }
-                            >
-                                인증
-                            </button>
+                            {!hasSentVerificationEmail ? (
+                                <button
+                                    type="button"
+                                    onClick={sendVerificationEmail}
+                                    disabled={!canSendVerificationEmail || isEmailVerified}
+                                    className={
+                                        canSendVerificationEmail && !isEmailVerified
+                                            ? `${signupPageStyles.nextButton} whitespace-nowrap`
+                                            : `${signupPageStyles.nextButton} whitespace-nowrap opacity-50 cursor-not-allowed`
+                                    }
+                                >
+                                    인증
+                                </button>
+                            ) : (
+                                <button
+                                    type="button"
+                                    onClick={sendVerificationEmail}
+                                    disabled={isEmailVerified}
+                                    className={
+                                        canResendVerificationEmail && !isEmailVerified
+                                            ? `${signupPageStyles.nextButton} whitespace-nowrap`
+                                            : `${signupPageStyles.nextButton} whitespace-nowrap opacity-50 cursor-not-allowed`
+                                    }
+                                >
+                                    {isEmailVerified ? "완료" : "재발송"}
+                                </button>
+                            )}
                         </div>
+
+                        {hasSentVerificationEmail && !isEmailVerified && (
+                            <p className="mt-2 text-xs text-gray-400">
+                                인증 코드 발송 횟수 {resendAttemptCount}/{maxResendAttempts}
+                            </p>
+                        )}
+
+                        {hasSentVerificationEmail &&
+                            !isEmailVerified &&
+                            resendSeconds !== null &&
+                            resendSeconds > 0 && (
+                                <p className="mt-1 text-xs text-gray-400">
+                                    {resendSeconds}초 후 인증코드 재발송이 가능합니다.
+                                </p>
+                            )
+                        }
                     </div>
 
                     <div className={signupPageStyles.inputGroup}>
@@ -197,15 +260,25 @@ export default function SignupPage() {
                                         : `${signupPageStyles.nextButton} whitespace-nowrap opacity-50 cursor-not-allowed`
                                 }
                             >
-                                확인
+                                {isEmailVerified ? "완료" : "확인"}
                             </button>
                         </div>
 
+                        {remainingSeconds !== null && !isEmailVerified && (
+                            <p className="mt-2 text-sm text-gray-500">
+                                인증 유효시간 {formatSeconds(remainingSeconds)}
+                            </p>
+                        )}
+
+                        {!isEmailVerified && confirmAttemptCount > 0 && (
+                            <p className="mt-1 text-xs text-gray-400">
+                                인증 시도 횟수 {confirmAttemptCount}/{maxConfirmAttempts}
+                            </p>
+                        )}
+
                         {emailVerificationMessage && (
                             <p
-                                className={`mt-2 text-sm ${
-                                    isEmailVerified ? "text-blue-500" : "text-gray-500"
-                                }`}
+                                className={`mt-2 text-sm ${getEmailVerificationMessageColor()}`}
                             >
                                 {emailVerificationMessage}
                             </p>

--- a/src/features/emailVerification/application/hooks/useEmailVerification.ts
+++ b/src/features/emailVerification/application/hooks/useEmailVerification.ts
@@ -1,23 +1,21 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { emailVerificationApi } from "@/features/emailVerification/infrastructure/api/emailVerificationApi";
 import type { EmailVerificationPurpose } from "@/features/emailVerification/domain/model/EmailVerificationPurpose";
+import type { EmailVerificationStatus } from "@/features/emailVerification/domain/model/EmailVerificationStatus";
 
-type EmailVerificationStatus =
-    | "IDLE"
-    | "SENDING"
-    | "SENT"
-    | "VERIFYING"
-    | "VERIFIED"
-    | "ERROR";
+import { startTimer } from "@/features/emailVerification/application/utils/timer";
 
 interface UseEmailVerificationParams {
     purpose: EmailVerificationPurpose;
 }
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const VERIFICATION_CODE_REGEX = /^\d{6}$/;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // 이메일 형식 검증
+const VERIFICATION_CODE_REGEX = /^\d{6}$/; // 인증 코드 6자리
+const VERIFICATION_EXPIRE_SECONDS = 300; // 인증코드 유효시간: 5분
+const MAX_CONFIRM_ATTEMPTS = 5; // 이메일 인증 횟수 5회 제한
+const MAX_RESEND_ATTEMPTS = 5; // 재발송 횟수 상태
 
 export function useEmailVerification({
     purpose,
@@ -26,12 +24,107 @@ export function useEmailVerification({
     const [code, setCode] = useState("");
     const [status, setStatus] = useState<EmailVerificationStatus>("IDLE");
     const [message, setMessage] = useState("");
+
+    // 인증 성공 시 받은 토큰
     const [emailVerificationToken, setEmailVerificationToken] =
         useState<string | null>(null);
-    const [resendAvailableAfterSeconds, setResendAvailableAfterSeconds] =
+
+    // 인증 코드 유효시간 (5분)
+    const [remainingSeconds, setRemainingSeconds] =
         useState<number | null>(null);
 
-    const validateEmail = (nextEmail: string) => {
+    // 재발송 대기시간
+    const [resendSeconds, setResendSeconds] =
+        useState<number | null>(null);
+
+    const [confirmAttemptCount, setConfirmAttemptCount] = useState(0);
+
+    // 재발송 횟수 상태
+    const [resendAttemptCount, setResendAttemptCount] = useState(0);
+
+    // 실제 발송 성공 여부 상태
+    const [hasSentVerificationEmail, setHasSentVerificationEmail] = useState(false);
+
+    // 인증 코드 타이머 종료 함수 저장
+    const verificationTimerRef = useRef<(() => void) | null>(null);
+
+    // 재발송 타이머 종료 함수 저장
+    const resendTimerRef = useRef<(() => void) | null>(null);
+
+    // 인증코드 타이머
+    useEffect(() => {
+        if (remainingSeconds === null) return;
+        if (remainingSeconds <= 0) return;
+
+        // 기존 타이머 제거 (중복 방지)
+        if (verificationTimerRef.current) {
+            verificationTimerRef.current();
+        }
+
+        // 새로운 타이머 시작
+        verificationTimerRef.current = startTimer(() => {
+            setRemainingSeconds((prev) => {
+                if (prev === null) return null;
+
+                if (prev <= 1) {
+                    if (verificationTimerRef.current) {
+                        verificationTimerRef.current();
+                        verificationTimerRef.current = null;
+                    }
+
+                    setStatus("EXPIRED");
+                    setMessage("인증 코드가 만료되었습니다. 다시 발송해주세요.");
+
+                    return 0;
+                }
+
+                return prev - 1;
+            });
+        });
+
+        // cleanup
+        return () => {
+            if (verificationTimerRef.current) {
+                verificationTimerRef.current();
+            }
+        };
+    }, [remainingSeconds]);
+
+    // 이메일 재발송 타이머
+    useEffect(() => {
+        if (resendSeconds === null) return;
+        if (resendSeconds <= 0) return;
+
+        if (resendTimerRef.current) {
+            resendTimerRef.current();
+        }
+
+        resendTimerRef.current = startTimer(() => {
+            setResendSeconds((prev) => {
+                if (prev === null) return null;
+
+                if (prev <= 1) {
+                    if (resendTimerRef.current) {
+                        resendTimerRef.current();
+                        resendTimerRef.current = null;
+                    }
+
+                    return 0;
+                }
+
+                return prev - 1;
+            });
+        });
+
+        return () => {
+            if (resendTimerRef.current) {
+                resendTimerRef.current();
+            }
+        };
+    }, [resendSeconds]);
+
+    // 이메일 검증
+    const validateEmail = (nextEmail: string): string | null => {
         const trimmedEmail = nextEmail.trim();
 
         if (!trimmedEmail) {
@@ -49,19 +142,41 @@ export function useEmailVerification({
         return trimmedEmail;
     };
 
+    // 인증 코드 발송
     const sendVerificationEmail = async () => {
         const trimmedEmail = validateEmail(email);
-
         if (!trimmedEmail) return;
 
+        console.log("📧 전송할 이메일:", trimmedEmail);
+        console.log("resendSeconds:", resendSeconds);
+
+        // 재발송 대기 중이어도 버튼은 클릭 가능하지만 API 호출은 막고 alert 표시
+        if (resendSeconds && resendSeconds > 0) {
+            alert(`${resendSeconds}초 후 인증코드 재발송이 가능합니다.`);
+            return;
+        }
+
+        // 인증 코드 발송/재발송 총 5회 제한
+        if (resendAttemptCount >= MAX_RESEND_ATTEMPTS) {
+            setStatus("ERROR");
+            setMessage("인증 코드 발송 횟수를 초과했습니다.");
+            return;
+        }
+
         setStatus("SENDING");
-        setMessage("인증 코드를 발송하는 중입니다.");
+        setMessage(
+            hasSentVerificationEmail
+                ? "인증 코드를 재발송하는 중입니다."
+                : "인증 코드를 발송하는 중입니다.",
+        );
 
         try {
             const response = await emailVerificationApi.sendVerificationEmail({
                 email: trimmedEmail,
                 purpose,
             });
+
+            console.log("📥 email API 응답:", response);
 
             if (!response.success) {
                 setStatus("ERROR");
@@ -70,21 +185,47 @@ export function useEmailVerification({
             }
 
             setStatus("SENT");
-            setMessage("인증 코드가 발송되었습니다.");
-            setResendAvailableAfterSeconds(
-                response.data.resendAvailableAfterSeconds,
+            setMessage(
+                hasSentVerificationEmail
+                    ? "인증 코드가 재발송되었습니다."
+                    : "인증 코드가 발송되었습니다.",
             );
-        } catch {
+
+            setHasSentVerificationEmail(true);
+            setResendAttemptCount((prev) => prev + 1);
+
+            setEmailVerificationToken(null);
+            setCode(""); // 재발송 시 이전 코드 초기화
+            setConfirmAttemptCount(0);
+
+            // 타이머 시작
+            setRemainingSeconds(VERIFICATION_EXPIRE_SECONDS);
+            setResendSeconds(response.data.resendAvailableAfterSeconds);
+        } catch (error) {
+            console.error("📥 email API 요청 실패:", error);
             setStatus("ERROR");
             setMessage("인증 코드 발송에 실패했습니다.");
         }
     };
 
+    // 인증 코드 확인
     const confirmVerificationEmail = async () => {
         const trimmedEmail = validateEmail(email);
         const trimmedCode = code.trim();
 
         if (!trimmedEmail) return;
+
+        if (remainingSeconds === 0 || status === "EXPIRED") {
+            setStatus("EXPIRED");
+            setMessage("인증 코드가 만료되었습니다. 다시 발송해주세요.");
+            return;
+        }
+
+        if (confirmAttemptCount >= MAX_CONFIRM_ATTEMPTS) {
+            setStatus("ERROR");
+            setMessage("인증 시도 횟수를 초과했습니다. 인증 코드를 다시 발송해주세요.");
+            return;
+        }
 
         if (!VERIFICATION_CODE_REGEX.test(trimmedCode)) {
             setStatus("ERROR");
@@ -103,17 +244,43 @@ export function useEmailVerification({
             });
 
             if (!response.success || !response.data.verified) {
+                const nextCount = confirmAttemptCount + 1;
+                setConfirmAttemptCount(nextCount);
+
+                if (nextCount >= MAX_CONFIRM_ATTEMPTS) {
+                    setStatus("ERROR");
+                    setMessage("인증 시도 횟수를 초과했습니다. 인증 코드를 다시 발송해주세요.");
+                    return;
+                }
+
                 setStatus("ERROR");
-                setMessage(response.error?.message || "이메일 인증에 실패했습니다.");
+                setMessage(`이메일 인증에 실패했습니다. (${nextCount}/${MAX_CONFIRM_ATTEMPTS})`);
                 return;
             }
 
             setStatus("VERIFIED");
             setMessage("이메일 인증이 완료되었습니다.");
             setEmailVerificationToken(response.data.emailVerificationToken);
+
+            // 타이머 종료
+            if (verificationTimerRef.current) {
+                verificationTimerRef.current();
+                verificationTimerRef.current = null;
+            }
+
+            setRemainingSeconds(null);
         } catch {
+            const nextCount = confirmAttemptCount + 1;
+            setConfirmAttemptCount(nextCount);
+
+            if (nextCount >= MAX_CONFIRM_ATTEMPTS) {
+                setStatus("ERROR");
+                setMessage("인증 시도 횟수를 초과했습니다. 인증 코드를 다시 발송해주세요.");
+                return;
+            }
+
             setStatus("ERROR");
-            setMessage("이메일 인증에 실패했습니다.");
+            setMessage(`이메일 인증에 실패했습니다. (${nextCount}/${MAX_CONFIRM_ATTEMPTS})`);
         }
     };
 
@@ -123,18 +290,50 @@ export function useEmailVerification({
         setStatus("IDLE");
         setMessage("");
         setEmailVerificationToken(null);
-        setResendAvailableAfterSeconds(null);
+        setConfirmAttemptCount(0);
+        setResendAttemptCount(0);
+        setHasSentVerificationEmail(false);
+
+        if (verificationTimerRef.current) {
+            verificationTimerRef.current();
+            verificationTimerRef.current = null;
+        }
+
+        if (resendTimerRef.current) {
+            resendTimerRef.current();
+            resendTimerRef.current = null;
+        }
+
+        // 타이머 초기화
+        setRemainingSeconds(null);
+        setResendSeconds(null);
     };
 
     const handleCodeChange = (nextCode: string) => {
         setCode(nextCode);
     };
 
+    // 버튼 활성화 조건
     const canSendVerificationEmail =
-        email.trim().length > 0 && status !== "SENDING";
+        email.trim().length > 0 &&
+        status !== "SENDING" &&
+        status !== "VERIFIED" &&
+        !hasSentVerificationEmail &&
+        resendAttemptCount < MAX_RESEND_ATTEMPTS;
+
+    const canResendVerificationEmail =
+        hasSentVerificationEmail &&
+        status !== "SENDING" &&
+        status !== "VERIFIED" &&
+        resendAttemptCount < MAX_RESEND_ATTEMPTS;
 
     const canConfirmVerificationEmail =
-        code.trim().length === 6 && status !== "VERIFYING";
+        code.trim().length === 6 &&
+        status !== "VERIFYING" &&
+        status !== "VERIFIED" &&
+        status !== "EXPIRED" &&
+        remainingSeconds !== 0 &&
+        confirmAttemptCount < MAX_CONFIRM_ATTEMPTS;
 
     const isVerified = status === "VERIFIED" && !!emailVerificationToken;
 
@@ -144,8 +343,15 @@ export function useEmailVerification({
         status,
         message,
         emailVerificationToken,
-        resendAvailableAfterSeconds,
+        remainingSeconds,
+        resendSeconds,
+        confirmAttemptCount,
+        maxConfirmAttempts: MAX_CONFIRM_ATTEMPTS,
+        resendAttemptCount,
+        maxResendAttempts: MAX_RESEND_ATTEMPTS,
+        hasSentVerificationEmail,
         canSendVerificationEmail,
+        canResendVerificationEmail,
         canConfirmVerificationEmail,
         isVerified,
         handleEmailChange,

--- a/src/features/emailVerification/application/utils/timer.ts
+++ b/src/features/emailVerification/application/utils/timer.ts
@@ -1,0 +1,10 @@
+export function startTimer(
+    callback: () => void,
+    interval: number = 1000
+) {
+  const timerId = setInterval(callback, interval);
+
+  return () => {
+    clearInterval(timerId);
+  };
+}

--- a/src/features/emailVerification/domain/model/EmailVerificationStatus.ts
+++ b/src/features/emailVerification/domain/model/EmailVerificationStatus.ts
@@ -1,0 +1,9 @@
+// 현재 이메일 인증 상태
+export type EmailVerificationStatus =
+    | "IDLE"
+    | "SENDING" // 인증 코드 발송 중
+    | "SENT" // 인증 코드 발송 완료
+    | "VERIFYING" // 인증 코드 확인 중
+    | "VERIFIED" // 이메일 인증 완료
+    | "EXPIRED" // 인증 코드 만료
+    | "ERROR"; // 오류 발생

--- a/src/infrastructure/http/httpClient.ts
+++ b/src/infrastructure/http/httpClient.ts
@@ -26,6 +26,8 @@ const NO_REFRESH_PATHS = [
     "/api/v1/auth/login",
     "/api/v1/auth/refresh",
     "/api/v1/members/signup",
+    "/api/v1/auth/email",
+    "/api/v1/auth/email/confirm",
 ];
 
 function shouldTryRefresh(path: string, isRetry: boolean) {


### PR DESCRIPTION
## 관련 이슈
Closes #91 

## 요약
- 이메일 인증/재발송 로직 개선 및 횟수 제한(5회) 적용
- 재발송 대기 UX 개선(alert 안내) 및 불필요한 API 호출 방지

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
