### PR TITLE
[Refactor] 회원가입 이메일 인증 로직 usecase 기반으로 분리 (#97)

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -10,6 +10,8 @@ import { accountStorage } from "@/features/signup/infrastructure/storage/account
 import { useLoginIdValidation } from "@/features/signup/application/hooks/useLoginIdValidation";
 import { usePasswordValidation } from "@/features/signup/application/hooks/usePasswordValidation";
 import { useEmailVerification } from "@/features/emailVerification/application/hooks/useEmailVerification";
+import { useVerificationExpireTimer } from "@/features/emailVerification/application/hooks/useVerificationExpireTimer";
+import { useResendTimer } from "@/features/emailVerification/application/hooks/useResendTimer";
 
 const providers: AuthProvider[] = ["GOOGLE", "KAKAO", "NAVER"];
 
@@ -47,12 +49,26 @@ export default function SignupPage() {
         canSendVerificationEmail,
         canResendVerificationEmail,
         canConfirmVerificationEmail,
+        setRemainingSeconds,
+        setResendSeconds,
+        handleExpired,
         handleEmailChange,
         handleCodeChange,
         sendVerificationEmail,
         confirmVerificationEmail,
     } = useEmailVerification({
         purpose: "SIGNUP",
+    });
+
+    const { stopVerificationTimer } = useVerificationExpireTimer({
+        remainingSeconds,
+        setRemainingSeconds,
+        onExpired: handleExpired,
+    });
+
+    useResendTimer({
+        resendSeconds,
+        setResendSeconds,
     });
 
     const canSubmit =
@@ -195,9 +211,9 @@ export default function SignupPage() {
                                 <button
                                     type="button"
                                     onClick={sendVerificationEmail}
-                                    disabled={!canSendVerificationEmail || isEmailVerified}
+                                    disabled={!canSendVerificationEmail}
                                     className={
-                                        canSendVerificationEmail && !isEmailVerified
+                                        canSendVerificationEmail
                                             ? `${signupPageStyles.nextButton} whitespace-nowrap`
                                             : `${signupPageStyles.nextButton} whitespace-nowrap opacity-50 cursor-not-allowed`
                                     }
@@ -223,18 +239,11 @@ export default function SignupPage() {
                         {hasSentVerificationEmail && !isEmailVerified && (
                             <p className="mt-2 text-xs text-gray-400">
                                 인증 코드 발송 횟수 {resendAttemptCount}/{maxResendAttempts}
+                                {resendSeconds !== null &&
+                                    resendSeconds > 0 &&
+                                    `, 인증코드 재발송 가능 시간: ${resendSeconds}초 후`}
                             </p>
                         )}
-
-                        {hasSentVerificationEmail &&
-                            !isEmailVerified &&
-                            resendSeconds !== null &&
-                            resendSeconds > 0 && (
-                                <p className="mt-1 text-xs text-gray-400">
-                                    {resendSeconds}초 후 인증코드 재발송이 가능합니다.
-                                </p>
-                            )
-                        }
                     </div>
 
                     <div className={signupPageStyles.inputGroup}>
@@ -252,7 +261,7 @@ export default function SignupPage() {
 
                             <button
                                 type="button"
-                                onClick={confirmVerificationEmail}
+                                onClick={() => confirmVerificationEmail(stopVerificationTimer)}
                                 disabled={!canConfirmVerificationEmail || isEmailVerified}
                                 className={
                                     canConfirmVerificationEmail && !isEmailVerified
@@ -264,16 +273,20 @@ export default function SignupPage() {
                             </button>
                         </div>
 
+                        {/*
                         {remainingSeconds !== null && !isEmailVerified && (
                             <p className="mt-2 text-sm text-gray-500">
                                 인증 유효시간 {formatSeconds(remainingSeconds)}
                             </p>
                         )}
+                        */}
 
-                        {!isEmailVerified && confirmAttemptCount > 0 && (
-                            <p className="mt-1 text-xs text-gray-400">
-                                인증 시도 횟수 {confirmAttemptCount}/{maxConfirmAttempts}
-                            </p>
+                        {!isEmailVerified && (
+                            <p className="mt-2 text-xs text-gray-400">
+                                인증 시도 {confirmAttemptCount}/{maxConfirmAttempts}
+                                {remainingSeconds !== null &&
+                                    `, 인증 유효시간 ${formatSeconds(remainingSeconds)}`}
+                          </p>
                         )}
 
                         {emailVerificationMessage && (

--- a/src/features/emailVerification/application/hooks/useEmailVerification.ts
+++ b/src/features/emailVerification/application/hooks/useEmailVerification.ts
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { emailVerificationApi } from "@/features/emailVerification/infrastructure/api/emailVerificationApi";
+import { useCallback, useState } from "react";
+
 import type { EmailVerificationPurpose } from "@/features/emailVerification/domain/model/EmailVerificationPurpose";
 import type { EmailVerificationStatus } from "@/features/emailVerification/domain/model/EmailVerificationStatus";
-
-import { startTimer } from "@/features/emailVerification/application/utils/timer";
+import { sendEmailVerification } from "@/features/emailVerification/application/usecase/sendEmailVerification";
+import { confirmEmailVerification } from "@/features/emailVerification/application/usecase/confirmEmailVerification";
 
 interface UseEmailVerificationParams {
     purpose: EmailVerificationPurpose;
@@ -13,6 +13,7 @@ interface UseEmailVerificationParams {
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // 이메일 형식 검증
 const VERIFICATION_CODE_REGEX = /^\d{6}$/; // 인증 코드 6자리
+
 const VERIFICATION_EXPIRE_SECONDS = 300; // 인증코드 유효시간: 5분
 const MAX_CONFIRM_ATTEMPTS = 5; // 이메일 인증 횟수 5회 제한
 const MAX_RESEND_ATTEMPTS = 5; // 재발송 횟수 상태
@@ -26,16 +27,13 @@ export function useEmailVerification({
     const [message, setMessage] = useState("");
 
     // 인증 성공 시 받은 토큰
-    const [emailVerificationToken, setEmailVerificationToken] =
-        useState<string | null>(null);
+    const [emailVerificationToken, setEmailVerificationToken] = useState<string | null>(null);
 
     // 인증 코드 유효시간 (5분)
-    const [remainingSeconds, setRemainingSeconds] =
-        useState<number | null>(null);
+    const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
 
     // 재발송 대기시간
-    const [resendSeconds, setResendSeconds] =
-        useState<number | null>(null);
+    const [resendSeconds, setResendSeconds] = useState<number | null>(null);
 
     const [confirmAttemptCount, setConfirmAttemptCount] = useState(0);
 
@@ -44,84 +42,6 @@ export function useEmailVerification({
 
     // 실제 발송 성공 여부 상태
     const [hasSentVerificationEmail, setHasSentVerificationEmail] = useState(false);
-
-    // 인증 코드 타이머 종료 함수 저장
-    const verificationTimerRef = useRef<(() => void) | null>(null);
-
-    // 재발송 타이머 종료 함수 저장
-    const resendTimerRef = useRef<(() => void) | null>(null);
-
-    // 인증코드 타이머
-    useEffect(() => {
-        if (remainingSeconds === null) return;
-        if (remainingSeconds <= 0) return;
-
-        // 기존 타이머 제거 (중복 방지)
-        if (verificationTimerRef.current) {
-            verificationTimerRef.current();
-        }
-
-        // 새로운 타이머 시작
-        verificationTimerRef.current = startTimer(() => {
-            setRemainingSeconds((prev) => {
-                if (prev === null) return null;
-
-                if (prev <= 1) {
-                    if (verificationTimerRef.current) {
-                        verificationTimerRef.current();
-                        verificationTimerRef.current = null;
-                    }
-
-                    setStatus("EXPIRED");
-                    setMessage("인증 코드가 만료되었습니다. 다시 발송해주세요.");
-
-                    return 0;
-                }
-
-                return prev - 1;
-            });
-        });
-
-        // cleanup
-        return () => {
-            if (verificationTimerRef.current) {
-                verificationTimerRef.current();
-            }
-        };
-    }, [remainingSeconds]);
-
-    // 이메일 재발송 타이머
-    useEffect(() => {
-        if (resendSeconds === null) return;
-        if (resendSeconds <= 0) return;
-
-        if (resendTimerRef.current) {
-            resendTimerRef.current();
-        }
-
-        resendTimerRef.current = startTimer(() => {
-            setResendSeconds((prev) => {
-                if (prev === null) return null;
-
-                if (prev <= 1) {
-                    if (resendTimerRef.current) {
-                        resendTimerRef.current();
-                        resendTimerRef.current = null;
-                    }
-
-                    return 0;
-                }
-
-                return prev - 1;
-            });
-        });
-
-        return () => {
-            if (resendTimerRef.current) {
-                resendTimerRef.current();
-            }
-        };
-    }, [resendSeconds]);
 
     // 이메일 검증
     const validateEmail = (nextEmail: string): string | null => {
@@ -142,21 +62,37 @@ export function useEmailVerification({
         return trimmedEmail;
     };
 
-    // 인증 코드 발송
+    const handleEmailChange = (nextEmail: string) => {
+        setEmail(nextEmail);
+        setCode("");
+        setStatus("IDLE");
+        setMessage("");
+        setEmailVerificationToken(null);
+        setRemainingSeconds(null);
+        setResendSeconds(null);
+        setConfirmAttemptCount(0);
+        setResendAttemptCount(0);
+        setHasSentVerificationEmail(false);
+    };
+
+    const handleCodeChange = (nextCode: string) => {
+        setCode(nextCode);
+    };
+
+    const handleExpired = useCallback(() => {
+        setStatus("EXPIRED");
+        setMessage("인증 코드가 만료되었습니다. 다시 발송해주세요.");
+    }, []);
+
     const sendVerificationEmail = async () => {
         const trimmedEmail = validateEmail(email);
         if (!trimmedEmail) return;
 
-        console.log("📧 전송할 이메일:", trimmedEmail);
-        console.log("resendSeconds:", resendSeconds);
-
-        // 재발송 대기 중이어도 버튼은 클릭 가능하지만 API 호출은 막고 alert 표시
         if (resendSeconds && resendSeconds > 0) {
             alert(`${resendSeconds}초 후 인증코드 재발송이 가능합니다.`);
             return;
         }
 
-        // 인증 코드 발송/재발송 총 5회 제한
         if (resendAttemptCount >= MAX_RESEND_ATTEMPTS) {
             setStatus("ERROR");
             setMessage("인증 코드 발송 횟수를 초과했습니다.");
@@ -170,46 +106,36 @@ export function useEmailVerification({
                 : "인증 코드를 발송하는 중입니다.",
         );
 
-        try {
-            const response = await emailVerificationApi.sendVerificationEmail({
-                email: trimmedEmail,
-                purpose,
-            });
+        const result = await sendEmailVerification({
+            email: trimmedEmail,
+            purpose,
+        });
 
-            console.log("📥 email API 응답:", response);
-
-            if (!response.success) {
-                setStatus("ERROR");
-                setMessage(response.error?.message || "인증 코드 발송에 실패했습니다.");
-                return;
-            }
-
-            setStatus("SENT");
-            setMessage(
-                hasSentVerificationEmail
-                    ? "인증 코드가 재발송되었습니다."
-                    : "인증 코드가 발송되었습니다.",
-            );
-
-            setHasSentVerificationEmail(true);
-            setResendAttemptCount((prev) => prev + 1);
-
-            setEmailVerificationToken(null);
-            setCode(""); // 재발송 시 이전 코드 초기화
-            setConfirmAttemptCount(0);
-
-            // 타이머 시작
-            setRemainingSeconds(VERIFICATION_EXPIRE_SECONDS);
-            setResendSeconds(response.data.resendAvailableAfterSeconds);
-        } catch (error) {
-            console.error("📥 email API 요청 실패:", error);
+        if (!result.success) {
             setStatus("ERROR");
-            setMessage("인증 코드 발송에 실패했습니다.");
+            setMessage(result.message);
+            return;
         }
+
+        setStatus("SENT");
+        setMessage(
+            hasSentVerificationEmail
+                ? "인증 코드가 재발송되었습니다."
+                : "인증 코드가 발송되었습니다.",
+        );
+
+        setHasSentVerificationEmail(true);
+        setResendAttemptCount((prev) => prev + 1);
+
+        setEmailVerificationToken(null);
+        setCode("");
+        setConfirmAttemptCount(0);
+
+        setRemainingSeconds(VERIFICATION_EXPIRE_SECONDS);
+        setResendSeconds(result.resendAvailableAfterSeconds);
     };
 
-    // 인증 코드 확인
-    const confirmVerificationEmail = async () => {
+    const confirmVerificationEmail = async (stopVerificationTimer: () => void) => {
         const trimmedEmail = validateEmail(email);
         const trimmedCode = code.trim();
 
@@ -236,40 +162,13 @@ export function useEmailVerification({
         setStatus("VERIFYING");
         setMessage("인증 코드를 확인하는 중입니다.");
 
-        try {
-            const response = await emailVerificationApi.confirmVerificationEmail({
-                email: trimmedEmail,
-                purpose,
-                code: trimmedCode,
-            });
+        const result = await confirmEmailVerification({
+            email: trimmedEmail,
+            purpose,
+            code: trimmedCode,
+        });
 
-            if (!response.success || !response.data.verified) {
-                const nextCount = confirmAttemptCount + 1;
-                setConfirmAttemptCount(nextCount);
-
-                if (nextCount >= MAX_CONFIRM_ATTEMPTS) {
-                    setStatus("ERROR");
-                    setMessage("인증 시도 횟수를 초과했습니다. 인증 코드를 다시 발송해주세요.");
-                    return;
-                }
-
-                setStatus("ERROR");
-                setMessage(`이메일 인증에 실패했습니다. (${nextCount}/${MAX_CONFIRM_ATTEMPTS})`);
-                return;
-            }
-
-            setStatus("VERIFIED");
-            setMessage("이메일 인증이 완료되었습니다.");
-            setEmailVerificationToken(response.data.emailVerificationToken);
-
-            // 타이머 종료
-            if (verificationTimerRef.current) {
-                verificationTimerRef.current();
-                verificationTimerRef.current = null;
-            }
-
-            setRemainingSeconds(null);
-        } catch {
+        if (!result.success) {
             const nextCount = confirmAttemptCount + 1;
             setConfirmAttemptCount(nextCount);
 
@@ -281,36 +180,15 @@ export function useEmailVerification({
 
             setStatus("ERROR");
             setMessage(`이메일 인증에 실패했습니다. (${nextCount}/${MAX_CONFIRM_ATTEMPTS})`);
-        }
-    };
-
-    const handleEmailChange = (nextEmail: string) => {
-        setEmail(nextEmail);
-        setCode("");
-        setStatus("IDLE");
-        setMessage("");
-        setEmailVerificationToken(null);
-        setConfirmAttemptCount(0);
-        setResendAttemptCount(0);
-        setHasSentVerificationEmail(false);
-
-        if (verificationTimerRef.current) {
-            verificationTimerRef.current();
-            verificationTimerRef.current = null;
+            return;
         }
 
-        if (resendTimerRef.current) {
-            resendTimerRef.current();
-            resendTimerRef.current = null;
-        }
+        setStatus("VERIFIED");
+        setMessage("이메일 인증이 완료되었습니다.");
+        setEmailVerificationToken(result.emailVerificationToken);
 
-        // 타이머 초기화
+        stopVerificationTimer();
         setRemainingSeconds(null);
-        setResendSeconds(null);
-    };
-
-    const handleCodeChange = (nextCode: string) => {
-        setCode(nextCode);
     };
 
     // 버튼 활성화 조건
@@ -354,6 +232,9 @@ export function useEmailVerification({
         canResendVerificationEmail,
         canConfirmVerificationEmail,
         isVerified,
+        setRemainingSeconds,
+        setResendSeconds,
+        handleExpired,
         handleEmailChange,
         handleCodeChange,
         sendVerificationEmail,

--- a/src/features/emailVerification/application/hooks/useResendTimer.ts
+++ b/src/features/emailVerification/application/hooks/useResendTimer.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { startTimer } from "@/features/emailVerification/application/utils/timer";
+
+interface UseResendTimerParams {
+    resendSeconds: number | null;
+    setResendSeconds: React.Dispatch<React.SetStateAction<number | null>>;
+}
+
+export function useResendTimer({
+    resendSeconds,
+    setResendSeconds,
+}: UseResendTimerParams) {
+    const timerRef = useRef<(() => void) | null>(null);
+
+    const stopResendTimer = () => {
+        if (timerRef.current) {
+            timerRef.current();
+            timerRef.current = null;
+        }
+    };
+
+    useEffect(() => {
+        if (resendSeconds === null) return;
+        if (resendSeconds <= 0) return;
+
+        stopResendTimer();
+
+        timerRef.current = startTimer(() => {
+            setResendSeconds((prev) => {
+                if (prev === null) return null;
+
+                if (prev <= 1) {
+                    stopResendTimer();
+                    return 0;
+                }
+
+                return prev - 1;
+            });
+        });
+
+        return stopResendTimer;
+    }, [resendSeconds, setResendSeconds]);
+
+    return {
+        stopResendTimer,
+    };
+}

--- a/src/features/emailVerification/application/hooks/useVerificationExpireTimer.ts
+++ b/src/features/emailVerification/application/hooks/useVerificationExpireTimer.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { startTimer } from "@/features/emailVerification/application/utils/timer";
+
+interface UseVerificationExpireTimerParams {
+    remainingSeconds: number | null;
+    setRemainingSeconds: React.Dispatch<React.SetStateAction<number | null>>;
+    onExpired: () => void;
+}
+
+export function useVerificationExpireTimer({
+    remainingSeconds,
+    setRemainingSeconds,
+    onExpired,
+}: UseVerificationExpireTimerParams) {
+    const timerRef = useRef<(() => void) | null>(null);
+
+    const stopVerificationTimer = () => {
+        if (timerRef.current) {
+            timerRef.current();
+            timerRef.current = null;
+        }
+    };
+
+    useEffect(() => {
+        if (remainingSeconds === null) return;
+        if (remainingSeconds <= 0) return;
+
+        stopVerificationTimer();
+
+        timerRef.current = startTimer(() => {
+            setRemainingSeconds((prev) => {
+                if (prev === null) return null;
+
+                if (prev <= 1) {
+                    stopVerificationTimer();
+                    onExpired();
+                    return 0;
+                }
+
+                return prev - 1;
+            });
+        });
+
+        return stopVerificationTimer;
+    }, [remainingSeconds, setRemainingSeconds, onExpired]);
+
+    return {
+        stopVerificationTimer,
+    };
+}

--- a/src/features/emailVerification/application/usecase/confirmEmailVerification.ts
+++ b/src/features/emailVerification/application/usecase/confirmEmailVerification.ts
@@ -1,0 +1,49 @@
+import { emailVerificationApi } from "@/features/emailVerification/infrastructure/api/emailVerificationApi";
+import type { EmailVerificationPurpose } from "@/features/emailVerification/domain/model/EmailVerificationPurpose";
+
+interface ConfirmEmailVerificationParams {
+    readonly email: string;
+    readonly purpose: EmailVerificationPurpose;
+    readonly code: string;
+}
+
+type ConfirmEmailVerificationResult =
+    | {
+        readonly success: true;
+        readonly emailVerificationToken: string;
+    }
+    | {
+        readonly success: false;
+        readonly message: string;
+    };
+
+export async function confirmEmailVerification({
+    email,
+    purpose,
+    code,
+}: ConfirmEmailVerificationParams): Promise<ConfirmEmailVerificationResult> {
+    try {
+        const response = await emailVerificationApi.confirmVerificationEmail({
+            email,
+            purpose,
+            code,
+        });
+
+        if (!response.success || !response.data.verified) {
+            return {
+                success: false,
+                message: response.error?.message || "이메일 인증에 실패했습니다.",
+            };
+        }
+
+        return {
+            success: true,
+            emailVerificationToken: response.data.emailVerificationToken,
+        };
+    } catch {
+        return {
+            success: false,
+            message: "이메일 인증에 실패했습니다.",
+        };
+    }
+}

--- a/src/features/emailVerification/application/usecase/sendEmailVerification.ts
+++ b/src/features/emailVerification/application/usecase/sendEmailVerification.ts
@@ -1,0 +1,46 @@
+import { emailVerificationApi } from "@/features/emailVerification/infrastructure/api/emailVerificationApi";
+import type { EmailVerificationPurpose } from "@/features/emailVerification/domain/model/EmailVerificationPurpose";
+
+interface SendEmailVerificationParams {
+    readonly email: string;
+    readonly purpose: EmailVerificationPurpose;
+}
+
+type SendEmailVerificationResult =
+    | {
+        readonly success: true;
+        readonly resendAvailableAfterSeconds: number;
+    }
+    | {
+        readonly success: false;
+        readonly message: string;
+    };
+
+export async function sendEmailVerification({
+    email,
+    purpose,
+}: SendEmailVerificationParams): Promise<SendEmailVerificationResult> {
+    try {
+        const response = await emailVerificationApi.sendVerificationEmail({
+            email,
+            purpose,
+        });
+
+        if (!response.success) {
+            return {
+                success: false,
+                message: response.error?.message || "인증 코드 발송에 실패했습니다.",
+            };
+        }
+
+        return {
+            success: true,
+            resendAvailableAfterSeconds: response.data.resendAvailableAfterSeconds,
+        };
+    } catch {
+        return {
+            success: false,
+            message: "인증 코드 발송에 실패했습니다.",
+        };
+    }
+}

--- a/src/infrastructure/http/httpClient.ts
+++ b/src/infrastructure/http/httpClient.ts
@@ -30,6 +30,11 @@ const NO_REFRESH_PATHS = [
     "/api/v1/auth/email/confirm",
 ];
 
+const SILENT_ERROR_LOG_PATHS = [
+    "/api/v1/auth/refresh",
+    "/api/v1/auth/email/confirm",
+];
+
 function shouldTryRefresh(path: string, isRetry: boolean) {
     if (isRetry) return false;
     if (NO_REFRESH_PATHS.includes(path)) return false;
@@ -99,7 +104,7 @@ async function request<T>(
     if (!response.ok) {
         const errorBody = await response.json().catch(() => null);
         //  refresh는 로그 안 찍음
-        if (path !== "/api/v1/auth/refresh") {
+        if (!SILENT_ERROR_LOG_PATHS.includes(path)) {
             console.error("[httpClient] 요청 실패 응답:", {
                 path,
                 status: response.status,


### PR DESCRIPTION
## 관련 이슈
Closes #97 

## 요약
- 무엇을 변경했나요?
이메일 인증 로직을 리팩토링하여 API 호출을 usecase로 분리하고 hook은 입력 상태와 UI 상태 관리에 집중하도록 구조를 개선
또한 타이머 로직을 별도 hook으로 분리하고 인증 실패 시 불필요한 콘솔 에러 로그가 출력되지 않도록 수정

- 왜 이 변경이 필요한가요?
기존에 하나의 hook에 로직이 집중되어 있어 복잡하고 유지보수가 어려운 문제를 해결하고
역할을 명확히 분리하여 코드 가독성과 확장성을 개선하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
