### PR TITLE
[Feat] 비밀번호 찾기 및 재설정 기능 구현

### DIFF
--- a/src/app/auth/find-password/page.tsx
+++ b/src/app/auth/find-password/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSetAtom } from "jotai";
+import ResetPasswordForm from "@/features/resetPassword/ui/components/ResetPasswordForm";
+import {
+    initialResetPasswordState,
+    resetPasswordAtom,
+} from "@/features/resetPassword/application/atoms/resetPasswordAtom";
+import { resetPasswordPageStyles } from "@/ui/styles/resetPasswordPageStyles";
+
+export default function FindPasswordPage() {
+    const setResetPasswordState = useSetAtom(resetPasswordAtom);
+
+    useEffect(() => {
+        setResetPasswordState(initialResetPasswordState);
+    }, [setResetPasswordState]);
+
+    return (
+        <main className={resetPasswordPageStyles.page}>
+            <section className={resetPasswordPageStyles.card}>
+                <h1 className={resetPasswordPageStyles.title}>비밀번호 찾기</h1>
+                <ResetPasswordForm />
+            </section>
+        </main>
+    );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -109,7 +109,7 @@ export default function LoginPage() {
                         아이디 찾기
                     </Link>
                     <span className={loginPageStyles.separator}>|</span>
-                    <Link href="/" className={loginPageStyles.helperLink}>
+                    <Link href="/auth/find-password" className={loginPageStyles.helperLink}>
                         비밀번호 찾기
                     </Link>
                     <span className={loginPageStyles.separator}>|</span>

--- a/src/features/emailVerification/application/usecase/confirmEmailVerification.ts
+++ b/src/features/emailVerification/application/usecase/confirmEmailVerification.ts
@@ -5,6 +5,7 @@ interface ConfirmEmailVerificationParams {
     readonly email: string;
     readonly purpose: EmailVerificationPurpose;
     readonly code: string;
+    readonly loginId?: string;
 }
 
 type ConfirmEmailVerificationResult =
@@ -21,12 +22,14 @@ export async function confirmEmailVerification({
     email,
     purpose,
     code,
+    loginId,
 }: ConfirmEmailVerificationParams): Promise<ConfirmEmailVerificationResult> {
     try {
         const response = await emailVerificationApi.confirmVerificationEmail({
             email,
             purpose,
             code,
+            loginId,
         });
 
         if (!response.success || !response.data.verified) {

--- a/src/features/emailVerification/application/usecase/sendEmailVerification.ts
+++ b/src/features/emailVerification/application/usecase/sendEmailVerification.ts
@@ -4,6 +4,7 @@ import type { EmailVerificationPurpose } from "@/features/emailVerification/doma
 interface SendEmailVerificationParams {
     readonly email: string;
     readonly purpose: EmailVerificationPurpose;
+    readonly loginId?: string;
 }
 
 type SendEmailVerificationResult =
@@ -19,11 +20,13 @@ type SendEmailVerificationResult =
 export async function sendEmailVerification({
     email,
     purpose,
+    loginId,
 }: SendEmailVerificationParams): Promise<SendEmailVerificationResult> {
     try {
         const response = await emailVerificationApi.sendVerificationEmail({
             email,
             purpose,
+            loginId,
         });
 
         if (!response.success) {

--- a/src/features/resetPassword/application/atoms/resetPasswordAtom.ts
+++ b/src/features/resetPassword/application/atoms/resetPasswordAtom.ts
@@ -1,0 +1,10 @@
+import { atom } from "jotai";
+import type { ResetPasswordState } from "@/features/resetPassword/domain/state/ResetPasswordState";
+
+export const initialResetPasswordState: ResetPasswordState = {
+    status: "ACCOUNT_INPUT",
+};
+
+export const resetPasswordAtom = atom<ResetPasswordState>(
+    initialResetPasswordState,
+);

--- a/src/features/resetPassword/application/hooks/useResetPassword.ts
+++ b/src/features/resetPassword/application/hooks/useResetPassword.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+import { resetPasswordAtom } from "@/features/resetPassword/application/atoms/resetPasswordAtom";
+
+export function useResetPassword() {
+    const setResetPasswordState = useSetAtom(resetPasswordAtom);
+
+    const [loginId, setLoginId] = useState("");
+    const [email, setEmail] = useState("");
+    const [code, setCode] = useState("");
+    const [newPassword, setNewPassword] = useState("");
+    const [newPasswordConfirm, setNewPasswordConfirm] = useState("");
+
+    const handleRequestVerification = () => {
+        if (!loginId.trim() || !email.trim()) return;
+
+        setResetPasswordState({
+            status: "CODE_INPUT",
+        });
+    };
+
+    const handleConfirmCode = () => {
+        if (!code.trim()) return;
+
+        setResetPasswordState({
+            status: "PASSWORD_INPUT",
+        });
+    };
+
+    const handleResetPassword = () => {
+        if (!newPassword || !newPasswordConfirm) return;
+        if (newPassword !== newPasswordConfirm) return;
+
+        setResetPasswordState({
+            status: "COMPLETE",
+        });
+    };
+
+    return {
+        loginId,
+        email,
+        code,
+        newPassword,
+        newPasswordConfirm,
+        canRequestVerification: !!loginId.trim() && !!email.trim(),
+        canConfirmCode: !!code.trim(),
+        canResetPassword:
+            !!newPassword &&
+            !!newPasswordConfirm &&
+            newPassword === newPasswordConfirm,
+        setLoginId,
+        setEmail,
+        setCode,
+        setNewPassword,
+        setNewPasswordConfirm,
+        handleRequestVerification,
+        handleConfirmCode,
+        handleResetPassword,
+    };
+}

--- a/src/features/resetPassword/application/hooks/useResetPassword.ts
+++ b/src/features/resetPassword/application/hooks/useResetPassword.ts
@@ -3,6 +3,10 @@
 import { useState } from "react";
 import { useSetAtom } from "jotai";
 import { resetPasswordAtom } from "@/features/resetPassword/application/atoms/resetPasswordAtom";
+import { requestPasswordVerification } from "@/features/resetPassword/application/usecase/requestPasswordVerification";
+import { confirmPasswordVerification } from "@/features/resetPassword/application/usecase/confirmPasswordVerification";
+import { resetPassword } from "@/features/resetPassword/application/usecase/resetPassword";
+import { validateResetPassword } from "@/features/resetPassword/domain/validator/validateResetPassword";
 
 export function useResetPassword() {
     const setResetPasswordState = useSetAtom(resetPasswordAtom);
@@ -13,25 +17,101 @@ export function useResetPassword() {
     const [newPassword, setNewPassword] = useState("");
     const [newPasswordConfirm, setNewPasswordConfirm] = useState("");
 
-    const handleRequestVerification = () => {
-        if (!loginId.trim() || !email.trim()) return;
+    const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
+    const [message, setMessage] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const passwordValidationResult = validateResetPassword(newPassword);
+
+    const passwordMessage =
+        passwordValidationResult.success ? "" : passwordValidationResult.message;
+
+    const isPasswordValid = passwordValidationResult.success;
+
+    const isPasswordConfirmMatched =
+        !!newPasswordConfirm && newPassword === newPasswordConfirm;
+
+    const handleExpired = () => {
+        setMessage("인증 시간이 만료되었습니다. 다시 시도해주세요.");
+    };
+
+    const handleRequestVerification = async () => {
+        setIsLoading(true);
+        setMessage(null);
+
+        const result = await requestPasswordVerification({
+            loginId,
+            email,
+        });
+
+        setIsLoading(false);
+
+        if (!result.success) {
+            setMessage(result.message);
+            return;
+        }
+
+        setRemainingSeconds(300);
 
         setResetPasswordState({
             status: "CODE_INPUT",
         });
     };
 
-    const handleConfirmCode = () => {
-        if (!code.trim()) return;
+    const handleConfirmCode = async () => {
+        if (remainingSeconds === 0) {
+            setMessage("인증 시간이 만료되었습니다. 다시 시도해주세요.");
+            return;
+        }
+
+        setIsLoading(true);
+        setMessage(null);
+
+        const result = await confirmPasswordVerification({
+            loginId,
+            email,
+            code,
+        });
+
+        setIsLoading(false);
+
+        if (!result.success) {
+            setMessage(result.message);
+            return;
+        }
+
+        setRemainingSeconds(null);
 
         setResetPasswordState({
             status: "PASSWORD_INPUT",
         });
     };
 
-    const handleResetPassword = () => {
-        if (!newPassword || !newPasswordConfirm) return;
-        if (newPassword !== newPasswordConfirm) return;
+    const handleResetPassword = async () => {
+        if (!isPasswordValid) {
+            setMessage(passwordMessage);
+            return;
+        }
+
+        if (!isPasswordConfirmMatched) {
+            setMessage("비밀번호가 일치하지 않습니다.");
+            return;
+        }
+
+        setIsLoading(true);
+        setMessage(null);
+
+        const result = await resetPassword({
+            newPassword,
+            newPasswordConfirm,
+        });
+
+        setIsLoading(false);
+
+        if (!result.success) {
+            setMessage(result.message);
+            return;
+        }
 
         setResetPasswordState({
             status: "COMPLETE",
@@ -44,17 +124,21 @@ export function useResetPassword() {
         code,
         newPassword,
         newPasswordConfirm,
+        remainingSeconds,
+        message,
+        passwordMessage,
+        isPasswordValid,
+        isLoading,
         canRequestVerification: !!loginId.trim() && !!email.trim(),
-        canConfirmCode: !!code.trim(),
-        canResetPassword:
-            !!newPassword &&
-            !!newPasswordConfirm &&
-            newPassword === newPasswordConfirm,
+        canConfirmCode: !!code.trim() && remainingSeconds !== 0,
+        canResetPassword: isPasswordValid && isPasswordConfirmMatched,
         setLoginId,
         setEmail,
         setCode,
         setNewPassword,
         setNewPasswordConfirm,
+        setRemainingSeconds,
+        handleExpired,
         handleRequestVerification,
         handleConfirmCode,
         handleResetPassword,

--- a/src/features/resetPassword/application/usecase/confirmPasswordVerification.ts
+++ b/src/features/resetPassword/application/usecase/confirmPasswordVerification.ts
@@ -1,0 +1,44 @@
+import { confirmEmailVerification } from "@/features/emailVerification/application/usecase/confirmEmailVerification";
+import { resetPasswordStorage } from "@/features/resetPassword/infrastructure/storage/resetPasswordStorage";
+
+interface ConfirmPasswordVerificationParams {
+    readonly loginId: string;
+    readonly email: string;
+    readonly code: string;
+}
+
+type ConfirmPasswordVerificationResult =
+    | { readonly success: true; readonly emailVerificationToken: string }
+    | { readonly success: false; readonly message: string };
+
+export async function confirmPasswordVerification({
+    loginId,
+    email,
+    code,
+}: ConfirmPasswordVerificationParams): Promise<ConfirmPasswordVerificationResult> {
+    if (!code.trim()) {
+        return {
+            success: false,
+            message: "인증 코드를 입력해주세요.",
+        };
+    }
+
+    const result = await confirmEmailVerification({
+        email: email.trim(),
+        loginId: loginId.trim(),
+        code: code.trim(),
+        purpose: "RESET_PASSWORD",
+    });
+
+    if (!result.success) {
+        return result;
+    }
+
+    resetPasswordStorage.save({
+        loginId: loginId.trim(),
+        email: email.trim(),
+        emailVerificationToken: result.emailVerificationToken,
+    });
+
+    return result;
+}

--- a/src/features/resetPassword/application/usecase/requestPasswordVerification.ts
+++ b/src/features/resetPassword/application/usecase/requestPasswordVerification.ts
@@ -1,0 +1,36 @@
+import { sendEmailVerification } from "@/features/emailVerification/application/usecase/sendEmailVerification";
+
+interface RequestPasswordVerificationParams {
+    readonly loginId: string;
+    readonly email: string;
+}
+
+type RequestPasswordVerificationResult =
+    | { readonly success: true }
+    | { readonly success: false; readonly message: string };
+
+export async function requestPasswordVerification({
+    loginId,
+    email,
+}: RequestPasswordVerificationParams): Promise<RequestPasswordVerificationResult> {
+    if (!loginId.trim() || !email.trim()) {
+        return {
+            success: false,
+            message: "아이디와 이메일을 입력해주세요.",
+        };
+    }
+
+    const result = await sendEmailVerification({
+        email: email.trim(),
+        loginId: loginId.trim(),
+        purpose: "RESET_PASSWORD",
+    });
+
+    if (!result.success) {
+        return result;
+    }
+
+    return {
+        success: true,
+    };
+}

--- a/src/features/resetPassword/application/usecase/resetPassword.ts
+++ b/src/features/resetPassword/application/usecase/resetPassword.ts
@@ -1,0 +1,65 @@
+import { resetPasswordApi } from "@/features/resetPassword/infrastructure/api/resetPasswordApi";
+import { resetPasswordStorage } from "@/features/resetPassword/infrastructure/storage/resetPasswordStorage";
+
+interface ResetPasswordParams {
+    readonly newPassword: string;
+    readonly newPasswordConfirm: string;
+}
+
+type ResetPasswordResult =
+    | { readonly success: true }
+    | { readonly success: false; readonly message: string };
+
+export async function resetPassword({
+    newPassword,
+    newPasswordConfirm,
+}: ResetPasswordParams): Promise<ResetPasswordResult> {
+    if (!newPassword || !newPasswordConfirm) {
+        return {
+            success: false,
+            message: "새 비밀번호를 입력해주세요.",
+        };
+    }
+
+    if (newPassword !== newPasswordConfirm) {
+        return {
+            success: false,
+            message: "비밀번호가 일치하지 않습니다.",
+        };
+    }
+
+    const savedData = resetPasswordStorage.load();
+
+    if (!savedData) {
+        return {
+            success: false,
+            message: "이메일 인증 정보가 없습니다. 다시 인증해주세요.",
+        };
+    }
+
+    try {
+        const response = await resetPasswordApi.resetPassword({
+            loginId: savedData.loginId,
+            emailVerificationToken: savedData.emailVerificationToken,
+            newPassword,
+        });
+
+        if (!response.success || !response.data?.reset) {
+            return {
+                success: false,
+                message: response.error?.message || "비밀번호 변경에 실패했습니다.",
+            };
+        }
+
+        resetPasswordStorage.clear();
+
+        return {
+            success: true,
+        };
+    } catch {
+        return {
+            success: false,
+            message: "비밀번호 변경에 실패했습니다.",
+        };
+    }
+}

--- a/src/features/resetPassword/domain/state/ResetPasswordState.ts
+++ b/src/features/resetPassword/domain/state/ResetPasswordState.ts
@@ -1,0 +1,5 @@
+export type ResetPasswordState =
+    | { readonly status: "ACCOUNT_INPUT" }
+    | { readonly status: "CODE_INPUT" }
+    | { readonly status: "PASSWORD_INPUT" }
+    | { readonly status: "COMPLETE" };

--- a/src/features/resetPassword/domain/validator/validateResetPassword.ts
+++ b/src/features/resetPassword/domain/validator/validateResetPassword.ts
@@ -1,0 +1,47 @@
+const PASSWORD_MIN = 8;
+const PASSWORD_MAX = 100;
+
+const PASSWORD_REGEX =
+    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).+$/;
+
+const WHITESPACE_REGEX = /\s/;
+
+type ValidateResetPasswordResult =
+    | { readonly success: true }
+    | { readonly success: false; readonly message: string };
+
+export function validateResetPassword(
+    password: string,
+): ValidateResetPasswordResult {
+    if (!password) {
+        return {
+            success: false,
+            message: "",
+        };
+    }
+
+    if (WHITESPACE_REGEX.test(password)) {
+        return {
+            success: false,
+            message: "비밀번호에는 공백을 사용할 수 없습니다.",
+        };
+    }
+
+    if (password.length < PASSWORD_MIN || password.length > PASSWORD_MAX) {
+        return {
+            success: false,
+            message: "비밀번호는 8자 이상 100자 이하로 입력해주세요.",
+        };
+    }
+
+    if (!PASSWORD_REGEX.test(password)) {
+        return {
+            success: false,
+            message: "비밀번호는 문자, 숫자, 특수문자를 각각 1개 이상 포함해야 합니다.",
+        };
+    }
+
+    return {
+        success: true,
+    };
+}

--- a/src/features/resetPassword/infrastructure/api/dto/ResetPasswordRequest.ts
+++ b/src/features/resetPassword/infrastructure/api/dto/ResetPasswordRequest.ts
@@ -1,0 +1,5 @@
+export interface ResetPasswordRequest {
+    readonly loginId: string;
+    readonly emailVerificationToken: string;
+    readonly newPassword: string;
+}

--- a/src/features/resetPassword/infrastructure/api/dto/ResetPasswordResponse.ts
+++ b/src/features/resetPassword/infrastructure/api/dto/ResetPasswordResponse.ts
@@ -1,0 +1,22 @@
+interface ApiErrorDetail {
+    readonly source: string;
+    readonly field: string;
+    readonly reason: string;
+}
+
+interface ApiError {
+    readonly status: number;
+    readonly code: string;
+    readonly message: string;
+    readonly details?: readonly ApiErrorDetail[];
+}
+
+interface ResetPasswordData {
+    readonly reset: boolean;
+}
+
+export interface ResetPasswordResponse {
+    readonly success: boolean;
+    readonly data: ResetPasswordData | null;
+    readonly error: ApiError | null;
+}

--- a/src/features/resetPassword/infrastructure/api/resetPasswordApi.ts
+++ b/src/features/resetPassword/infrastructure/api/resetPasswordApi.ts
@@ -1,0 +1,12 @@
+import { httpClient } from "@/infrastructure/http/httpClient";
+import type { ResetPasswordRequest } from "@/features/resetPassword/infrastructure/api/dto/ResetPasswordRequest";
+import type { ResetPasswordResponse } from "@/features/resetPassword/infrastructure/api/dto/ResetPasswordResponse";
+
+export const resetPasswordApi = {
+    resetPassword(payload: ResetPasswordRequest) {
+        return httpClient.post<ResetPasswordResponse>(
+            "/api/v1/auth/recovery/password",
+            payload,
+        );
+    },
+} as const;

--- a/src/features/resetPassword/infrastructure/storage/resetPasswordStorage.ts
+++ b/src/features/resetPassword/infrastructure/storage/resetPasswordStorage.ts
@@ -1,0 +1,22 @@
+const KEY = "reset_password_account";
+
+export interface ResetPasswordData {
+    readonly loginId: string;
+    readonly email: string;
+    readonly emailVerificationToken: string;
+}
+
+export const resetPasswordStorage = {
+    save: (data: ResetPasswordData) => {
+        sessionStorage.setItem(KEY, JSON.stringify(data));
+    },
+
+    load: (): ResetPasswordData | null => {
+        const data = sessionStorage.getItem(KEY);
+        return data ? JSON.parse(data) : null;
+    },
+
+    clear: () => {
+        sessionStorage.removeItem(KEY);
+    },
+};

--- a/src/features/resetPassword/ui/components/ResetPasswordAccountInput.tsx
+++ b/src/features/resetPassword/ui/components/ResetPasswordAccountInput.tsx
@@ -5,6 +5,8 @@ import { resetPasswordPageStyles } from "@/ui/styles/resetPasswordPageStyles";
 interface ResetPasswordAccountInputProps {
     readonly loginId: string;
     readonly email: string;
+    readonly message: string | null;
+    readonly isLoading: boolean;
     readonly canRequestVerification: boolean;
     readonly setLoginId: (loginId: string) => void;
     readonly setEmail: (email: string) => void;
@@ -14,6 +16,8 @@ interface ResetPasswordAccountInputProps {
 export default function ResetPasswordAccountInput({
     loginId,
     email,
+    message,
+    isLoading,
     canRequestVerification,
     setLoginId,
     setEmail,
@@ -25,7 +29,9 @@ export default function ResetPasswordAccountInput({
                 가입한 아이디와 이메일을 입력하세요
             </p>
 
-            <label className={resetPasswordPageStyles.label}>아이디</label>
+            <label className={`${resetPasswordPageStyles.label} mt-8`}>
+                아이디
+            </label>
             <input
                 type="text"
                 value={loginId}
@@ -41,13 +47,17 @@ export default function ResetPasswordAccountInput({
                 className={resetPasswordPageStyles.input}
             />
 
+            {message && (
+                <p className={resetPasswordPageStyles.message}>{message}</p>
+            )}
+
             <button
                 type="button"
                 onClick={handleRequestVerification}
-                disabled={!canRequestVerification}
+                disabled={!canRequestVerification || isLoading}
                 className={resetPasswordPageStyles.button}
             >
-                비밀번호 찾기
+                {isLoading ? "발송 중..." : "비밀번호 찾기"}
             </button>
         </div>
     );

--- a/src/features/resetPassword/ui/components/ResetPasswordAccountInput.tsx
+++ b/src/features/resetPassword/ui/components/ResetPasswordAccountInput.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { resetPasswordPageStyles } from "@/ui/styles/resetPasswordPageStyles";
+
+interface ResetPasswordAccountInputProps {
+    readonly loginId: string;
+    readonly email: string;
+    readonly canRequestVerification: boolean;
+    readonly setLoginId: (loginId: string) => void;
+    readonly setEmail: (email: string) => void;
+    readonly handleRequestVerification: () => void;
+}
+
+export default function ResetPasswordAccountInput({
+    loginId,
+    email,
+    canRequestVerification,
+    setLoginId,
+    setEmail,
+    handleRequestVerification,
+}: ResetPasswordAccountInputProps) {
+    return (
+        <div className={resetPasswordPageStyles.form}>
+            <p className={resetPasswordPageStyles.description}>
+                가입한 아이디와 이메일을 입력하세요
+            </p>
+
+            <label className={resetPasswordPageStyles.label}>아이디</label>
+            <input
+                type="text"
+                value={loginId}
+                onChange={(event) => setLoginId(event.target.value)}
+                className={resetPasswordPageStyles.input}
+            />
+
+            <label className={resetPasswordPageStyles.label}>이메일</label>
+            <input
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className={resetPasswordPageStyles.input}
+            />
+
+            <button
+                type="button"
+                onClick={handleRequestVerification}
+                disabled={!canRequestVerification}
+                className={resetPasswordPageStyles.button}
+            >
+                비밀번호 찾기
+            </button>
+        </div>
+    );
+}

--- a/src/features/resetPassword/ui/components/ResetPasswordCodeInput.tsx
+++ b/src/features/resetPassword/ui/components/ResetPasswordCodeInput.tsx
@@ -4,6 +4,9 @@ import { resetPasswordPageStyles } from "@/ui/styles/resetPasswordPageStyles";
 
 interface ResetPasswordCodeInputProps {
     readonly code: string;
+    readonly remainingSeconds: number | null;
+    readonly message: string | null;
+    readonly isLoading: boolean;
     readonly canConfirmCode: boolean;
     readonly setCode: (code: string) => void;
     readonly handleConfirmCode: () => void;
@@ -11,17 +14,30 @@ interface ResetPasswordCodeInputProps {
 
 export default function ResetPasswordCodeInput({
     code,
+    remainingSeconds,
+    message,
+    isLoading,
     canConfirmCode,
     setCode,
     handleConfirmCode,
 }: ResetPasswordCodeInputProps) {
+    const formatSeconds = (seconds: number) => {
+        const minutes = Math.floor(seconds / 60);
+        const remaining = seconds % 60;
+
+        return `${minutes}:${remaining.toString().padStart(2, "0")}`;
+    };
+
     return (
         <div className={resetPasswordPageStyles.form}>
             <p className={resetPasswordPageStyles.description}>
                 이메일로 발송된 인증 코드를 입력하세요
             </p>
 
-            <label className={resetPasswordPageStyles.label}>인증 코드</label>
+            <label className={`${resetPasswordPageStyles.label} mt-8`}>
+                인증 코드
+            </label>
+
             <input
                 type="text"
                 value={code}
@@ -29,17 +45,23 @@ export default function ResetPasswordCodeInput({
                 className={resetPasswordPageStyles.input}
             />
 
-            <p className={resetPasswordPageStyles.timerText}>
-                인증 유효시간 5:00
-            </p>
+            {remainingSeconds !== null && (
+                <p className={resetPasswordPageStyles.timerText}>
+                    인증 유효시간 {formatSeconds(remainingSeconds)}
+                </p>
+            )}
+
+            {message && (
+                <p className={resetPasswordPageStyles.message}>{message}</p>
+            )}
 
             <button
                 type="button"
                 onClick={handleConfirmCode}
-                disabled={!canConfirmCode}
+                disabled={!canConfirmCode || isLoading}
                 className={resetPasswordPageStyles.button}
             >
-                확인
+                {isLoading ? "확인 중..." : "확인"}
             </button>
         </div>
     );

--- a/src/features/resetPassword/ui/components/ResetPasswordCodeInput.tsx
+++ b/src/features/resetPassword/ui/components/ResetPasswordCodeInput.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { resetPasswordPageStyles } from "@/ui/styles/resetPasswordPageStyles";
+
+interface ResetPasswordCodeInputProps {
+    readonly code: string;
+    readonly canConfirmCode: boolean;
+    readonly setCode: (code: string) => void;
+    readonly handleConfirmCode: () => void;
+}
+
+export default function ResetPasswordCodeInput({
+    code,
+    canConfirmCode,
+    setCode,
+    handleConfirmCode,
+}: ResetPasswordCodeInputProps) {
+    return (
+        <div className={resetPasswordPageStyles.form}>
+            <p className={resetPasswordPageStyles.description}>
+                이메일로 발송된 인증 코드를 입력하세요
+            </p>
+
+            <label className={resetPasswordPageStyles.label}>인증 코드</label>
+            <input
+                type="text"
+                value={code}
+                onChange={(event) => setCode(event.target.value)}
+                className={resetPasswordPageStyles.input}
+            />
+
+            <p className={resetPasswordPageStyles.timerText}>
+                인증 유효시간 5:00
+            </p>
+
+            <button
+                type="button"
+                onClick={handleConfirmCode}
+                disabled={!canConfirmCode}
+                className={resetPasswordPageStyles.button}
+            >
+                확인
+            </button>
+        </div>
+    );
+}

--- a/src/features/resetPassword/ui/components/ResetPasswordComplete.tsx
+++ b/src/features/resetPassword/ui/components/ResetPasswordComplete.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Link from "next/link";
+import { resetPasswordPageStyles } from "@/ui/styles/resetPasswordPageStyles";
+
+export default function ResetPasswordComplete() {
+    return (
+        <div className={resetPasswordPageStyles.resultBox}>
+            <p className={resetPasswordPageStyles.resultLabel}>
+                비밀번호 변경이 완료되었습니다.
+            </p>
+
+            <Link href="/login" className={resetPasswordPageStyles.resultButton}>
+                로그인 화면으로 이동
+            </Link>
+        </div>
+    );
+}

--- a/src/features/resetPassword/ui/components/ResetPasswordForm.tsx
+++ b/src/features/resetPassword/ui/components/ResetPasswordForm.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useAtomValue } from "jotai";
+import { resetPasswordAtom } from "@/features/resetPassword/application/atoms/resetPasswordAtom";
+import { useResetPassword } from "@/features/resetPassword/application/hooks/useResetPassword";
+import ResetPasswordAccountInput from "@/features/resetPassword/ui/components/ResetPasswordAccountInput";
+import ResetPasswordCodeInput from "@/features/resetPassword/ui/components/ResetPasswordCodeInput";
+import ResetPasswordNewPasswordInput from "@/features/resetPassword/ui/components/ResetPasswordNewPasswordInput";
+import ResetPasswordComplete from "@/features/resetPassword/ui/components/ResetPasswordComplete";
+
+export default function ResetPasswordForm() {
+    const state = useAtomValue(resetPasswordAtom);
+    const resetPassword = useResetPassword();
+
+    if (state.status === "CODE_INPUT") {
+        return <ResetPasswordCodeInput {...resetPassword} />;
+    }
+
+    if (state.status === "PASSWORD_INPUT") {
+        return <ResetPasswordNewPasswordInput {...resetPassword} />;
+    }
+
+    if (state.status === "COMPLETE") {
+        return <ResetPasswordComplete />;
+    }
+
+    return <ResetPasswordAccountInput {...resetPassword} />;
+}

--- a/src/features/resetPassword/ui/components/ResetPasswordForm.tsx
+++ b/src/features/resetPassword/ui/components/ResetPasswordForm.tsx
@@ -3,6 +3,7 @@
 import { useAtomValue } from "jotai";
 import { resetPasswordAtom } from "@/features/resetPassword/application/atoms/resetPasswordAtom";
 import { useResetPassword } from "@/features/resetPassword/application/hooks/useResetPassword";
+import { useVerificationExpireTimer } from "@/features/emailVerification/application/hooks/useVerificationExpireTimer";
 import ResetPasswordAccountInput from "@/features/resetPassword/ui/components/ResetPasswordAccountInput";
 import ResetPasswordCodeInput from "@/features/resetPassword/ui/components/ResetPasswordCodeInput";
 import ResetPasswordNewPasswordInput from "@/features/resetPassword/ui/components/ResetPasswordNewPasswordInput";
@@ -11,6 +12,12 @@ import ResetPasswordComplete from "@/features/resetPassword/ui/components/ResetP
 export default function ResetPasswordForm() {
     const state = useAtomValue(resetPasswordAtom);
     const resetPassword = useResetPassword();
+
+    useVerificationExpireTimer({
+        remainingSeconds: resetPassword.remainingSeconds,
+        setRemainingSeconds: resetPassword.setRemainingSeconds,
+        onExpired: resetPassword.handleExpired,
+    });
 
     if (state.status === "CODE_INPUT") {
         return <ResetPasswordCodeInput {...resetPassword} />;

--- a/src/features/resetPassword/ui/components/ResetPasswordNewPasswordInput.tsx
+++ b/src/features/resetPassword/ui/components/ResetPasswordNewPasswordInput.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { resetPasswordPageStyles } from "@/ui/styles/resetPasswordPageStyles";
+
+interface ResetPasswordNewPasswordInputProps {
+    readonly newPassword: string;
+    readonly newPasswordConfirm: string;
+    readonly canResetPassword: boolean;
+    readonly setNewPassword: (password: string) => void;
+    readonly setNewPasswordConfirm: (password: string) => void;
+    readonly handleResetPassword: () => void;
+}
+
+export default function ResetPasswordNewPasswordInput({
+    newPassword,
+    newPasswordConfirm,
+    canResetPassword,
+    setNewPassword,
+    setNewPasswordConfirm,
+    handleResetPassword,
+}: ResetPasswordNewPasswordInputProps) {
+    return (
+        <div className={resetPasswordPageStyles.form}>
+            <p className={resetPasswordPageStyles.description}>
+                새 비밀번호를 입력하세요
+            </p>
+
+            <label className={resetPasswordPageStyles.label}>새 비밀번호</label>
+            <input
+                type="password"
+                value={newPassword}
+                onChange={(event) => setNewPassword(event.target.value)}
+                className={resetPasswordPageStyles.input}
+            />
+
+            <label className={resetPasswordPageStyles.label}>
+                새 비밀번호 확인
+            </label>
+            <input
+                type="password"
+                value={newPasswordConfirm}
+                onChange={(event) => setNewPasswordConfirm(event.target.value)}
+                className={resetPasswordPageStyles.input}
+            />
+
+            <button
+                type="button"
+                onClick={handleResetPassword}
+                disabled={!canResetPassword}
+                className={resetPasswordPageStyles.button}
+            >
+                확인
+            </button>
+        </div>
+    );
+}

--- a/src/features/resetPassword/ui/components/ResetPasswordNewPasswordInput.tsx
+++ b/src/features/resetPassword/ui/components/ResetPasswordNewPasswordInput.tsx
@@ -5,6 +5,9 @@ import { resetPasswordPageStyles } from "@/ui/styles/resetPasswordPageStyles";
 interface ResetPasswordNewPasswordInputProps {
     readonly newPassword: string;
     readonly newPasswordConfirm: string;
+    readonly message: string | null;
+    readonly passwordMessage: string;
+    readonly isLoading: boolean;
     readonly canResetPassword: boolean;
     readonly setNewPassword: (password: string) => void;
     readonly setNewPasswordConfirm: (password: string) => void;
@@ -14,18 +17,28 @@ interface ResetPasswordNewPasswordInputProps {
 export default function ResetPasswordNewPasswordInput({
     newPassword,
     newPasswordConfirm,
+    message,
+    passwordMessage,
+    isLoading,
     canResetPassword,
     setNewPassword,
     setNewPasswordConfirm,
     handleResetPassword,
 }: ResetPasswordNewPasswordInputProps) {
+    const passwordConfirmMessage =
+        newPasswordConfirm && newPassword !== newPasswordConfirm
+            ? "비밀번호가 일치하지 않습니다."
+            : "";
+
     return (
         <div className={resetPasswordPageStyles.form}>
             <p className={resetPasswordPageStyles.description}>
                 새 비밀번호를 입력하세요
             </p>
 
-            <label className={resetPasswordPageStyles.label}>새 비밀번호</label>
+            <label className={`${resetPasswordPageStyles.label} mt-8`}>
+                새 비밀번호
+            </label>
             <input
                 type="password"
                 value={newPassword}
@@ -33,23 +46,41 @@ export default function ResetPasswordNewPasswordInput({
                 className={resetPasswordPageStyles.input}
             />
 
-            <label className={resetPasswordPageStyles.label}>
+            {passwordMessage && (
+                <p className={resetPasswordPageStyles.message}>
+                    {passwordMessage}
+                </p>
+            )}
+
+            <label className={`${resetPasswordPageStyles.label} mt-6`}>
                 새 비밀번호 확인
             </label>
             <input
                 type="password"
                 value={newPasswordConfirm}
-                onChange={(event) => setNewPasswordConfirm(event.target.value)}
+                onChange={(event) =>
+                    setNewPasswordConfirm(event.target.value)
+                }
                 className={resetPasswordPageStyles.input}
             />
+
+            {passwordConfirmMessage && (
+                <p className={resetPasswordPageStyles.message}>
+                    {passwordConfirmMessage}
+                </p>
+            )}
+
+            {message && (
+                <p className={resetPasswordPageStyles.message}>{message}</p>
+            )}
 
             <button
                 type="button"
                 onClick={handleResetPassword}
-                disabled={!canResetPassword}
+                disabled={!canResetPassword || isLoading}
                 className={resetPasswordPageStyles.button}
             >
-                확인
+                {isLoading ? "변경 중..." : "확인"}
             </button>
         </div>
     );

--- a/src/ui/styles/resetPasswordPageStyles.ts
+++ b/src/ui/styles/resetPasswordPageStyles.ts
@@ -1,0 +1,15 @@
+export const resetPasswordPageStyles = {
+    page: "min-h-screen bg-slate-100 flex items-center justify-center px-4",
+    card: "w-full max-w-[560px] min-h-[680px] rounded-2xl bg-white px-14 py-12 shadow-sm",
+    title: "text-4xl font-bold text-slate-950",
+    description: "mt-1 text-base text-slate-700",
+    form: "mt-4 flex flex-col",
+    label: "mt-12 mb-3 text-base font-semibold text-slate-950",
+    input: "mb-6 h-14 rounded-xl border border-slate-300 px-4 text-base text-zinc-800 outline-none focus:border-slate-500",
+    button:
+        "mt-4 flex h-14 items-center justify-center rounded-xl bg-slate-500 text-base font-semibold text-white hover:bg-slate-600 disabled:cursor-not-allowed disabled:opacity-50",
+    timerText: "text-sm text-slate-500",
+    resultBox: "mt-24 flex flex-col items-center text-center",
+    resultLabel: "text-xl font-medium text-slate-950",
+    resultButton: "mt-14 flex h-14 w-full items-center justify-center rounded-xl bg-slate-600 text-base font-semibold text-white hover:bg-slate-700",
+} as const;

--- a/src/ui/styles/resetPasswordPageStyles.ts
+++ b/src/ui/styles/resetPasswordPageStyles.ts
@@ -9,6 +9,7 @@ export const resetPasswordPageStyles = {
     button:
         "mt-4 flex h-14 items-center justify-center rounded-xl bg-slate-500 text-base font-semibold text-white hover:bg-slate-600 disabled:cursor-not-allowed disabled:opacity-50",
     timerText: "text-sm text-slate-500",
+    message: "mt-2 text-sm text-red-500",
     resultBox: "mt-24 flex flex-col items-center text-center",
     resultLabel: "text-xl font-medium text-slate-950",
     resultButton: "mt-14 flex h-14 w-full items-center justify-center rounded-xl bg-slate-600 text-base font-semibold text-white hover:bg-slate-700",


### PR DESCRIPTION
## 관련 이슈
Closes #103 
Closes #104 

## 요약
- 비밀번호 찾기 및 재설정 화면 렌더링 구현
- 이메일 인증 기반 비밀번호 재설정 API 연동
- 인증 코드 유효시간 타이머 및 단계별 화면 전환 처리
- 비밀번호 유효성 검증 및 재설정 완료 흐름 추가

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
