### PR TITLE
[Refactor] 회원가입 닉네임 페이지 접근 제어 로직 분리 (#79)

### DIFF
--- a/src/app/signup/nickname/page.tsx
+++ b/src/app/signup/nickname/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
 import { useAtomValue } from "jotai";
 
 import { nicknamePageStyles } from "@/ui/styles/nicknamePageStyles";
@@ -12,10 +11,13 @@ import { signupApi } from "@/features/signup/infrastructure/api/signupApi"
 import { onboardingAtom } from "@/features/auth/application/selectors/authSelectors";
 import { useSubmitMyNickname } from "@/features/auth/application/hooks/useSubmitMyNickname";
 import { useNicknameValidation } from "@/features/nickname/application/hooks/useNicknameValidation";
+import { useSignupNicknameGuard } from "@/features/signup/application/hooks/useSignupNicknameGuard"; // ✅ 추가
 
 export default function NicknamePage() {
     const router = useRouter();
     const onboarding = useAtomValue(onboardingAtom);
+
+    useSignupNicknameGuard();
 
     const { submit: submitMyNickname, isSubmitting } = useSubmitMyNickname();
     const isSocialOnboarding = onboarding?.nextStep === "REQUIRED_NICKNAME";
@@ -30,38 +32,6 @@ export default function NicknamePage() {
     } = useNicknameValidation();
 
     const canSubmit = canSaveNickname && !isSubmitting;
-
-    useEffect(() => {
-        const account = accountStorage.load();
-        const savedAgreements = termsStorage.load();
-
-        const isGeneralSignup =
-            !!account &&
-            !!account.email &&
-            !!account.emailVerificationToken &&
-            !!savedAgreements &&
-            savedAgreements.length > 0;
-
-        if (isGeneralSignup) return;
-
-        if (onboarding?.nextStep === "REQUIRED_NICKNAME") return;
-
-        if (onboarding?.nextStep === "REQUIRED_AGREEMENTS") {
-            router.replace("/terms");
-            return;
-        }
-
-        if (onboarding?.nextStep === "READY") {
-            router.replace("/home");
-            return;
-        }
-
-        if (onboarding === null) {
-            return;
-        }
-
-        router.replace("/signup");
-    }, [router, onboarding]);
 
     const handleSubmit = async () => {
         if (!canSubmit) return;

--- a/src/features/signup/application/hooks/useSignupNicknameGuard.ts
+++ b/src/features/signup/application/hooks/useSignupNicknameGuard.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAtomValue } from "jotai";
+
+import { onboardingAtom } from "@/features/auth/application/selectors/authSelectors";
+import { accountStorage } from "@/features/signup/infrastructure/storage/accountStorage";
+import { termsStorage } from "@/features/terms/infrastructure/storage/termsStorage";
+
+export function useSignupNicknameGuard() {
+    const router = useRouter();
+    const onboarding = useAtomValue(onboardingAtom);
+
+    useEffect(() => {
+        const account = accountStorage.load();
+        const savedAgreements = termsStorage.load();
+
+        // 일반 회원가입 플로우 조건
+        const isGeneralSignup =
+            !!account &&
+            !!account.email &&
+            !!account.emailVerificationToken &&
+            !!savedAgreements &&
+            savedAgreements.length > 0;
+
+        // 일반 회원가입 정상 접근
+        if (isGeneralSignup) return;
+
+        // 소셜 온보딩 닉네임 단계
+        if (onboarding?.nextStep === "REQUIRED_NICKNAME") return;
+
+        // 소셜 온보딩 - 약관 단계면 이동
+        if (onboarding?.nextStep === "REQUIRED_AGREEMENTS") {
+            router.replace("/terms");
+            return;
+        }
+
+        // 소셜 온보딩 완료 상태
+        if (onboarding?.nextStep === "READY") {
+            router.replace("/home");
+            return;
+        }
+
+        // 아직 onboarding 정보 없음 (초기 로딩 상태)
+        if (onboarding === null) {
+            return;
+        }
+
+        // 그 외 잘못된 접근
+        router.replace("/signup");
+    }, [router, onboarding]);
+}


### PR DESCRIPTION
## 관련 이슈
Closes #79 

## 요약
- 무엇을 변경했나요?
회원가입 닉네임 페이지의 접근 제어 로직을 useSignupNicknameGuard 훅으로 분리 
일반 회원가입 흐름과 소셜 온보딩 흐름을 각각 명확하게 처리하도록 구조를 개선

- 왜 이 변경이 필요한가요?
기존에는 하나의 useEffect에 여러 접근 조건이 혼재되어 있어 흐름 이해와 유지보수가 어려웠음
로직을 훅으로 분리하여 가독성을 높이고 회원가입 및 온보딩 단계별 접근 제어를 명확하게 관리하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
