### PR TITLE
[Refactor] 위치 설정 모달 검색 로직 및 기본 위치값 분리 (#128)

### DIFF
--- a/src/features/locationSetting/application/hooks/useLocationSearch.ts
+++ b/src/features/locationSetting/application/hooks/useLocationSearch.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
+export function useLocationSearch() {
+    const [inputKeyword, setInputKeyword] = useState("");
+    const [searchKeyword, setSearchKeyword] = useState("");
+    const [searchErrorMessage, setSearchErrorMessage] = useState<string | null>(
+        null,
+    );
+
+    const submitSearch = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const keyword = inputKeyword.trim();
+
+        if (!keyword) {
+            setSearchErrorMessage("검색어를 입력해 주세요.");
+            return;
+        }
+
+        setSearchErrorMessage(null);
+        setSearchKeyword(keyword);
+    };
+
+    const handleSearchFailed = () => {
+        setSearchErrorMessage("검색 결과를 찾을 수 없습니다.");
+    };
+
+    return {
+        inputKeyword,
+        setInputKeyword,
+        searchKeyword,
+        searchErrorMessage,
+        submitSearch,
+        handleSearchFailed,
+    };
+}

--- a/src/features/locationSetting/ui/components/LocationModal.tsx
+++ b/src/features/locationSetting/ui/components/LocationModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { useState } from "react";
 import {
     Check,
     ChevronLeft,
@@ -12,6 +12,8 @@ import {
 
 import KakaoMapView from "@/features/map/ui/components/KakaoMapView";
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+import { defaultLocationSetting } from "@/features/locationSetting/ui/config/defaultLocationSetting";
+import { useLocationSearch } from "@/features/locationSetting/application/hooks/useLocationSearch";
 import { locationModalStyles } from "@/ui/styles/locationModalStyles";
 
 interface LocationModalProps {
@@ -21,31 +23,22 @@ interface LocationModalProps {
     readonly onSave: (location: LocationSetting) => void;
 }
 
-const DEFAULT_LOCATION: LocationSetting = {
-    address: "서울특별시 강남구 강남대로 396",
-
-    latitude: 37.497942,
-    longitude: 127.027621,
-
-    level: 4,
-
-    southWestLatitude: 37.4900,
-    southWestLongitude: 127.0200,
-
-    northEastLatitude: 37.5050,
-    northEastLongitude: 127.0400,
-};
-
 export default function LocationModal({
     isOpen,
     onClose,
     initialLocation,
     onSave,
 }: LocationModalProps) {
-    const baseLocation = initialLocation ?? DEFAULT_LOCATION;
+    const baseLocation = initialLocation ?? defaultLocationSetting;
 
-    const [inputKeyword, setInputKeyword] = useState("");
-    const [searchKeyword, setSearchKeyword] = useState("");
+    const {
+        inputKeyword,
+        setInputKeyword,
+        searchKeyword,
+        searchErrorMessage,
+        submitSearch,
+        handleSearchFailed,
+    } = useLocationSearch();
 
     const [selectedAddress, setSelectedAddress] = useState(
         baseLocation.address,
@@ -64,25 +57,7 @@ export default function LocationModal({
         northEastLongitude: baseLocation.northEastLongitude,
     });
 
-    const [searchErrorMessage, setSearchErrorMessage] = useState<string | null>(
-        null,
-    );
-
     if (!isOpen) return null;
-
-    const handleSubmitSearch = (event: FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-
-        const keyword = inputKeyword.trim();
-
-        if (!keyword) {
-            setSearchErrorMessage("검색어를 입력해 주세요.");
-            return;
-        }
-
-        setSearchErrorMessage(null);
-        setSearchKeyword(keyword);
-    };
 
     const handleSave = () => {
         onSave({
@@ -124,7 +99,7 @@ export default function LocationModal({
 
                 <div className={locationModalStyles.mapSection}>
                     <form
-                        onSubmit={handleSubmitSearch}
+                        onSubmit={submitSearch}
                         className={locationModalStyles.searchBar}
                     >
                         <Search size={20} />
@@ -178,11 +153,7 @@ export default function LocationModal({
                                 });
                             }}
                             onAddressChanged={setSelectedAddress}
-                            onSearchFailed={() => {
-                                setSearchErrorMessage(
-                                    "검색 결과를 찾을 수 없습니다.",
-                                );
-                            }}
+                            onSearchFailed={handleSearchFailed}
                         />
 
                         <div className={locationModalStyles.centerPin}>

--- a/src/features/locationSetting/ui/config/defaultLocationSetting.ts
+++ b/src/features/locationSetting/ui/config/defaultLocationSetting.ts
@@ -1,0 +1,16 @@
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+
+export const defaultLocationSetting: LocationSetting = {
+    address: "서울특별시 강남구 강남대로 396",
+
+    latitude: 37.497942,
+    longitude: 127.027621,
+
+    level: 4,
+
+    southWestLatitude: 37.49,
+    southWestLongitude: 127.02,
+
+    northEastLatitude: 37.505,
+    northEastLongitude: 127.04,
+};


### PR DESCRIPTION
## 관련 이슈
Closes #128 

## 요약
- 무엇을 변경했나요?
위치 설정 모달의 기본 위치값을 별도 config 파일로 분리
위치 검색 submit 및 검색 상태 관리 로직을 custom hook으로 분리
LocationModal.tsx가 UI 조합 및 상태 연결 역할만 담당하도록 구조 개선

- 왜 이 변경이 필요한가요?
위치 설정 기능이 개인/그룹 메뉴 추천 등 여러 화면에서 재사용될 예정이므로 유지보수성과 재사용성을 높이기 위해 모달 내부 책임을 분리할 필요가 있었음
UI 컴포넌트와 상태/검색 로직을 분리하여 이후 기능 확장 시 변경 영향을 줄이기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
