### PR TITLE
[Feat] 설정 페이지 접근 권한 Guard 적용 (#100)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -10,14 +10,14 @@ import AccountManagementSection from "@/features/settings/ui/components/AccountM
 import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
 
 export default function SettingsPage() {
-    const { isAuthenticated, isAuthLoading } = useAuthGuard();
+    const { isAuthLoading, canAccess } = useAuthGuard();
 
-    useSettingsProfile(isAuthenticated);
+    useSettingsProfile(canAccess);
 
     const settingsState = useAtomValue(settingsAtom);
     const isLocalLogin = useAtomValue(isLocalLoginAtom);
 
-    if (isAuthLoading || !isAuthenticated) {
+    if (isAuthLoading || !canAccess) {
         return (
             <main className={settingsPageStyles.page}>
                 로그인 상태를 확인하는 중...


### PR DESCRIPTION
## 관련 이슈
Closes #100 

## 요약
비로그인 사용자가 /settings 주소로 직접 접근했을 때 설정 API를 호출하기 전에 로그인 페이지로 이동하도록 처리

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
