### PR TITLE
[Fix] 계정별 위치 설정 localStorage key 분리(#127)

### DIFF
--- a/src/app/personal-recommendation/page.tsx
+++ b/src/app/personal-recommendation/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { useAtomValue } from "jotai";
+import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
 
 import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommendationPageStyles";
 
@@ -13,6 +15,7 @@ import PreferenceModal from "@/features/preference/ui/components/PreferenceModal
 
 import { useLocationSetting } from "@/features/locationSetting/application/hooks/useLocationSetting";
 import {personalRecommendationHistoryMock} from "@/features/personalRecommendation/ui/config/personalRecommendationMockData";
+import { createLocationStorageKey } from "@/features/locationSetting/application/utils/createLocationStorageKey";
 
 const PERSONAL_RECOMMENDATION_LOCATION_KEY = "personal-recommendation-location";
 
@@ -20,9 +23,18 @@ export default function PersonalRecommendationPage() {
     const [isPreferenceModalOpen, setIsPreferenceModalOpen] = useState(false);
     const [isLocationModalOpen, setIsLocationModalOpen] = useState(false);
 
-    const { location, saveLocation } = useLocationSetting(
-            PERSONAL_RECOMMENDATION_LOCATION_KEY,
+    const member = useAtomValue(memberAtom);
+
+    const storageKey = createLocationStorageKey(
+        PERSONAL_RECOMMENDATION_LOCATION_KEY,
+        member?.id ?? "unknown",
     );
+
+    const { location, saveLocation } = useLocationSetting(storageKey);
+
+    if (!member) {
+        return null;
+    }
 
     return (
         <>

--- a/src/features/auth/application/hooks/useAuthInit.ts
+++ b/src/features/auth/application/hooks/useAuthInit.ts
@@ -19,6 +19,7 @@ export function useAuthInit() {
                 const response = await authApi.refresh();
                 const accessToken = response.data.accessToken;
                 const onboarding = response.data.onboarding;
+                const member = response.data.member;
 
                 if (!accessToken || !onboarding) {
                     if (!cancelled) {
@@ -28,7 +29,7 @@ export function useAuthInit() {
                 }
 
                 if (!cancelled) {
-                    setAuthenticated(accessToken, onboarding);
+                    setAuthenticated(accessToken, onboarding, member);
                 }
             } catch {
                 if (!cancelled) {

--- a/src/features/auth/application/hooks/useSubmitRequiredAgreements.ts
+++ b/src/features/auth/application/hooks/useSubmitRequiredAgreements.ts
@@ -28,7 +28,11 @@ export function useSubmitRequiredAgreements() {
                 const response = await onboardingApi.submitRequiredAgreements({ agreements });
 
                 if (response.data.accessToken) {
-                    setAuthenticated(response.data.accessToken, response.data.onboarding);
+                    setAuthenticated(
+                        response.data.accessToken,
+                        response.data.onboarding,
+                        response.data.member
+                    );
                 } else {
                     updateOnboarding(response.data.onboarding);
                 }

--- a/src/features/auth/application/selectors/authSelectors.ts
+++ b/src/features/auth/application/selectors/authSelectors.ts
@@ -29,3 +29,8 @@ export const isOnboardingReadyAtom = atom((get) => {
         auth.onboarding.nextStep === "READY"
     );
 });
+
+export const memberAtom = atom((get) => {
+    const auth = get(authAtom);
+    return auth.status === "AUTHENTICATED" ? auth.member : null;
+});

--- a/src/features/auth/application/store/authStore.ts
+++ b/src/features/auth/application/store/authStore.ts
@@ -1,6 +1,7 @@
 import { authAtom } from "@/features/auth/application/atom/authAtom";
 import { jotaiStore } from "@/shared/lib/jotaiStore";
 import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
+import type { LoginMember } from "@/features/auth/domain/model/LoginMember";
 
 export function setAuthLoading() {
     jotaiStore.set(authAtom, { status: "LOADING" });
@@ -9,11 +10,13 @@ export function setAuthLoading() {
 export function setAuthenticated(
     accessToken: string,
     onboarding: OnboardingState,
+    member: LoginMember,
 ) {
     jotaiStore.set(authAtom, {
         status: "AUTHENTICATED",
         accessToken,
         onboarding,
+        member,
     });
 }
 

--- a/src/features/auth/application/usecase/exchangeOAuthCode.ts
+++ b/src/features/auth/application/usecase/exchangeOAuthCode.ts
@@ -19,7 +19,12 @@ export async function exchangeOAuthCode(
         const accessToken = response.data.accessToken;
         const onboarding = response.data.onboarding;
 
-        setAuthenticated(accessToken, onboarding);
+        setAuthenticated(
+            accessToken,
+            onboarding,
+            response.data.member,
+        );
+
         console.log("accessToken 저장 완료:", accessToken);
         console.log("onboarding:", onboarding);
 

--- a/src/features/auth/application/usecase/login.ts
+++ b/src/features/auth/application/usecase/login.ts
@@ -11,7 +11,11 @@ export async function login(request: LoginRequest) {
         const accessToken = response.data.accessToken;
         const onboarding = response.data.onboarding;
 
-        setAuthenticated(accessToken, onboarding);
+        setAuthenticated(
+            accessToken,
+            onboarding,
+            response.data.member,
+        );
 
         return response;
     } catch (error) {

--- a/src/features/auth/domain/model/LoginMember.ts
+++ b/src/features/auth/domain/model/LoginMember.ts
@@ -2,4 +2,5 @@
 export interface LoginMember {
     readonly id: number;
     readonly role: string;
+    readonly nickname: string;
 }

--- a/src/features/auth/domain/state/AuthState.ts
+++ b/src/features/auth/domain/state/AuthState.ts
@@ -1,4 +1,5 @@
 import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
+import type { LoginMember } from "@/features/auth/domain/model/LoginMember";
 
 export type AuthState =
     | { readonly status: "LOADING" } // 로그인 시작
@@ -7,4 +8,5 @@ export type AuthState =
           readonly status: "AUTHENTICATED"; // 성공
           readonly accessToken: string;
           readonly onboarding: OnboardingState;
+          readonly member: LoginMember;
       };

--- a/src/features/auth/infrastructure/api/dto/RefreshResponse.ts
+++ b/src/features/auth/infrastructure/api/dto/RefreshResponse.ts
@@ -1,9 +1,13 @@
 import type { ApiResponse } from "@/features/auth/domain/model/ApiResponse";
 import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
+import type { LoginMember } from "@/features/auth/domain/model/LoginMember";
 
 export interface RefreshData {
-    accessToken: string;
-    onboarding: OnboardingState;
+    readonly accessToken: string;
+    readonly refreshToken: string | null;
+    readonly expiresIn: number;
+    readonly onboarding: OnboardingState;
+    readonly member: LoginMember;
 }
 
 export type RefreshResponse = ApiResponse<RefreshData>;

--- a/src/features/auth/infrastructure/api/dto/SubmitAgreementsResponse.ts
+++ b/src/features/auth/infrastructure/api/dto/SubmitAgreementsResponse.ts
@@ -1,5 +1,6 @@
 import type { ApiResponse } from "@/features/auth/domain/model/ApiResponse";
 import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
+import type { LoginMember } from "@/features/auth/domain/model/LoginMember";
 
 export interface SubmitAgreementsResponseData {
     readonly requiredAgreementsCompleted: boolean;
@@ -7,6 +8,7 @@ export interface SubmitAgreementsResponseData {
     readonly onboarding: OnboardingState;
     readonly accessToken: string;
     readonly expiresIn: number;
+    readonly member: LoginMember;
 }
 
 export type SubmitAgreementsResponse = ApiResponse<SubmitAgreementsResponseData>;

--- a/src/features/locationSetting/application/utils/createLocationStorageKey.ts
+++ b/src/features/locationSetting/application/utils/createLocationStorageKey.ts
@@ -1,0 +1,6 @@
+export function createLocationStorageKey(
+    prefix: string, // 저장할 위치 데이터의 종류를 구분하는 key 값(개인 메뉴 추천인지 그룹 메뉴 추천인지)
+    scopeId: number | string, //저장 데이터의 소유/적용 대상 id
+): string {
+    return `${prefix}:${scopeId}`;
+}

--- a/src/infrastructure/http/httpClient.ts
+++ b/src/infrastructure/http/httpClient.ts
@@ -5,6 +5,7 @@ import {
     setAuthenticated,
 } from "@/features/auth/application/store/authStore";
 import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
+import type { LoginMember } from "@/features/auth/domain/model/LoginMember";
 
 class HttpError extends Error {
     constructor(
@@ -19,6 +20,7 @@ class HttpError extends Error {
 interface RefreshResult {
     accessToken: string;
     onboarding: OnboardingState;
+    member: LoginMember;
 }
 
 const NO_REFRESH_PATHS = [
@@ -65,6 +67,7 @@ async function refreshAccessToken(): Promise<RefreshResult> {
     return {
         accessToken: body.data.accessToken,
         onboarding: body.data.onboarding,
+        member: body.data.member,
     };
 }
 
@@ -91,7 +94,7 @@ async function request<T>(
         try {
             const refreshed = await refreshAccessToken();
 
-            setAuthenticated(refreshed.accessToken, refreshed.onboarding);
+            setAuthenticated(refreshed.accessToken, refreshed.onboarding, refreshed.member,);
 
             return request<T>(path, options, true);
         } catch (error) {


### PR DESCRIPTION
## 관련 이슈
Closes #127 

## 요약
- 무엇을 변경했나요?
로그인 사용자별로 위치 설정 정보가 분리되도록 localStorage key 생성 구조를 수정
auth 상태에 member 정보를 저장하도록 인증 상태 관리 로직 수정
refresh 응답 처리 시 member 정보가 함께 갱신되도록 수정

- 왜 이 변경이 필요한가요?
기존에는 공통 localStorage key를 사용하여 계정 전환 시 이전 사용자의 위치 설정이 그대로 표시되는 문제가 있었음
사용자별 위치 설정을 안전하게 분리하고, 로그인 사용자 정보를 전역 인증 상태에서 활용할 수 있도록 구조를 개선하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
