### PR TITLE
[Feat] 로컬 로그인 사용자의 설정 페이지에 이메일 표시 (#99)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -54,6 +54,7 @@ export default function SettingsPage() {
 
             <AccountManagementSection
                 userId={profile.id}
+                email={profile.email}
                 showPasswordFields={isLocalLogin}
             />
         </main>

--- a/src/features/settings/domain/model/SettingsProfile.ts
+++ b/src/features/settings/domain/model/SettingsProfile.ts
@@ -2,4 +2,5 @@ export interface SettingsProfile {
     readonly id: number;
     readonly nickname: string;
     readonly isSocial: boolean;
+    readonly email: string;
 }

--- a/src/features/settings/ui/components/AccountManagementSection.tsx
+++ b/src/features/settings/ui/components/AccountManagementSection.tsx
@@ -5,11 +5,13 @@ import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
 
 interface AccountManagementSectionProps {
     userId?: number; // TODO: 서버에서 아이디를 받는 거 추가되면 string으로 수정 필요
+    email?: string;
     showPasswordFields: boolean;
 }
 
 export default function AccountManagementSection({
     userId,
+    email,
     showPasswordFields,
 }: AccountManagementSectionProps) {
     return (
@@ -27,6 +29,13 @@ export default function AccountManagementSection({
                                 USER ID
                             </p>
                             <p>{userId}</p>
+                        </div>
+
+                        <div className={`${settingsPageStyles.disabledInput} mb-4`}>
+                            <p className="mb-2 text-xs font-semibold uppercase">
+                                EMAIL
+                            </p>
+                            <p>{email}</p>
                         </div>
 
                         <label className={settingsPageStyles.label}>


### PR DESCRIPTION
## 관련 이슈
Closes #99

## 요약
- 설정 페이지의 계정 관리 영역에서 일반 로그인 사용자의 가입 ID와 인증된 이메일을 함께 표시

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
