### PR TITLE
[Feat] 개인 메뉴 추천 메인 화면 UI 렌더링 (#109)

### DIFF
--- a/src/app/personal-recommendation/page.tsx
+++ b/src/app/personal-recommendation/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommendationPageStyles";
+import PersonalRecommendationHero from "@/features/personalRecommendation/ui/components/PersonalRecommendationHero";
+import PersonalRecommendationLocationCard from "@/features/personalRecommendation/ui/components/PersonalRecommendationLocationCard";
+import PersonalRecommendationPreferenceCard from "@/features/personalRecommendation/ui/components/PersonalRecommendationPreferenceCard";
+import PersonalRecommendationHistoryPanel from "@/features/personalRecommendation/ui/components/PersonalRecommendationHistoryPanel";
+import {
+    personalRecommendationLocationMock,
+    personalRecommendationHistoryMock,
+} from "@/features/personalRecommendation/ui/config/personalRecommendationMockData";
+
+export default function PersonalRecommendationPage() {
+    return (
+        <main className={personalRecommendationPageStyles.container}>
+            <div className={personalRecommendationPageStyles.content}>
+                <header className={personalRecommendationPageStyles.header}>
+                    <h1 className={personalRecommendationPageStyles.title}>
+                        개인 메뉴 추천
+                    </h1>
+                    <p className={personalRecommendationPageStyles.description}>
+                        당신의 맞춤형 메뉴를 탐색해보세요!
+                    </p>
+                </header>
+
+                <div className={personalRecommendationPageStyles.layout}>
+                    <div className={personalRecommendationPageStyles.mainColumn}>
+                        <PersonalRecommendationHero />
+
+                        <div className={personalRecommendationPageStyles.cardGrid}>
+                            <PersonalRecommendationLocationCard
+                                address={personalRecommendationLocationMock.address}
+                            />
+
+                            <PersonalRecommendationPreferenceCard />
+                        </div>
+                    </div>
+
+                    <PersonalRecommendationHistoryPanel
+                        histories={personalRecommendationHistoryMock}
+                    />
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationHero.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationHero.tsx
@@ -1,0 +1,23 @@
+import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommendationPageStyles";
+
+export default function PersonalRecommendationHero() {
+    return (
+        <section className={personalRecommendationPageStyles.heroCard}>
+            <div>
+                <h2 className={personalRecommendationPageStyles.heroTitle}>
+                    당신의 완벽한 한 끼를 찾아보세요.
+                </h2>
+                <p className={personalRecommendationPageStyles.heroDescription}>
+                    설정한 취향과 현재 위치를 기반으로 최적화된 미식 경험을 제안합니다.
+                </p>
+            </div>
+
+            <button
+                type="button"
+                className={personalRecommendationPageStyles.primaryButton}
+            >
+                메뉴 추천 시작하기
+            </button>
+        </section>
+    );
+}

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationHistoryPanel.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationHistoryPanel.tsx
@@ -1,0 +1,42 @@
+import { Clock3 } from "lucide-react";
+import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommendationPageStyles";
+
+interface PersonalRecommendationHistory {
+    readonly id: number;
+    readonly recommendedDate: string;
+}
+
+interface PersonalRecommendationHistoryPanelProps {
+    readonly histories: readonly PersonalRecommendationHistory[];
+}
+
+export default function PersonalRecommendationHistoryPanel({
+    histories,
+}: PersonalRecommendationHistoryPanelProps) {
+    const hasHistories = histories.length > 0;
+
+    return (
+        <aside className={personalRecommendationPageStyles.historyPanel}>
+            {hasHistories ? (
+                <div className={personalRecommendationPageStyles.historyList}>
+                    {histories.map((history) => (
+                        <button
+                            key={history.id}
+                            type="button"
+                            className={personalRecommendationPageStyles.historyItem}
+                        >
+                            {history.recommendedDate}
+                        </button>
+                    ))}
+                </div>
+            ) : (
+                <div className={personalRecommendationPageStyles.emptyHistory}>
+                    <div className={personalRecommendationPageStyles.emptyIconBox}>
+                        <Clock3 size={34} />
+                    </div>
+                    <p>기록이 없습니다.</p>
+                </div>
+            )}
+        </aside>
+    );
+}

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationLocationCard.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationLocationCard.tsx
@@ -1,0 +1,34 @@
+import { MapPin } from "lucide-react";
+import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommendationPageStyles";
+
+interface PersonalRecommendationLocationCardProps {
+    readonly address?: string;
+}
+
+export default function PersonalRecommendationLocationCard({
+    address,
+}: PersonalRecommendationLocationCardProps) {
+    return (
+        <section className={personalRecommendationPageStyles.locationCard}>
+            <div className={personalRecommendationPageStyles.iconBox}>
+                <MapPin size={22} />
+            </div>
+
+            <div className={personalRecommendationPageStyles.cardTextGroup}>
+                <h3 className={personalRecommendationPageStyles.cardTitle}>
+                    현재 위치
+                </h3>
+                <p className={personalRecommendationPageStyles.cardDescription}>
+                    {address ?? "설정된 위치가 없습니다."}
+                </p>
+            </div>
+
+            <button
+                type="button"
+                className={personalRecommendationPageStyles.smallButton}
+            >
+                위치 수정하기
+            </button>
+        </section>
+    );
+}

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationPreferenceCard.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationPreferenceCard.tsx
@@ -1,0 +1,25 @@
+import { Heart } from "lucide-react";
+import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommendationPageStyles";
+
+export default function PersonalRecommendationPreferenceCard() {
+    return (
+        <section className={personalRecommendationPageStyles.preferenceCard}>
+            <div className={personalRecommendationPageStyles.preferenceIconBox}>
+                <Heart size={22} />
+            </div>
+
+            <div className={personalRecommendationPageStyles.cardTextGroup}>
+                <h3 className={personalRecommendationPageStyles.cardTitle}>
+                    취향 프로필
+                </h3>
+            </div>
+
+            <button
+                type="button"
+                className={personalRecommendationPageStyles.smallButton}
+            >
+                취향 수정하기
+            </button>
+        </section>
+    );
+}

--- a/src/features/personalRecommendation/ui/config/personalRecommendationMockData.ts
+++ b/src/features/personalRecommendation/ui/config/personalRecommendationMockData.ts
@@ -4,6 +4,10 @@ export const personalRecommendationLocationMock = {
 
 export const personalRecommendationHistoryMock: readonly {
     id: number;
-    menuName: string;
-    recommendedAt: string;
-}[] = [];
+    recommendedDate: string;
+}[] = [
+//     {
+//         id: 1,
+//         recommendedDate: "2026.05.22",
+//     },
+];

--- a/src/features/personalRecommendation/ui/config/personalRecommendationMockData.ts
+++ b/src/features/personalRecommendation/ui/config/personalRecommendationMockData.ts
@@ -1,0 +1,9 @@
+export const personalRecommendationLocationMock = {
+    address: "서울 서초동 서초구 118",
+} as const;
+
+export const personalRecommendationHistoryMock: readonly {
+    id: number;
+    menuName: string;
+    recommendedAt: string;
+}[] = [];

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -7,7 +7,6 @@ import {
   User,
   Users,
   UtensilsCrossed,
-  MapPin,
   Settings,
 } from "lucide-react";
 
@@ -18,10 +17,9 @@ import {
 
 const MENUS = [
   { href: "/home", label: "홈", icon: Home, enabled: true },
-  { href: "/personal", label: "개인 메뉴 추천", icon: User, enabled: false },
+  { href: "/personal-recommendation", label: "개인 메뉴 추천", icon: User, enabled: true },
   { href: "/group", label: "그룹 메뉴 추천", icon: Users, enabled: false },
   { href: "/preference", label: "취향 관리", icon: UtensilsCrossed, enabled: true },
-  { href: "/location", label: "위치 설정", icon: MapPin, enabled: false },
   { href: "/settings", label: "설정", icon: Settings, enabled: true },
 ];
 

--- a/src/ui/styles/personalRecommendationPageStyles.ts
+++ b/src/ui/styles/personalRecommendationPageStyles.ts
@@ -1,0 +1,38 @@
+export const personalRecommendationPageStyles = {
+    container: "min-h-screen bg-[#faf8f8] px-10 py-20",
+    content: "mx-auto flex w-full max-w-6xl flex-col gap-10",
+    header: "flex flex-col gap-2",
+    title: "text-4xl font-medium text-zinc-900",
+    description: "text-lg font-medium text-[#17315c]",
+    layout: "grid grid-cols-[1fr_340px] gap-6",
+    mainColumn: "flex flex-col gap-6",
+    cardGrid: "grid grid-cols-2 gap-6",
+    heroCard:
+        "flex min-h-[300px] flex-col justify-between rounded-[28px] bg-[#fff0e8] px-14 py-12 shadow-md",
+    heroTitle: "text-3xl font-semibold text-zinc-950",
+    heroDescription: "mt-3 text-base font-medium text-zinc-900",
+    primaryButton:
+        "h-16 w-[300px] rounded-full bg-black text-base font-semibold text-white shadow-md transition hover:bg-zinc-800",
+    locationCard:
+        "flex min-h-[300px] flex-col justify-between rounded-[28px] bg-[#e9e9e9] px-10 py-9 shadow-md",
+    preferenceCard:
+        "flex min-h-[300px] flex-col justify-between rounded-[28px] bg-[#ffdda3] px-10 py-9 shadow-md",
+    iconBox:
+        "flex h-12 w-12 items-center justify-center rounded-2xl bg-white text-zinc-500",
+    preferenceIconBox:
+        "flex h-12 w-12 items-center justify-center rounded-2xl bg-[#c7efc9] text-zinc-700",
+    cardTextGroup: "flex flex-col gap-2",
+    cardTitle: "text-base font-semibold text-zinc-950",
+    cardDescription: "text-base font-medium text-zinc-600",
+    smallButton:
+        "h-12 w-[180px] rounded-full bg-black text-base font-semibold text-white transition hover:bg-zinc-800",
+    historyPanel:
+        "flex min-h-[630px] rounded-[32px] border border-zinc-200 bg-white px-8 py-10 shadow-sm",
+    emptyHistory:
+        "flex flex-1 flex-col items-center justify-center gap-4 text-base font-medium text-zinc-400",
+    emptyIconBox:
+        "flex h-16 w-16 items-center justify-center rounded-full bg-[#eaf1fb] text-[#b5c4d7]",
+    historyList: "flex w-full flex-col gap-3",
+    historyItem:
+        "flex flex-col gap-1 rounded-2xl bg-zinc-50 px-4 py-3 text-sm text-zinc-700",
+} as const;


### PR DESCRIPTION
## 관련 이슈
Closes #109 

## 요약
- 로그인 사용자가 개인 메뉴 추천 페이지에서 추천 시작, 위치 설정, 취향 수정, 최근 기록 영역을 확인할 수 있는 화면 구상

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
