### PR TITLE
[Feat] 아이디 찾기 기능 구현

### DIFF
--- a/src/app/auth/find-id/page.tsx
+++ b/src/app/auth/find-id/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import FindIdForm from "@/features/findId/ui/components/FindIdForm";
+import { findIdPageStyles } from "@/ui/styles/findIdPageStyles";
+
+export default function FindIdPage() {
+    return (
+        <main className={findIdPageStyles.page}>
+            <section className={findIdPageStyles.card}>
+                <h1 className={findIdPageStyles.title}>아이디 찾기</h1>
+                <p className={findIdPageStyles.description}>
+                    가입 시 사용한 이메일을 입력하세요
+                </p>
+
+                <FindIdForm />
+            </section>
+        </main>
+    );
+}

--- a/src/app/auth/find-id/page.tsx
+++ b/src/app/auth/find-id/page.tsx
@@ -8,10 +8,6 @@ export default function FindIdPage() {
         <main className={findIdPageStyles.page}>
             <section className={findIdPageStyles.card}>
                 <h1 className={findIdPageStyles.title}>아이디 찾기</h1>
-                <p className={findIdPageStyles.description}>
-                    가입 시 사용한 이메일을 입력하세요
-                </p>
-
                 <FindIdForm />
             </section>
         </main>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -105,7 +105,7 @@ export default function LoginPage() {
                 </div>
 
                 <div className={loginPageStyles.helperLinks}>
-                    <Link href="/" className={loginPageStyles.helperLink}>
+                    <Link href="/auth/find-id" className={loginPageStyles.helperLink}>
                         아이디 찾기
                     </Link>
                     <span className={loginPageStyles.separator}>|</span>

--- a/src/features/findId/application/atoms/findIdAtom.ts
+++ b/src/features/findId/application/atoms/findIdAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from "jotai";
+import type { FindIdState } from "@/features/findId/domain/state/FindIdState";
+
+export const findIdAtom = atom<FindIdState>({
+    status: "EMAIL_INPUT",
+});

--- a/src/features/findId/application/hooks/useFindId.ts
+++ b/src/features/findId/application/hooks/useFindId.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { findIdAtom } from "@/features/findId/application/atoms/findIdAtom";
+import { sendEmailVerification } from "@/features/emailVerification/application/usecase/sendEmailVerification";
+import { confirmEmailVerification } from "@/features/emailVerification/application/usecase/confirmEmailVerification";
+import { findIdByVerificationToken } from "@/features/findId/application/usecase/findIdByVerificationToken";
+
+export function useFindId() {
+    const setFindIdState = useSetAtom(findIdAtom);
+
+    const [email, setEmail] = useState("");
+    const [code, setCode] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleSendCode = async () => {
+        const trimmedEmail = email.trim();
+
+        if (!trimmedEmail) return;
+
+        setIsLoading(true);
+
+        const result = await sendEmailVerification({
+            email: trimmedEmail,
+            purpose: "FIND_LOGIN_ID",
+        });
+
+        setIsLoading(false);
+
+        if (!result.success) {
+            setFindIdState({
+                status: "ERROR",
+                message: result.message,
+            });
+            return;
+        }
+
+        setFindIdState({
+            status: "CODE_INPUT",
+        });
+    };
+
+    const handleFindId = async () => {
+        const trimmedEmail = email.trim();
+        const trimmedCode = code.trim();
+
+        if (!trimmedEmail || !trimmedCode) return;
+
+        setIsLoading(true);
+
+        const confirmResult = await confirmEmailVerification({
+            email: trimmedEmail,
+            code: trimmedCode,
+            purpose: "FIND_LOGIN_ID",
+        });
+
+        if (!confirmResult.success) {
+            setIsLoading(false);
+            setFindIdState({
+                status: "ERROR",
+                message: confirmResult.message,
+            });
+            return;
+        }
+
+        const result = await findIdByVerificationToken({
+            emailVerificationToken: confirmResult.emailVerificationToken,
+        });
+
+        setIsLoading(false);
+        setFindIdState(result);
+    };
+
+    return {
+        email,
+        code,
+        isLoading,
+        setEmail,
+        setCode,
+        handleSendCode,
+        handleFindId,
+    };
+}

--- a/src/features/findId/application/selectors/findIdSelectors.ts
+++ b/src/features/findId/application/selectors/findIdSelectors.ts
@@ -1,0 +1,34 @@
+import { atom } from "jotai";
+import { findIdAtom } from "@/features/findId/application/atoms/findIdAtom";
+
+export const isEmailInputStepAtom = atom(
+    (get) => get(findIdAtom).status === "EMAIL_INPUT",
+);
+
+export const isCodeInputStepAtom = atom(
+    (get) => get(findIdAtom).status === "CODE_INPUT",
+);
+
+export const isFindIdResultStepAtom = atom((get) => {
+    const status = get(findIdAtom).status;
+
+    return (
+        status === "FOUND" ||
+        status === "NOT_FOUND" ||
+        status === "ERROR"
+    );
+});
+
+export const foundIdAtom = atom((get) => {
+    const state = get(findIdAtom);
+
+    return state.status === "FOUND" ? state.loginId : null;
+});
+
+export const findIdMessageAtom = atom((get) => {
+    const state = get(findIdAtom);
+
+    return state.status === "NOT_FOUND" || state.status === "ERROR"
+        ? state.message
+        : null;
+});

--- a/src/features/findId/application/usecase/findIdByVerificationToken.ts
+++ b/src/features/findId/application/usecase/findIdByVerificationToken.ts
@@ -1,0 +1,33 @@
+import { findIdApi } from "@/features/findId/infrastructure/api/findIdApi";
+import type { FindIdState } from "@/features/findId/domain/state/FindIdState";
+
+interface FindIdByVerificationTokenParams {
+    readonly emailVerificationToken: string;
+}
+
+export async function findIdByVerificationToken({
+    emailVerificationToken,
+}: FindIdByVerificationTokenParams): Promise<FindIdState> {
+    try {
+        const response = await findIdApi.findId({
+            emailVerificationToken,
+        });
+
+        if (!response.success || !response.data) {
+            return {
+                status: "NOT_FOUND",
+                message: "조회 결과가 없습니다.",
+            };
+        }
+
+        return {
+            status: "FOUND",
+            loginId: response.data.loginId,
+        };
+    } catch {
+        return {
+            status: "ERROR",
+            message: "아이디 조회 중 오류가 발생했습니다.",
+        };
+    }
+}

--- a/src/features/findId/domain/state/FindIdState.ts
+++ b/src/features/findId/domain/state/FindIdState.ts
@@ -1,0 +1,6 @@
+export type FindIdState =
+    | { readonly status: "EMAIL_INPUT" }
+    | { readonly status: "CODE_INPUT" }
+    | { readonly status: "FOUND"; readonly loginId: string }
+    | { readonly status: "NOT_FOUND"; readonly message: string }
+    | { readonly status: "ERROR"; readonly message: string };

--- a/src/features/findId/infrastructure/api/dto/FindIdRequest.ts
+++ b/src/features/findId/infrastructure/api/dto/FindIdRequest.ts
@@ -1,0 +1,3 @@
+export interface FindIdRequest {
+    readonly emailVerificationToken: string;
+}

--- a/src/features/findId/infrastructure/api/dto/FindIdResponseData.ts
+++ b/src/features/findId/infrastructure/api/dto/FindIdResponseData.ts
@@ -1,0 +1,3 @@
+export interface FindIdResponseData {
+    readonly loginId: string;
+}

--- a/src/features/findId/infrastructure/api/findIdApi.ts
+++ b/src/features/findId/infrastructure/api/findIdApi.ts
@@ -1,0 +1,31 @@
+import { httpClient } from "@/infrastructure/http/httpClient";
+import type { FindIdRequest } from "@/features/findId/infrastructure/api/dto/FindIdRequest";
+import type { FindIdResponseData } from "@/features/findId/infrastructure/api/dto/FindIdResponseData";
+
+interface ApiErrorDetail {
+    readonly source: string;
+    readonly field: string;
+    readonly reason: string;
+}
+
+interface ApiError {
+    readonly status: number;
+    readonly code: string;
+    readonly message: string;
+    readonly details: readonly ApiErrorDetail[];
+}
+
+interface FindIdResponse {
+    readonly success: boolean;
+    readonly data: FindIdResponseData | null;
+    readonly error: ApiError | null;
+}
+
+export const findIdApi = {
+    findId(payload: FindIdRequest) {
+        return httpClient.post<FindIdResponse>(
+            "/api/v1/auth/recovery/login-id",
+            payload,
+        );
+    },
+} as const;

--- a/src/features/findId/ui/components/FindIdCodeInput.tsx
+++ b/src/features/findId/ui/components/FindIdCodeInput.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { findIdPageStyles } from "@/ui/styles/findIdPageStyles";
+
+interface FindIdCodeInputProps {
+    readonly code: string;
+    readonly isLoading: boolean;
+    readonly onCodeChange: (code: string) => void;
+    readonly onSubmit: () => void;
+}
+
+export default function FindIdCodeInput({
+    code,
+    isLoading,
+    onCodeChange,
+    onSubmit,
+}: FindIdCodeInputProps) {
+    return (
+        <div className={findIdPageStyles.form}>
+            <p className={findIdPageStyles.description}>
+                이메일로 발송된 인증 코드를 입력하세요
+            </p>
+
+            <label className={findIdPageStyles.label}>인증 코드</label>
+
+            <input
+                type="text"
+                value={code}
+                onChange={(event) => onCodeChange(event.target.value)}
+                className={findIdPageStyles.input}
+            />
+
+            <button
+                type="button"
+                onClick={onSubmit}
+                disabled={isLoading}
+                className={findIdPageStyles.button}
+            >
+                {isLoading ? "확인 중..." : "확인"}
+            </button>
+        </div>
+    );
+}

--- a/src/features/findId/ui/components/FindIdEmailInput.tsx
+++ b/src/features/findId/ui/components/FindIdEmailInput.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { findIdPageStyles } from "@/ui/styles/findIdPageStyles";
+
+interface FindIdEmailInputProps {
+    readonly email: string;
+    readonly isLoading: boolean;
+    readonly onEmailChange: (email: string) => void;
+    readonly onSubmit: () => void;
+}
+
+export default function FindIdEmailInput({
+    email,
+    isLoading,
+    onEmailChange,
+    onSubmit,
+}: FindIdEmailInputProps) {
+    return (
+        <div className={findIdPageStyles.form}>
+            <p className={findIdPageStyles.description}>
+                가입 시 사용한 이메일을 입력하세요
+            </p>
+
+            <label className={findIdPageStyles.label}>이메일</label>
+
+            <input
+                type="email"
+                value={email}
+                onChange={(event) => onEmailChange(event.target.value)}
+                className={findIdPageStyles.input}
+            />
+
+            <button
+                type="button"
+                onClick={onSubmit}
+                disabled={isLoading}
+                className={findIdPageStyles.button}
+            >
+                {isLoading ? "발송 중..." : "아이디 찾기"}
+            </button>
+        </div>
+    );
+}

--- a/src/features/findId/ui/components/FindIdForm.tsx
+++ b/src/features/findId/ui/components/FindIdForm.tsx
@@ -1,22 +1,50 @@
 "use client";
 
-import { findIdPageStyles } from "@/ui/styles/findIdPageStyles";
+import { useAtomValue } from "jotai";
+import { findIdAtom } from "@/features/findId/application/atoms/findIdAtom";
+import { useFindId } from "@/features/findId/application/hooks/useFindId";
+import FindIdEmailInput from "@/features/findId/ui/components/FindIdEmailInput";
+import FindIdCodeInput from "@/features/findId/ui/components/FindIdCodeInput";
+import FindIdResult from "@/features/findId/ui/components/FindIdResult";
 
 export default function FindIdForm() {
-    return (
-        <div className={findIdPageStyles.form}>
-            <label className={findIdPageStyles.label}>이메일</label>
-            <input
-                type="email"
-                className={findIdPageStyles.input}
-            />
+    const state = useAtomValue(findIdAtom);
 
-            <button
-                type="button"
-                className={findIdPageStyles.button}
-            >
-                아이디 찾기
-            </button>
-        </div>
+    const {
+        email,
+        code,
+        isLoading,
+        setEmail,
+        setCode,
+        handleSendCode,
+        handleFindId,
+    } = useFindId();
+
+    if (state.status === "CODE_INPUT") {
+        return (
+            <FindIdCodeInput
+                code={code}
+                isLoading={isLoading}
+                onCodeChange={setCode}
+                onSubmit={handleFindId}
+            />
+        );
+    }
+
+    if (
+        state.status === "FOUND" ||
+        state.status === "NOT_FOUND" ||
+        state.status === "ERROR"
+    ) {
+        return <FindIdResult result={state} />;
+    }
+
+    return (
+        <FindIdEmailInput
+            email={email}
+            isLoading={isLoading}
+            onEmailChange={setEmail}
+            onSubmit={handleSendCode}
+        />
     );
 }

--- a/src/features/findId/ui/components/FindIdForm.tsx
+++ b/src/features/findId/ui/components/FindIdForm.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { findIdPageStyles } from "@/ui/styles/findIdPageStyles";
+
+export default function FindIdForm() {
+    return (
+        <div className={findIdPageStyles.form}>
+            <label className={findIdPageStyles.label}>이메일</label>
+            <input
+                type="email"
+                className={findIdPageStyles.input}
+            />
+
+            <button
+                type="button"
+                className={findIdPageStyles.button}
+            >
+                아이디 찾기
+            </button>
+        </div>
+    );
+}

--- a/src/features/findId/ui/components/FindIdResult.tsx
+++ b/src/features/findId/ui/components/FindIdResult.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import { findIdPageStyles } from "@/ui/styles/findIdPageStyles";
+import type { FindIdState } from "@/features/findId/domain/state/FindIdState";
+
+interface FindIdResultProps {
+    readonly result: FindIdState;
+}
+
+export default function FindIdResult({ result }: FindIdResultProps) {
+    const isFound = result.status === "FOUND";
+
+    const handlePreparePasswordPage = () => {
+        alert("비밀번호 찾기 기능은 준비 중입니다.");
+    };
+
+    return (
+        <div className={findIdPageStyles.resultBox}>
+            {isFound ? (
+                <>
+                    <p className={findIdPageStyles.resultLabel}>
+                        아이디 찾기가 완료되었습니다.
+                    </p>
+                    <p className={findIdPageStyles.resultValue}>
+                        {result.loginId}
+                    </p>
+                </>
+            ) : (
+                <p className={findIdPageStyles.resultLabel}>
+                    조회 결과가 없습니다.
+                </p>
+            )}
+
+            <div className={findIdPageStyles.resultButtonGroup}>
+                <Link href="/login" className={findIdPageStyles.resultButton}>
+                    로그인
+                </Link>
+
+                <button
+                    type="button"
+                    onClick={handlePreparePasswordPage}
+                    className={findIdPageStyles.secondaryResultButton}
+                >
+                    비밀번호 찾기
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/ui/styles/findIdPageStyles.ts
+++ b/src/ui/styles/findIdPageStyles.ts
@@ -1,12 +1,18 @@
 export const findIdPageStyles = {
-    page: "min-h-screen bg-slate-100 flex flex-col items-center justify-center pt-28",
-    brand: "mb-12 flex items-center gap-3 text-2xl font-bold text-slate-800",
-    brandIcon: "text-blue-500",
-    card: "w-full max-w-[560px] min-h-[560px] rounded-xl bg-white px-14 py-12",
-    title: "text-4xl font-bold text-black",
-    description: "mt-3 text-base text-black",
-    form: "mt-28 flex flex-col gap-3",
-    label: "text-base font-semibold text-black",
-    input: "h-14 rounded-xl border border-slate-300 px-4 text-base outline-none focus:border-slate-500",
-    button: "mt-10 h-14 rounded-xl bg-slate-500 text-base font-semibold text-white hover:bg-slate-600",
-};
+    page: "min-h-screen bg-slate-100 flex items-center justify-center px-4",
+    card: "w-full max-w-[560px] min-h-[680px] rounded-2xl bg-white px-14 py-12 shadow-sm",
+    title: "text-4xl font-bold text-slate-950",
+    description: "mt-3 text-base text-slate-700",
+    form: "mt-24 flex flex-col",
+    label: "mb-3 text-base font-semibold text-slate-950",
+    input: "h-14 rounded-xl border border-slate-300 px-4 text-base text-zinc-900 outline-none focus:border-slate-500",
+    button:
+        "mt-10 flex h-14 items-center justify-center rounded-xl bg-slate-500 text-base font-semibold text-white hover:bg-slate-600 disabled:cursor-not-allowed disabled:opacity-50",
+    resultBox: "mt-24 flex flex-col items-center text-center",
+    resultLabel: "text-xl font-semibold text-slate-950",
+    resultValue: "mt-8 text-3xl font-bold text-slate-950",
+    resultButtonGroup: "mt-14 flex w-full flex-col gap-3",
+    resultButton: "flex h-14 items-center justify-center rounded-xl bg-slate-600 text-base font-semibold text-white hover:bg-slate-700",
+    secondaryResultButton:
+        "flex h-14 items-center justify-center rounded-xl border border-slate-300 bg-white text-base font-semibold text-slate-700 hover:bg-slate-50",
+} as const;

--- a/src/ui/styles/findIdPageStyles.ts
+++ b/src/ui/styles/findIdPageStyles.ts
@@ -1,0 +1,12 @@
+export const findIdPageStyles = {
+    page: "min-h-screen bg-slate-100 flex flex-col items-center justify-center pt-28",
+    brand: "mb-12 flex items-center gap-3 text-2xl font-bold text-slate-800",
+    brandIcon: "text-blue-500",
+    card: "w-full max-w-[560px] min-h-[560px] rounded-xl bg-white px-14 py-12",
+    title: "text-4xl font-bold text-black",
+    description: "mt-3 text-base text-black",
+    form: "mt-28 flex flex-col gap-3",
+    label: "text-base font-semibold text-black",
+    input: "h-14 rounded-xl border border-slate-300 px-4 text-base outline-none focus:border-slate-500",
+    button: "mt-10 h-14 rounded-xl bg-slate-500 text-base font-semibold text-white hover:bg-slate-600",
+};


### PR DESCRIPTION
## 관련 이슈
Closes #101 
Closes #102 

## 요약
- 아이디 찾기 페이지 및 단계형 UI 렌더링 구현
- 이메일 입력 → 인증 코드 입력 → 아이디 조회 결과 화면 전환 흐름 추가
- 이메일 인증 및 아이디 조회 API 연동 구현
- findId feature 상태 관리 구조를 Jotai atom 기반으로 정리
- 이메일 입력/인증 코드 입력/조회 결과 UI 컴포넌트 분리 및 스타일 적용

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
