### PR TITLE
[Feat] 개인 메뉴 추천 생성 및 결과 조회 플로우 구현

### DIFF
--- a/src/app/personal-recommendation/page.tsx
+++ b/src/app/personal-recommendation/page.tsx
@@ -43,11 +43,15 @@ export default function PersonalRecommendationPage() {
         preferenceState.status === "SUCCESS" &&
         hasRequiredPreference(preferenceState.data);
 
-    const { isAlertModalOpen, startRecommendation, closeAlertModal } =
-        usePersonalRecommendationStart({
-            location,
-            hasPreference,
-        });
+    const {
+        isAlertModalOpen,
+        isCreating,
+        startRecommendation,
+        closeAlertModal
+    } = usePersonalRecommendationStart({
+        location,
+        hasPreference,
+    });
 
     if (!member) {
         return null;
@@ -71,6 +75,7 @@ export default function PersonalRecommendationPage() {
                         <div className={personalRecommendationPageStyles.mainColumn}>
                             <PersonalRecommendationHero
                                 onStart={startRecommendation}
+                                isStarting={isCreating}
                             />
 
                             <div className={personalRecommendationPageStyles.cardGrid}>

--- a/src/app/personal-recommendation/page.tsx
+++ b/src/app/personal-recommendation/page.tsx
@@ -22,8 +22,8 @@ import { usePersonalRecommendationStart } from "@/features/personalRecommendatio
 import { hasRequiredPreference } from "@/features/personalRecommendation/domain/validator/hasRequiredPreference";
 import { isPersonalRecommendationLoadingAtom } from "@/features/personalRecommendation/application/selectors/personalRecommendationSelectors";
 import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
-
-import { personalRecommendationHistoryMock } from "@/features/personalRecommendation/ui/config/personalRecommendationMockData";
+import { usePersonalRecommendationHistories } from "@/features/personalRecommendation/application/hooks/usePersonalRecommendationHistories";
+import { personalRecommendationHistoryToPanelItemsMapper } from "@/features/personalRecommendation/ui/mapper/personalRecommendationHistoryToPanelItemsMapper";
 
 const PERSONAL_RECOMMENDATION_LOCATION_KEY = "personal-recommendation-location";
 
@@ -44,6 +44,10 @@ export default function PersonalRecommendationPage() {
     const isRecommendationLoading = useAtomValue(
         isPersonalRecommendationLoadingAtom,
     );
+
+    const { histories } = usePersonalRecommendationHistories();
+
+    const historyPanelItems = personalRecommendationHistoryToPanelItemsMapper(histories);
 
     const hasPreference =
         preferenceState.status === "SUCCESS" &&
@@ -112,7 +116,7 @@ export default function PersonalRecommendationPage() {
                         </div>
 
                         <PersonalRecommendationHistoryPanel
-                            histories={personalRecommendationHistoryMock}
+                            histories={historyPanelItems}
                         />
                     </div>
                 </div>

--- a/src/app/personal-recommendation/page.tsx
+++ b/src/app/personal-recommendation/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { useAtomValue } from "jotai";
-import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
 
 import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommendationPageStyles";
 
@@ -10,12 +9,19 @@ import PersonalRecommendationHero from "@/features/personalRecommendation/ui/com
 import PersonalRecommendationLocationCard from "@/features/personalRecommendation/ui/components/PersonalRecommendationLocationCard";
 import PersonalRecommendationPreferenceCard from "@/features/personalRecommendation/ui/components/PersonalRecommendationPreferenceCard";
 import PersonalRecommendationHistoryPanel from "@/features/personalRecommendation/ui/components/PersonalRecommendationHistoryPanel";
+import PersonalRecommendationStartAlertModal from "@/features/personalRecommendation/ui/components/PersonalRecommendationStartAlertModal";
+
 import LocationModal from "@/features/locationSetting/ui/components/LocationModal";
 import PreferenceModal from "@/features/preference/ui/components/PreferenceModal";
 
 import { useLocationSetting } from "@/features/locationSetting/application/hooks/useLocationSetting";
-import {personalRecommendationHistoryMock} from "@/features/personalRecommendation/ui/config/personalRecommendationMockData";
 import { createLocationStorageKey } from "@/features/locationSetting/application/utils/createLocationStorageKey";
+import { usePreferenceList } from "@/features/preference/application/hooks/usePreferenceList";
+import { usePersonalRecommendationStart } from "@/features/personalRecommendation/application/hooks/usePersonalRecommendationStart";
+import { hasRequiredPreference } from "@/features/personalRecommendation/domain/validator/hasRequiredPreference";
+import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
+
+import { personalRecommendationHistoryMock } from "@/features/personalRecommendation/ui/config/personalRecommendationMockData";
 
 const PERSONAL_RECOMMENDATION_LOCATION_KEY = "personal-recommendation-location";
 
@@ -25,12 +31,23 @@ export default function PersonalRecommendationPage() {
 
     const member = useAtomValue(memberAtom);
 
-    const storageKey = createLocationStorageKey(
+    const locationStorageKey = createLocationStorageKey(
         PERSONAL_RECOMMENDATION_LOCATION_KEY,
         member?.id ?? "unknown",
     );
 
-    const { location, saveLocation } = useLocationSetting(storageKey);
+    const { location, saveLocation } = useLocationSetting(locationStorageKey);
+    const { preferenceState } = usePreferenceList();
+
+    const hasPreference =
+        preferenceState.status === "SUCCESS" &&
+        hasRequiredPreference(preferenceState.data);
+
+    const { isAlertModalOpen, startRecommendation, closeAlertModal } =
+        usePersonalRecommendationStart({
+            location,
+            hasPreference,
+        });
 
     if (!member) {
         return null;
@@ -44,6 +61,7 @@ export default function PersonalRecommendationPage() {
                         <h1 className={personalRecommendationPageStyles.title}>
                             개인 메뉴 추천
                         </h1>
+
                         <p className={personalRecommendationPageStyles.description}>
                             당신의 맞춤형 메뉴를 탐색해보세요!
                         </p>
@@ -51,7 +69,9 @@ export default function PersonalRecommendationPage() {
 
                     <div className={personalRecommendationPageStyles.layout}>
                         <div className={personalRecommendationPageStyles.mainColumn}>
-                            <PersonalRecommendationHero />
+                            <PersonalRecommendationHero
+                                onStart={startRecommendation}
+                            />
 
                             <div className={personalRecommendationPageStyles.cardGrid}>
                                 <PersonalRecommendationLocationCard
@@ -92,6 +112,11 @@ export default function PersonalRecommendationPage() {
             <PreferenceModal
                 isOpen={isPreferenceModalOpen}
                 onClose={() => setIsPreferenceModalOpen(false)}
+            />
+
+            <PersonalRecommendationStartAlertModal
+                isOpen={isAlertModalOpen}
+                onClose={closeAlertModal}
             />
         </>
     );

--- a/src/app/personal-recommendation/page.tsx
+++ b/src/app/personal-recommendation/page.tsx
@@ -19,10 +19,12 @@ import { useLocationSetting } from "@/features/locationSetting/application/hooks
 import { createLocationStorageKey } from "@/features/locationSetting/application/utils/createLocationStorageKey";
 import { usePreferenceList } from "@/features/preference/application/hooks/usePreferenceList";
 import { usePersonalRecommendationStart } from "@/features/personalRecommendation/application/hooks/usePersonalRecommendationStart";
+import { usePersonalRecommendationHistories } from "@/features/personalRecommendation/application/hooks/usePersonalRecommendationHistories";
+import { usePersonalRecommendationResultNavigation } from "@/features/personalRecommendation/application/hooks/usePersonalRecommendationResultNavigation";
+
 import { hasRequiredPreference } from "@/features/personalRecommendation/domain/validator/hasRequiredPreference";
 import { isPersonalRecommendationLoadingAtom } from "@/features/personalRecommendation/application/selectors/personalRecommendationSelectors";
 import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
-import { usePersonalRecommendationHistories } from "@/features/personalRecommendation/application/hooks/usePersonalRecommendationHistories";
 import { personalRecommendationHistoryToPanelItemsMapper } from "@/features/personalRecommendation/ui/mapper/personalRecommendationHistoryToPanelItemsMapper";
 
 const PERSONAL_RECOMMENDATION_LOCATION_KEY = "personal-recommendation-location";
@@ -47,7 +49,17 @@ export default function PersonalRecommendationPage() {
 
     const { histories } = usePersonalRecommendationHistories();
 
-    const historyPanelItems = personalRecommendationHistoryToPanelItemsMapper(histories);
+    const historyPanelItems =
+        personalRecommendationHistoryToPanelItemsMapper(histories);
+
+    // 추천 결과 화면 이동
+    const { moveToRecommendationResult } =
+        usePersonalRecommendationResultNavigation();
+
+    // 선택 완료되지 않은 진행 중 추천 찾기
+    const openRecommendation = histories.find(
+        (history) => history.status === "OPEN",
+    );
 
     const hasPreference =
         preferenceState.status === "SUCCESS" &&
@@ -57,11 +69,16 @@ export default function PersonalRecommendationPage() {
         isAlertModalOpen,
         isCreating,
         startRecommendation,
-        closeAlertModal
+        closeAlertModal,
     } = usePersonalRecommendationStart({
         location,
         hasPreference,
     });
+
+    // 진행 중 추천이 있으면 새 추천 대신 기존 결과 이동
+    const handleClickHeroButton = openRecommendation
+        ? () => moveToRecommendationResult(openRecommendation.id)
+        : startRecommendation;
 
     if (!member) {
         return (
@@ -92,8 +109,13 @@ export default function PersonalRecommendationPage() {
                     <div className={personalRecommendationPageStyles.layout}>
                         <div className={personalRecommendationPageStyles.mainColumn}>
                             <PersonalRecommendationHero
-                                onStart={startRecommendation}
+                                onStart={handleClickHeroButton}
                                 isStarting={isCreating}
+                                buttonLabel={
+                                    openRecommendation
+                                        ? "메뉴 추천 결과"
+                                        : "메뉴 추천 시작하기"
+                                }
                             />
 
                             <div className={personalRecommendationPageStyles.cardGrid}>
@@ -117,6 +139,7 @@ export default function PersonalRecommendationPage() {
 
                         <PersonalRecommendationHistoryPanel
                             histories={historyPanelItems}
+                            onClickDetail={moveToRecommendationResult}
                         />
                     </div>
                 </div>

--- a/src/app/personal-recommendation/page.tsx
+++ b/src/app/personal-recommendation/page.tsx
@@ -60,7 +60,11 @@ export default function PersonalRecommendationPage() {
     });
 
     if (!member) {
-        return null;
+        return (
+            <main className={personalRecommendationPageStyles.container}>
+                <p>회원 정보를 불러오는 중...</p>
+            </main>
+        );
     }
 
     if (isRecommendationLoading) {

--- a/src/app/personal-recommendation/page.tsx
+++ b/src/app/personal-recommendation/page.tsx
@@ -10,6 +10,7 @@ import PersonalRecommendationLocationCard from "@/features/personalRecommendatio
 import PersonalRecommendationPreferenceCard from "@/features/personalRecommendation/ui/components/PersonalRecommendationPreferenceCard";
 import PersonalRecommendationHistoryPanel from "@/features/personalRecommendation/ui/components/PersonalRecommendationHistoryPanel";
 import PersonalRecommendationStartAlertModal from "@/features/personalRecommendation/ui/components/PersonalRecommendationStartAlertModal";
+import PersonalRecommendationLoadingView from "@/features/personalRecommendation/ui/components/PersonalRecommendationLoadingView";
 
 import LocationModal from "@/features/locationSetting/ui/components/LocationModal";
 import PreferenceModal from "@/features/preference/ui/components/PreferenceModal";
@@ -19,6 +20,7 @@ import { createLocationStorageKey } from "@/features/locationSetting/application
 import { usePreferenceList } from "@/features/preference/application/hooks/usePreferenceList";
 import { usePersonalRecommendationStart } from "@/features/personalRecommendation/application/hooks/usePersonalRecommendationStart";
 import { hasRequiredPreference } from "@/features/personalRecommendation/domain/validator/hasRequiredPreference";
+import { isPersonalRecommendationLoadingAtom } from "@/features/personalRecommendation/application/selectors/personalRecommendationSelectors";
 import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
 
 import { personalRecommendationHistoryMock } from "@/features/personalRecommendation/ui/config/personalRecommendationMockData";
@@ -39,6 +41,10 @@ export default function PersonalRecommendationPage() {
     const { location, saveLocation } = useLocationSetting(locationStorageKey);
     const { preferenceState } = usePreferenceList();
 
+    const isRecommendationLoading = useAtomValue(
+        isPersonalRecommendationLoadingAtom,
+    );
+
     const hasPreference =
         preferenceState.status === "SUCCESS" &&
         hasRequiredPreference(preferenceState.data);
@@ -55,6 +61,10 @@ export default function PersonalRecommendationPage() {
 
     if (!member) {
         return null;
+    }
+
+    if (isRecommendationLoading) {
+        return <PersonalRecommendationLoadingView />;
     }
 
     return (

--- a/src/app/personal-recommendation/result/page.tsx
+++ b/src/app/personal-recommendation/result/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAtomValue } from "jotai";
 import { ArrowLeft } from "lucide-react";
@@ -8,6 +8,7 @@ import { ArrowLeft } from "lucide-react";
 import { personalRecommendationResultAtom } from "@/features/personalRecommendation/application/selectors/personalRecommendationSelectors";
 import { userPreferenceAtom } from "@/features/preference/application/selectors/preferenceSelectors";
 import { getPreferenceSummaryKeywords } from "@/features/preference/application/mapper/getPreferenceSummaryKeywords";
+import { useCompletePersonalRecommendationSelection } from "@/features/personalRecommendation/application/hooks/useCompletePersonalRecommendationSelection";
 
 import PersonalRecommendationResultCard from "@/features/personalRecommendation/ui/components/PersonalRecommendationResultCard";
 import PersonalRecommendationResultActionButtons from "@/features/personalRecommendation/ui/components/PersonalRecommendationResultActionButtons";
@@ -20,6 +21,13 @@ export default function PersonalRecommendationResultPage() {
     const recommendation = useAtomValue(personalRecommendationResultAtom);
     const preference = useAtomValue(userPreferenceAtom);
 
+    const { isCompleting, completeSelection } =
+        useCompletePersonalRecommendationSelection();
+
+    const [selectedCandidateId, setSelectedCandidateId] = useState<number | null>(
+        recommendation?.selectedCandidateId ?? null,
+    );
+
     useEffect(() => {
         if (!recommendation) {
             router.replace("/personal-recommendation");
@@ -30,7 +38,17 @@ export default function PersonalRecommendationResultPage() {
         return null;
     }
 
+    const isClosed = recommendation.status !== "OPEN";
     const keywords = getPreferenceSummaryKeywords(preference);
+
+    const handleCompleteSelection = async () => {
+        if (!selectedCandidateId) {
+            alert("추천 메뉴를 먼저 선택해 주세요.");
+            return;
+        }
+
+        await completeSelection(recommendation.requestId, selectedCandidateId);
+    };
 
     return (
         <main className={personalRecommendationResultPageStyles.container}>
@@ -45,6 +63,12 @@ export default function PersonalRecommendationResultPage() {
             <h1 className={personalRecommendationResultPageStyles.title}>
                 메뉴 추천 결과
             </h1>
+
+            {isClosed && (
+                <p className={personalRecommendationResultPageStyles.closedMessage}>
+                    메뉴 추천이 종료되었습니다.
+                </p>
+            )}
 
             <section className={personalRecommendationResultPageStyles.summaryCard}>
                 <h2 className={personalRecommendationResultPageStyles.summaryTitle}>
@@ -75,8 +99,12 @@ export default function PersonalRecommendationResultPage() {
                 {recommendation.candidates.map((candidate) => (
                     <PersonalRecommendationResultCard
                         key={candidate.id}
+                        candidateId={candidate.id}
                         menuName={candidate.menuName}
                         score={candidate.score}
+                        selected={selectedCandidateId === candidate.id}
+                        disabled={isClosed}
+                        onSelect={setSelectedCandidateId}
                     />
                 ))}
             </section>
@@ -85,9 +113,10 @@ export default function PersonalRecommendationResultPage() {
                 onRetryRecommendation={() => {
                     console.log("재요청");
                 }}
-                onCompleteSelection={() => {
-                    console.log("선택 완료");
-                }}
+                onCompleteSelection={handleCompleteSelection}
+                canCompleteSelection={selectedCandidateId !== null}
+                isCompleteSelectionLoading={isCompleting}
+                isClosed={isClosed}
             />
         </main>
     );

--- a/src/app/personal-recommendation/result/page.tsx
+++ b/src/app/personal-recommendation/result/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAtomValue } from "jotai";
+import { ArrowLeft } from "lucide-react";
+
+import { personalRecommendationResultAtom } from "@/features/personalRecommendation/application/selectors/personalRecommendationSelectors";
+import { userPreferenceAtom } from "@/features/preference/application/selectors/preferenceSelectors";
+import { getPreferenceSummaryKeywords } from "@/features/preference/application/mapper/getPreferenceSummaryKeywords";
+
+import PersonalRecommendationResultCard from "@/features/personalRecommendation/ui/components/PersonalRecommendationResultCard";
+import PersonalRecommendationResultActionButtons from "@/features/personalRecommendation/ui/components/PersonalRecommendationResultActionButtons";
+
+import { personalRecommendationResultPageStyles } from "@/ui/styles/personalRecommendationResultPageStyles";
+
+export default function PersonalRecommendationResultPage() {
+    const router = useRouter();
+
+    const recommendation = useAtomValue(personalRecommendationResultAtom);
+    const preference = useAtomValue(userPreferenceAtom);
+
+    useEffect(() => {
+        if (!recommendation) {
+            router.replace("/personal-recommendation");
+        }
+    }, [recommendation, router]);
+
+    if (!recommendation) {
+        return null;
+    }
+
+    const keywords = getPreferenceSummaryKeywords(preference);
+
+    return (
+        <main className={personalRecommendationResultPageStyles.container}>
+            <button
+                type="button"
+                onClick={() => router.push("/personal-recommendation")}
+                className={personalRecommendationResultPageStyles.backButton}
+            >
+                <ArrowLeft size={24} />
+            </button>
+
+            <h1 className={personalRecommendationResultPageStyles.title}>
+                메뉴 추천 결과
+            </h1>
+
+            <section className={personalRecommendationResultPageStyles.summaryCard}>
+                <h2 className={personalRecommendationResultPageStyles.summaryTitle}>
+                    취향 프로필 요약
+                </h2>
+
+                <div className={personalRecommendationResultPageStyles.keywordGroup}>
+                    {keywords.length > 0 ? (
+                        keywords.map((keyword) => (
+                            <span
+                                key={keyword}
+                                className={
+                                    personalRecommendationResultPageStyles.keywordChip
+                                }
+                            >
+                                #{keyword}
+                            </span>
+                        ))
+                    ) : (
+                        <span className={personalRecommendationResultPageStyles.emptyText}>
+                            표시할 취향 정보가 없습니다.
+                        </span>
+                    )}
+                </div>
+            </section>
+
+            <section className={personalRecommendationResultPageStyles.cardGrid}>
+                {recommendation.candidates.map((candidate) => (
+                    <PersonalRecommendationResultCard
+                        key={candidate.id}
+                        menuName={candidate.menuName}
+                        score={candidate.score}
+                    />
+                ))}
+            </section>
+
+            <PersonalRecommendationResultActionButtons
+                onRetryRecommendation={() => {
+                    console.log("재요청");
+                }}
+                onCompleteSelection={() => {
+                    console.log("선택 완료");
+                }}
+            />
+        </main>
+    );
+}

--- a/src/features/auth/application/hooks/useSubmitRequiredAgreements.ts
+++ b/src/features/auth/application/hooks/useSubmitRequiredAgreements.ts
@@ -27,7 +27,7 @@ export function useSubmitRequiredAgreements() {
             try {
                 const response = await onboardingApi.submitRequiredAgreements({ agreements });
 
-                if (response.data.accessToken) {
+                if (response.data.accessToken && response.data.member) {
                     setAuthenticated(
                         response.data.accessToken,
                         response.data.onboarding,

--- a/src/features/auth/application/store/authStore.ts
+++ b/src/features/auth/application/store/authStore.ts
@@ -12,6 +12,7 @@ export function setAuthenticated(
     onboarding: OnboardingState,
     member: LoginMember,
 ) {
+    console.log("[setAuthenticated]", { accessToken, onboarding, member });
     jotaiStore.set(authAtom, {
         status: "AUTHENTICATED",
         accessToken,

--- a/src/features/personalRecommendation/application/atoms/personalRecommendationAtom.ts
+++ b/src/features/personalRecommendation/application/atoms/personalRecommendationAtom.ts
@@ -1,0 +1,8 @@
+import { atom } from "jotai";
+
+import type { PersonalRecommendationState } from "@/features/personalRecommendation/domain/state/PersonalRecommendationState";
+
+export const personalRecommendationAtom =
+    atom<PersonalRecommendationState>({
+        status: "IDLE",
+    });

--- a/src/features/personalRecommendation/application/hooks/useCompletePersonalRecommendationSelection.ts
+++ b/src/features/personalRecommendation/application/hooks/useCompletePersonalRecommendationSelection.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+
+import { personalRecommendationAtom } from "@/features/personalRecommendation/application/atoms/personalRecommendationAtom";
+import { personalRecommendationApi } from "@/features/personalRecommendation/infrastructure/api/personalRecommendationApi";
+
+export function useCompletePersonalRecommendationSelection() {
+    const setRecommendationState = useSetAtom(personalRecommendationAtom);
+    const [isCompleting, setIsCompleting] = useState(false);
+
+    const completeSelection = async (
+        requestId: number,
+        selectedCandidateId: number,
+    ) => {
+        if (isCompleting) return;
+
+        setIsCompleting(true);
+
+        try {
+            const result = await personalRecommendationApi.selectCandidate(
+                requestId,
+                selectedCandidateId,
+            );
+
+            setRecommendationState((prev) => {
+                if (prev.status !== "SUCCESS") return prev;
+
+                return {
+                    status: "SUCCESS",
+                    data: {
+                        ...prev.data,
+                        status: result.status,
+                        selectedCandidateId: result.selectedCandidateId,
+                        closedAt: result.closedAt,
+                    },
+                };
+            });
+
+            return result;
+        } catch (error) {
+            alert(
+                error instanceof Error
+                    ? error.message
+                    : "추천 메뉴 선택에 실패했습니다.",
+            );
+        } finally {
+            setIsCompleting(false);
+        }
+    };
+
+    return {
+        isCompleting,
+        completeSelection,
+    };
+}

--- a/src/features/personalRecommendation/application/hooks/usePersonalRecommendationHistories.ts
+++ b/src/features/personalRecommendation/application/hooks/usePersonalRecommendationHistories.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { personalRecommendationApi } from "@/features/personalRecommendation/infrastructure/api/personalRecommendationApi";
+import type { PersonalRecommendationHistory } from "@/features/personalRecommendation/domain/model/PersonalRecommendationHistory";
+
+export function usePersonalRecommendationHistories() {
+    const [histories, setHistories] = useState<
+        readonly PersonalRecommendationHistory[]
+    >([]);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const fetchHistories = useCallback(async () => {
+        setIsLoading(true);
+
+        try {
+            const data = await personalRecommendationApi.fetchHistories();
+            setHistories(data);
+        } catch {
+            setHistories([]);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchHistories();
+    }, [fetchHistories]);
+
+    return {
+        histories,
+        isLoading,
+        refetchHistories: fetchHistories,
+    };
+}

--- a/src/features/personalRecommendation/application/hooks/usePersonalRecommendationResultNavigation.ts
+++ b/src/features/personalRecommendation/application/hooks/usePersonalRecommendationResultNavigation.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useSetAtom } from "jotai";
+
+import { personalRecommendationAtom } from "@/features/personalRecommendation/application/atoms/personalRecommendationAtom";
+import { personalRecommendationApi } from "@/features/personalRecommendation/infrastructure/api/personalRecommendationApi";
+
+export function usePersonalRecommendationResultNavigation() {
+    const router = useRouter();
+    const setRecommendationState = useSetAtom(personalRecommendationAtom);
+
+    const moveToRecommendationResult = useCallback(
+        async (requestId: number) => {
+            try {
+                const recommendation =
+                    await personalRecommendationApi.fetchRecommendationDetail(
+                        requestId,
+                    );
+
+                setRecommendationState({
+                    status: "SUCCESS",
+                    data: recommendation,
+                });
+
+                router.push("/personal-recommendation/result");
+            } catch (error) {
+                alert(
+                    error instanceof Error
+                        ? error.message
+                        : "추천 결과를 불러오지 못했습니다.",
+                );
+            }
+        },
+        [router, setRecommendationState],
+    );
+
+    return {
+        moveToRecommendationResult,
+    };
+}

--- a/src/features/personalRecommendation/application/hooks/usePersonalRecommendationStart.ts
+++ b/src/features/personalRecommendation/application/hooks/usePersonalRecommendationStart.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+
+interface UsePersonalRecommendationStartParams {
+    readonly location: LocationSetting | null;
+    readonly hasPreference: boolean;
+}
+
+export function usePersonalRecommendationStart({
+    location,
+    hasPreference,
+}: UsePersonalRecommendationStartParams) {
+    const [isAlertModalOpen, setIsAlertModalOpen] = useState(false);
+
+    const canStartRecommendation = hasPreference && location !== null;
+
+    const startRecommendation = () => {
+        if (!canStartRecommendation) {
+            setIsAlertModalOpen(true);
+            return;
+        }
+
+        // TODO: 추천 API 호출/로딩 화면 이동 연결
+        console.log("메뉴 추천 시작 가능");
+    };
+
+    const closeAlertModal = () => {
+        setIsAlertModalOpen(false);
+    };
+
+    return {
+        canStartRecommendation,
+        isAlertModalOpen,
+        startRecommendation,
+        closeAlertModal,
+    };
+}

--- a/src/features/personalRecommendation/application/hooks/usePersonalRecommendationStart.ts
+++ b/src/features/personalRecommendation/application/hooks/usePersonalRecommendationStart.ts
@@ -51,6 +51,11 @@ export function usePersonalRecommendationStart({
                 wait(MIN_LOADING_TIME_MS),
             ]);
 
+            console.log(
+                "[personalRecommendation] 추천 결과:",
+                recommendation,
+            );
+
             setRecommendationState({
                 status: "SUCCESS",
                 data: recommendation,

--- a/src/features/personalRecommendation/application/hooks/usePersonalRecommendationStart.ts
+++ b/src/features/personalRecommendation/application/hooks/usePersonalRecommendationStart.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { useSetAtom } from "jotai";
+import { useRouter } from "next/navigation";
 
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
 import { personalRecommendationAtom } from "@/features/personalRecommendation/application/atoms/personalRecommendationAtom";
@@ -24,6 +25,8 @@ export function usePersonalRecommendationStart({
     location,
     hasPreference,
 }: UsePersonalRecommendationStartParams) {
+    const router = useRouter();
+
     const setRecommendationState = useSetAtom(personalRecommendationAtom);
 
     const [isAlertModalOpen, setIsAlertModalOpen] = useState(false);
@@ -53,7 +56,7 @@ export function usePersonalRecommendationStart({
                 data: recommendation,
             });
 
-            console.log("개인 메뉴 추천 요청 성공:", recommendation);
+            router.push("/personal-recommendation/result");
         } catch (error) {
             setRecommendationState({
                 status: "ERROR",
@@ -75,6 +78,7 @@ export function usePersonalRecommendationStart({
         isCreating,
         canStartRecommendation,
         setRecommendationState,
+        router,
     ]);
 
     const closeAlertModal = () => {

--- a/src/features/personalRecommendation/application/hooks/usePersonalRecommendationStart.ts
+++ b/src/features/personalRecommendation/application/hooks/usePersonalRecommendationStart.ts
@@ -1,7 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import { useSetAtom } from "jotai";
+
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+import { personalRecommendationAtom } from "@/features/personalRecommendation/application/atoms/personalRecommendationAtom";
+import { personalRecommendationApi } from "@/features/personalRecommendation/infrastructure/api/personalRecommendationApi";
 
 interface UsePersonalRecommendationStartParams {
     readonly location: LocationSetting | null;
@@ -12,19 +16,55 @@ export function usePersonalRecommendationStart({
     location,
     hasPreference,
 }: UsePersonalRecommendationStartParams) {
+    const setRecommendationState = useSetAtom(personalRecommendationAtom);
+
     const [isAlertModalOpen, setIsAlertModalOpen] = useState(false);
+    const [isCreating, setIsCreating] = useState(false);
 
     const canStartRecommendation = hasPreference && location !== null;
 
-    const startRecommendation = () => {
+    const startRecommendation = useCallback(async () => {
+        if (isCreating) return;
+
         if (!canStartRecommendation) {
             setIsAlertModalOpen(true);
             return;
         }
 
-        // TODO: 추천 API 호출/로딩 화면 이동 연결
-        console.log("메뉴 추천 시작 가능");
-    };
+        setIsCreating(true);
+        setRecommendationState({ status: "LOADING" });
+
+        try {
+            const recommendation = await personalRecommendationApi.createRecommendation();
+
+            setRecommendationState({
+                status: "SUCCESS",
+                data: recommendation,
+            });
+
+            console.log("개인 메뉴 추천 요청 성공:", recommendation);
+        } catch (error) {
+            setRecommendationState({
+                status: "ERROR",
+                message:
+                    error instanceof Error
+                        ? error.message
+                        : "개인 메뉴 추천 요청에 실패했습니다.",
+            });
+
+            alert(
+                error instanceof Error
+                    ? error.message
+                    : "개인 메뉴 추천 요청에 실패했습니다.",
+            );
+        } finally {
+            setIsCreating(false);
+        }
+    }, [
+        isCreating,
+        canStartRecommendation,
+        setRecommendationState,
+    ]);
 
     const closeAlertModal = () => {
         setIsAlertModalOpen(false);
@@ -33,6 +73,7 @@ export function usePersonalRecommendationStart({
     return {
         canStartRecommendation,
         isAlertModalOpen,
+        isCreating,
         startRecommendation,
         closeAlertModal,
     };

--- a/src/features/personalRecommendation/application/hooks/usePersonalRecommendationStart.ts
+++ b/src/features/personalRecommendation/application/hooks/usePersonalRecommendationStart.ts
@@ -12,6 +12,14 @@ interface UsePersonalRecommendationStartParams {
     readonly hasPreference: boolean;
 }
 
+const MIN_LOADING_TIME_MS = 2000;
+
+function wait(ms: number) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
 export function usePersonalRecommendationStart({
     location,
     hasPreference,
@@ -35,7 +43,10 @@ export function usePersonalRecommendationStart({
         setRecommendationState({ status: "LOADING" });
 
         try {
-            const recommendation = await personalRecommendationApi.createRecommendation();
+            const [recommendation] = await Promise.all([
+                personalRecommendationApi.createRecommendation(),
+                wait(MIN_LOADING_TIME_MS),
+            ]);
 
             setRecommendationState({
                 status: "SUCCESS",

--- a/src/features/personalRecommendation/application/selectors/personalRecommendationSelectors.ts
+++ b/src/features/personalRecommendation/application/selectors/personalRecommendationSelectors.ts
@@ -1,0 +1,11 @@
+import { atom } from "jotai";
+import { personalRecommendationAtom } from "@/features/personalRecommendation/application/atoms/personalRecommendationAtom";
+
+export const isPersonalRecommendationLoadingAtom = atom(
+    (get) => get(personalRecommendationAtom).status === "LOADING",
+);
+
+export const personalRecommendationResultAtom = atom((get) => {
+    const state = get(personalRecommendationAtom);
+    return state.status === "SUCCESS" ? state.data : null;
+});

--- a/src/features/personalRecommendation/domain/model/PersonalRecommendation.ts
+++ b/src/features/personalRecommendation/domain/model/PersonalRecommendation.ts
@@ -11,5 +11,6 @@ export interface PersonalRecommendation {
     readonly status: string;
     readonly requestedAt: string;
     readonly closedAt: string | null;
+    readonly selectedCandidateId?: number | null;
     readonly candidates: readonly RecommendedMenu[];
 }

--- a/src/features/personalRecommendation/domain/model/PersonalRecommendation.ts
+++ b/src/features/personalRecommendation/domain/model/PersonalRecommendation.ts
@@ -1,0 +1,15 @@
+export interface RecommendedMenu {
+    readonly id: number;
+    readonly menuId: number;
+    readonly menuName: string;
+    readonly rankNo: number;
+    readonly score: number;
+}
+
+export interface PersonalRecommendation {
+    readonly requestId: number;
+    readonly status: string;
+    readonly requestedAt: string;
+    readonly closedAt: string | null;
+    readonly candidates: readonly RecommendedMenu[];
+}

--- a/src/features/personalRecommendation/domain/model/PersonalRecommendationHistory.ts
+++ b/src/features/personalRecommendation/domain/model/PersonalRecommendationHistory.ts
@@ -1,0 +1,6 @@
+export interface PersonalRecommendationHistory {
+    readonly id: number;
+    readonly status: string;
+    readonly requestedAt: string;
+    readonly closedAt: string | null;
+}

--- a/src/features/personalRecommendation/domain/state/PersonalRecommendationState.ts
+++ b/src/features/personalRecommendation/domain/state/PersonalRecommendationState.ts
@@ -1,0 +1,13 @@
+import type { PersonalRecommendation } from "@/features/personalRecommendation/domain/model/PersonalRecommendation";
+
+export type PersonalRecommendationState =
+    | { readonly status: "IDLE" }
+    | { readonly status: "LOADING" }
+    | {
+          readonly status: "SUCCESS";
+          readonly data: PersonalRecommendation;
+      }
+    | {
+          readonly status: "ERROR";
+          readonly message: string;
+      };

--- a/src/features/personalRecommendation/domain/validator/hasRequiredPreference.ts
+++ b/src/features/personalRecommendation/domain/validator/hasRequiredPreference.ts
@@ -1,0 +1,17 @@
+import type { PreferenceCategory } from "@/features/preference/domain/model/PreferenceCategory";
+import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
+
+const REQUIRED_PREFERENCE_CATEGORIES: readonly PreferenceCategory[] = [
+    "FLAVOR",
+    "COOKING_METHOD",
+];
+
+export function hasRequiredPreference(
+    preference: UserPreference | null,
+): boolean {
+    if (!preference) return false;
+
+    return REQUIRED_PREFERENCE_CATEGORIES.every(
+        (category) => (preference.selections[category]?.length ?? 0) > 0,
+    );
+}

--- a/src/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse.ts
+++ b/src/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse.ts
@@ -1,0 +1,27 @@
+export interface PersonalRecommendationCandidateResponse {
+    readonly id: number;
+    readonly menuId: number;
+    readonly menuName: string;
+    readonly rankNo: number;
+    readonly score: number;
+}
+
+export interface CreatePersonalRecommendationData {
+    readonly requestId: number;
+    readonly status: string;
+    readonly requestedAt: string;
+    readonly closedAt: string | null;
+    readonly candidates:
+        readonly PersonalRecommendationCandidateResponse[];
+}
+
+export interface CreatePersonalRecommendationResponse {
+    readonly success: boolean;
+    readonly data: CreatePersonalRecommendationData | null;
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse.ts
+++ b/src/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse.ts
@@ -1,0 +1,27 @@
+export interface PersonalRecommendationDetailCandidateResponse {
+    readonly id: number;
+    readonly menuId: number;
+    readonly menuName: string;
+    readonly rankNo: number;
+    readonly score: number;
+}
+
+export interface PersonalRecommendationDetailData {
+    readonly id: number;
+    readonly status: string;
+    readonly closedAt: string | null;
+    readonly contextJson: Record<string, unknown>;
+    readonly candidates: readonly PersonalRecommendationDetailCandidateResponse[];
+    readonly selectedCandidateId: number | null;
+}
+
+export interface PersonalRecommendationDetailResponse {
+    readonly success: boolean;
+    readonly data: PersonalRecommendationDetailData | null;
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationHistoryResponse.ts
+++ b/src/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationHistoryResponse.ts
@@ -1,0 +1,29 @@
+export interface PersonalRecommendationHistoryItemResponse {
+    readonly id: number;
+    readonly status: string;
+    readonly requestedAt: string;
+    readonly closedAt: string | null;
+}
+
+export interface PersonalRecommendationHistoryResponse {
+    readonly success: boolean;
+    readonly data: {
+        readonly content: readonly PersonalRecommendationHistoryItemResponse[];
+        readonly pageInfo: {
+            readonly page: number;
+            readonly size: number;
+            readonly totalElements: number;
+            readonly totalPages: number;
+            readonly first: boolean;
+            readonly last: boolean;
+            readonly hasNext: boolean;
+            readonly hasPrevious: boolean;
+        };
+    } | null;
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/personalRecommendation/infrastructure/api/dto/SelectPersonalRecommendationCandidateResponse.ts
+++ b/src/features/personalRecommendation/infrastructure/api/dto/SelectPersonalRecommendationCandidateResponse.ts
@@ -1,0 +1,19 @@
+// 메뉴 선택 완료 응답
+export interface SelectPersonalRecommendationCandidateData {
+    readonly id: number;
+    readonly status: string;
+    readonly selectedCandidateId: number;
+    readonly closedAt: string;
+    readonly updatedAt: string;
+}
+
+export interface SelectPersonalRecommendationCandidateResponse {
+    readonly success: boolean;
+    readonly data: SelectPersonalRecommendationCandidateData | null;
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationDetailMapper.ts
+++ b/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationDetailMapper.ts
@@ -1,0 +1,21 @@
+import type { PersonalRecommendation } from "@/features/personalRecommendation/domain/model/PersonalRecommendation";
+import type { PersonalRecommendationDetailData } from "@/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse";
+
+export function mapPersonalRecommendationDetail(
+    data: PersonalRecommendationDetailData,
+): PersonalRecommendation {
+    return {
+        requestId: data.id,
+        status: data.status,
+        requestedAt: "",
+        closedAt: data.closedAt,
+        selectedCandidateId: data.selectedCandidateId,
+        candidates: data.candidates.map((candidate) => ({
+            id: candidate.id,
+            menuId: candidate.menuId,
+            menuName: candidate.menuName,
+            rankNo: candidate.rankNo,
+            score: candidate.score,
+        })),
+    };
+}

--- a/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationMapper.ts
+++ b/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationMapper.ts
@@ -1,0 +1,24 @@
+import type { PersonalRecommendation } from "@/features/personalRecommendation/domain/model/PersonalRecommendation";
+
+import type {
+    CreatePersonalRecommendationData,
+} from "@/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse";
+
+export function mapPersonalRecommendation(
+    data: CreatePersonalRecommendationData,
+): PersonalRecommendation {
+    return {
+        requestId: data.requestId,
+        status: data.status,
+        requestedAt: data.requestedAt,
+        closedAt: data.closedAt,
+
+        candidates: data.candidates.map((candidate) => ({
+            id: candidate.id,
+            menuId: candidate.menuId,
+            menuName: candidate.menuName,
+            rankNo: candidate.rankNo,
+            score: candidate.score,
+        })),
+    };
+}

--- a/src/features/personalRecommendation/infrastructure/api/personalRecommendationApi.ts
+++ b/src/features/personalRecommendation/infrastructure/api/personalRecommendationApi.ts
@@ -1,0 +1,34 @@
+import { httpClient } from "@/infrastructure/http/httpClient";
+
+import type {
+    CreatePersonalRecommendationResponse,
+} from "@/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse";
+
+import { mapPersonalRecommendation } from "@/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationMapper";
+
+interface CreatePersonalRecommendationRequest {
+    readonly contextJson: Record<string, unknown>;
+}
+
+export const personalRecommendationApi = {
+    async createRecommendation() {
+        const request: CreatePersonalRecommendationRequest = {
+            contextJson: {},
+        };
+
+        const response =
+            await httpClient.post<CreatePersonalRecommendationResponse>(
+                "/api/v1/personal/recommendations",
+                request,
+            );
+
+        if (!response.success || !response.data) {
+            throw new Error(
+                response.error?.message ??
+                    "개인 메뉴 추천 요청에 실패했습니다.",
+            );
+        }
+
+        return mapPersonalRecommendation(response.data);
+    },
+};

--- a/src/features/personalRecommendation/infrastructure/api/personalRecommendationApi.ts
+++ b/src/features/personalRecommendation/infrastructure/api/personalRecommendationApi.ts
@@ -1,8 +1,9 @@
 import { httpClient } from "@/infrastructure/http/httpClient";
 
-import type {
-    CreatePersonalRecommendationResponse,
-} from "@/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse";
+import type { PersonalRecommendationHistory } from "@/features/personalRecommendation/domain/model/PersonalRecommendationHistory";
+import type { CreatePersonalRecommendationResponse } from "@/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse";
+import type { SelectPersonalRecommendationCandidateResponse } from "@/features/personalRecommendation/infrastructure/api/dto/SelectPersonalRecommendationCandidateResponse";
+import type { PersonalRecommendationHistoryResponse } from "@/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationHistoryResponse";
 
 import { mapPersonalRecommendation } from "@/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationMapper";
 
@@ -30,5 +31,42 @@ export const personalRecommendationApi = {
         }
 
         return mapPersonalRecommendation(response.data);
+    },
+
+    async selectCandidate(requestId: number, selectedCandidateId: number) {
+        const response =
+            await httpClient.patch<SelectPersonalRecommendationCandidateResponse>(
+                `/api/v1/personal/recommendations/${requestId}`,
+                {
+                    selectedCandidateId,
+                },
+            );
+
+        if (!response.success || !response.data) {
+            throw new Error(
+                response.error?.message ?? "추천 메뉴 선택에 실패했습니다.",
+            );
+        }
+
+        return response.data;
+    },
+
+    async fetchHistories(): Promise<readonly PersonalRecommendationHistory[]> {
+        const response = await httpClient.get<PersonalRecommendationHistoryResponse>(
+            "/api/v1/personal/recommendations",
+        );
+
+        if (!response.success || !response.data) {
+            throw new Error(
+                response.error?.message ?? "개인 메뉴 추천 이력 조회에 실패했습니다.",
+            );
+        }
+
+        return response.data.content.map((item) => ({
+            id: item.id,
+            status: item.status,
+            requestedAt: item.requestedAt,
+            closedAt: item.closedAt,
+        }));
     },
 };

--- a/src/features/personalRecommendation/infrastructure/api/personalRecommendationApi.ts
+++ b/src/features/personalRecommendation/infrastructure/api/personalRecommendationApi.ts
@@ -4,7 +4,9 @@ import type { PersonalRecommendationHistory } from "@/features/personalRecommend
 import type { CreatePersonalRecommendationResponse } from "@/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse";
 import type { SelectPersonalRecommendationCandidateResponse } from "@/features/personalRecommendation/infrastructure/api/dto/SelectPersonalRecommendationCandidateResponse";
 import type { PersonalRecommendationHistoryResponse } from "@/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationHistoryResponse";
+import type { PersonalRecommendationDetailResponse } from "@/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse";
 
+import { mapPersonalRecommendationDetail } from "@/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationDetailMapper";
 import { mapPersonalRecommendation } from "@/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationMapper";
 
 interface CreatePersonalRecommendationRequest {
@@ -68,5 +70,20 @@ export const personalRecommendationApi = {
             requestedAt: item.requestedAt,
             closedAt: item.closedAt,
         }));
+    },
+
+    async fetchRecommendationDetail(requestId: number) {
+        const response =
+            await httpClient.get<PersonalRecommendationDetailResponse>(
+                `/api/v1/personal/recommendations/${requestId}`,
+            );
+
+        if (!response.success || !response.data) {
+            throw new Error(
+                response.error?.message ?? "개인 메뉴 추천 상세 조회에 실패했습니다.",
+            );
+        }
+
+        return mapPersonalRecommendationDetail(response.data);
     },
 };

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationHero.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationHero.tsx
@@ -1,12 +1,19 @@
 import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommendationPageStyles";
 
-export default function PersonalRecommendationHero() {
+interface PersonalRecommendationHeroProps {
+    readonly onStart: () => void;
+}
+
+export default function PersonalRecommendationHero({
+    onStart,
+}: PersonalRecommendationHeroProps) {
     return (
         <section className={personalRecommendationPageStyles.heroCard}>
             <div>
                 <h2 className={personalRecommendationPageStyles.heroTitle}>
                     당신의 완벽한 한 끼를 찾아보세요.
                 </h2>
+
                 <p className={personalRecommendationPageStyles.heroDescription}>
                     설정한 취향과 현재 위치를 기반으로 최적화된 미식 경험을 제안합니다.
                 </p>
@@ -14,6 +21,7 @@ export default function PersonalRecommendationHero() {
 
             <button
                 type="button"
+                onClick={onStart}
                 className={personalRecommendationPageStyles.primaryButton}
             >
                 메뉴 추천 시작하기

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationHero.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationHero.tsx
@@ -2,10 +2,12 @@ import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommenda
 
 interface PersonalRecommendationHeroProps {
     readonly onStart: () => void;
+    readonly isStarting: boolean;
 }
 
 export default function PersonalRecommendationHero({
     onStart,
+    isStarting,
 }: PersonalRecommendationHeroProps) {
     return (
         <section className={personalRecommendationPageStyles.heroCard}>
@@ -22,9 +24,10 @@ export default function PersonalRecommendationHero({
             <button
                 type="button"
                 onClick={onStart}
+                disabled={isStarting}
                 className={personalRecommendationPageStyles.primaryButton}
             >
-                메뉴 추천 시작하기
+                {isStarting ? "추천 요청 중..." : "메뉴 추천 시작하기"}
             </button>
         </section>
     );

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationHero.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationHero.tsx
@@ -3,11 +3,13 @@ import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommenda
 interface PersonalRecommendationHeroProps {
     readonly onStart: () => void;
     readonly isStarting: boolean;
+    readonly buttonLabel?: string;
 }
 
 export default function PersonalRecommendationHero({
     onStart,
     isStarting,
+    buttonLabel = "메뉴 추천 시작하기",
 }: PersonalRecommendationHeroProps) {
     return (
         <section className={personalRecommendationPageStyles.heroCard}>
@@ -27,7 +29,7 @@ export default function PersonalRecommendationHero({
                 disabled={isStarting}
                 className={personalRecommendationPageStyles.primaryButton}
             >
-                {isStarting ? "추천 요청 중..." : "메뉴 추천 시작하기"}
+                {isStarting ? "처리 중..." : buttonLabel}
             </button>
         </section>
     );

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationHistoryPanel.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationHistoryPanel.tsx
@@ -1,17 +1,21 @@
 import { Clock3 } from "lucide-react";
+
 import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommendationPageStyles";
 
-interface PersonalRecommendationHistory {
+interface PersonalRecommendationHistoryItem {
     readonly id: number;
     readonly recommendedDate: string;
 }
 
 interface PersonalRecommendationHistoryPanelProps {
-    readonly histories: readonly PersonalRecommendationHistory[];
+    readonly histories: readonly PersonalRecommendationHistoryItem[];
+
+    readonly onClickDetail?: (requestId: number) => void;
 }
 
 export default function PersonalRecommendationHistoryPanel({
     histories,
+    onClickDetail,
 }: PersonalRecommendationHistoryPanelProps) {
     const hasHistories = histories.length > 0;
 
@@ -23,17 +27,31 @@ export default function PersonalRecommendationHistoryPanel({
                         <button
                             key={history.id}
                             type="button"
+                            onClick={() => onClickDetail?.(history.id)}
                             className={personalRecommendationPageStyles.historyItem}
                         >
-                            {history.recommendedDate}
+                            <span>{history.recommendedDate}</span>
+
+                            <span
+                                className={
+                                    personalRecommendationPageStyles.historyDetailButton
+                                }
+                            >
+                                자세히 보기
+                            </span>
                         </button>
                     ))}
                 </div>
             ) : (
                 <div className={personalRecommendationPageStyles.emptyHistory}>
-                    <div className={personalRecommendationPageStyles.emptyIconBox}>
+                    <div
+                        className={
+                            personalRecommendationPageStyles.emptyIconBox
+                        }
+                    >
                         <Clock3 size={34} />
                     </div>
+
                     <p>기록이 없습니다.</p>
                 </div>
             )}

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationLoadingView.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationLoadingView.tsx
@@ -1,0 +1,25 @@
+import { Utensils } from "lucide-react";
+import { personalRecommendationLoadingStyles } from "@/ui/styles/personalRecommendationLoadingStyles";
+
+export default function PersonalRecommendationLoadingView() {
+    return (
+        <main className={personalRecommendationLoadingStyles.container}>
+            <section className={personalRecommendationLoadingStyles.card}>
+                <div className={personalRecommendationLoadingStyles.iconWrapper}>
+                    <div className={personalRecommendationLoadingStyles.spinner} />
+                    <div className={personalRecommendationLoadingStyles.iconCircle}>
+                        <Utensils size={54} />
+                    </div>
+                </div>
+
+                <h1 className={personalRecommendationLoadingStyles.title}>
+                    취향을 분석하고 있습니다...
+                </h1>
+
+                <p className={personalRecommendationLoadingStyles.description}>
+                    당신을 위한 완벽한 3가지 메뉴를 찾아드릴게요
+                </p>
+            </section>
+        </main>
+    );
+}

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationResultActionButtons.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationResultActionButtons.tsx
@@ -1,0 +1,45 @@
+import { personalRecommendationResultActionButtonsStyles } from "@/ui/styles/personalRecommendationResultActionButtonsStyles";
+
+interface PersonalRecommendationResultActionButtonsProps {
+    readonly onRetryRecommendation: () => void;
+    readonly onCompleteSelection: () => void;
+
+    readonly isRetryRecommendationLoading?: boolean;
+    readonly isCompleteSelectionLoading?: boolean;
+}
+
+export default function PersonalRecommendationResultActionButtons({
+    onRetryRecommendation,
+    onCompleteSelection,
+    isRetryRecommendationLoading = false,
+    isCompleteSelectionLoading = false,
+}: PersonalRecommendationResultActionButtonsProps) {
+    const isDisabled =
+        isRetryRecommendationLoading || isCompleteSelectionLoading;
+
+    return (
+        <div className={personalRecommendationResultActionButtonsStyles.container}>
+            <button
+                type="button"
+                onClick={onRetryRecommendation}
+                disabled={isDisabled}
+                className={
+                    personalRecommendationResultActionButtonsStyles.retryRecommendationButton
+                }
+            >
+                {isRetryRecommendationLoading ? "재요청 중..." : "재요청"}
+            </button>
+
+            <button
+                type="button"
+                onClick={onCompleteSelection}
+                disabled={isDisabled}
+                className={
+                    personalRecommendationResultActionButtonsStyles.completeSelectionButton
+                }
+            >
+                {isCompleteSelectionLoading ? "처리 중..." : "선택 완료"}
+            </button>
+        </div>
+    );
+}

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationResultActionButtons.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationResultActionButtons.tsx
@@ -4,17 +4,21 @@ interface PersonalRecommendationResultActionButtonsProps {
     readonly onRetryRecommendation: () => void;
     readonly onCompleteSelection: () => void;
 
+    readonly canCompleteSelection: boolean;
     readonly isRetryRecommendationLoading?: boolean;
     readonly isCompleteSelectionLoading?: boolean;
+    readonly isClosed?: boolean;
 }
 
 export default function PersonalRecommendationResultActionButtons({
     onRetryRecommendation,
     onCompleteSelection,
+    canCompleteSelection,
     isRetryRecommendationLoading = false,
     isCompleteSelectionLoading = false,
+    isClosed = false,
 }: PersonalRecommendationResultActionButtonsProps) {
-    const isDisabled =
+    const isActionLoading =
         isRetryRecommendationLoading || isCompleteSelectionLoading;
 
     return (
@@ -22,7 +26,7 @@ export default function PersonalRecommendationResultActionButtons({
             <button
                 type="button"
                 onClick={onRetryRecommendation}
-                disabled={isDisabled}
+                disabled={isActionLoading || isClosed}
                 className={
                     personalRecommendationResultActionButtonsStyles.retryRecommendationButton
                 }
@@ -33,12 +37,14 @@ export default function PersonalRecommendationResultActionButtons({
             <button
                 type="button"
                 onClick={onCompleteSelection}
-                disabled={isDisabled}
+                disabled={
+                    isActionLoading || !canCompleteSelection || isClosed
+                }
                 className={
                     personalRecommendationResultActionButtonsStyles.completeSelectionButton
                 }
             >
-                {isCompleteSelectionLoading ? "처리 중..." : "선택 완료"}
+                {isClosed ? "선택 완료됨" : "선택 완료"}
             </button>
         </div>
     );

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationResultCard.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationResultCard.tsx
@@ -1,20 +1,47 @@
 import { personalRecommendationResultCardStyles } from "@/ui/styles/personalRecommendationResultCardStyles";
 
 interface PersonalRecommendationResultCardProps {
+    readonly candidateId: number;
     readonly menuName: string;
     readonly score: number;
+    readonly selected: boolean;
+    readonly disabled?: boolean;
+    readonly onSelect: (candidateId: number) => void;
 }
 
 export default function PersonalRecommendationResultCard({
+    candidateId,
     menuName,
     score,
+    selected,
+    disabled = false,
+    onSelect,
 }: PersonalRecommendationResultCardProps) {
+    const handleSelect = () => {
+        if (disabled) return;
+
+        onSelect(candidateId);
+    };
+
     return (
-        <article className={personalRecommendationResultCardStyles.card}>
+        <article
+            onClick={handleSelect}
+            className={
+                selected
+                    ? personalRecommendationResultCardStyles.selectedCard
+                    : personalRecommendationResultCardStyles.card
+            }
+        >
             <div className={personalRecommendationResultCardStyles.imagePlaceholder}>
                 <span className={personalRecommendationResultCardStyles.matchBadge}>
                     {Math.round(score)}% Match
                 </span>
+
+                {selected && (
+                    <span className={personalRecommendationResultCardStyles.selectedBadge}>
+                        선택됨
+                    </span>
+                )}
             </div>
 
             <div className={personalRecommendationResultCardStyles.content}>
@@ -24,7 +51,11 @@ export default function PersonalRecommendationResultCard({
 
                 <button
                     type="button"
+                    disabled={disabled}
                     className={personalRecommendationResultCardStyles.restaurantButton}
+                    onClick={(event) => {
+                        event.stopPropagation();
+                    }}
                 >
                     맛집 보기
                 </button>

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationResultCard.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationResultCard.tsx
@@ -1,0 +1,34 @@
+import { personalRecommendationResultCardStyles } from "@/ui/styles/personalRecommendationResultCardStyles";
+
+interface PersonalRecommendationResultCardProps {
+    readonly menuName: string;
+    readonly score: number;
+}
+
+export default function PersonalRecommendationResultCard({
+    menuName,
+    score,
+}: PersonalRecommendationResultCardProps) {
+    return (
+        <article className={personalRecommendationResultCardStyles.card}>
+            <div className={personalRecommendationResultCardStyles.imagePlaceholder}>
+                <span className={personalRecommendationResultCardStyles.matchBadge}>
+                    {Math.round(score)}% Match
+                </span>
+            </div>
+
+            <div className={personalRecommendationResultCardStyles.content}>
+                <h3 className={personalRecommendationResultCardStyles.menuName}>
+                    {menuName}
+                </h3>
+
+                <button
+                    type="button"
+                    className={personalRecommendationResultCardStyles.restaurantButton}
+                >
+                    맛집 보기
+                </button>
+            </div>
+        </article>
+    );
+}

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationStartAlertModal.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationStartAlertModal.tsx
@@ -1,0 +1,35 @@
+import { personalRecommendationStartAlertModalStyles } from "@/ui/styles/personalRecommendationStartAlertModalStyles";
+
+interface PersonalRecommendationStartAlertModalProps {
+    readonly isOpen: boolean;
+    readonly onClose: () => void;
+}
+
+export default function PersonalRecommendationStartAlertModal({
+    isOpen,
+    onClose,
+}: PersonalRecommendationStartAlertModalProps) {
+    if (!isOpen) return null;
+
+    return (
+        <div className={personalRecommendationStartAlertModalStyles.overlay}>
+            <div className={personalRecommendationStartAlertModalStyles.modal}>
+                <h2 className={personalRecommendationStartAlertModalStyles.title}>
+                    메뉴 추천을 위해 취향과 위치 설정이 필요해요
+                </h2>
+
+                <p className={personalRecommendationStartAlertModalStyles.description}>
+                    취향과 위치를 모두 등록한 뒤 메뉴 추천을 시작할 수 있어요.
+                </p>
+
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className={personalRecommendationStartAlertModalStyles.confirmButton}
+                >
+                    확인
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/features/personalRecommendation/ui/mapper/personalRecommendationHistoryToPanelItemsMapper.ts
+++ b/src/features/personalRecommendation/ui/mapper/personalRecommendationHistoryToPanelItemsMapper.ts
@@ -1,16 +1,19 @@
 import type { PersonalRecommendationHistory } from "@/features/personalRecommendation/domain/model/PersonalRecommendationHistory";
 
 function formatKoreanDate(dateString: string) {
-    const date = new Date(dateString);
+    const [datePart] = dateString.split("T");
+    const [year, month, day] = datePart.split("-").map(Number);
 
-    return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+    return `${year}년 ${month}월 ${day}일`;
 }
 
 export function personalRecommendationHistoryToPanelItemsMapper(
     histories: readonly PersonalRecommendationHistory[],
 ) {
-    return histories.map((history) => ({
-        id: history.id,
-        recommendedDate: formatKoreanDate(history.closedAt ?? history.requestedAt),
-    }));
+    return histories
+        .filter((history) => history.status === "SELECTED")
+        .map((history) => ({
+            id: history.id,
+            recommendedDate: formatKoreanDate(history.requestedAt),
+        }));
 }

--- a/src/features/personalRecommendation/ui/mapper/personalRecommendationHistoryToPanelItemsMapper.ts
+++ b/src/features/personalRecommendation/ui/mapper/personalRecommendationHistoryToPanelItemsMapper.ts
@@ -1,0 +1,16 @@
+import type { PersonalRecommendationHistory } from "@/features/personalRecommendation/domain/model/PersonalRecommendationHistory";
+
+function formatKoreanDate(dateString: string) {
+    const date = new Date(dateString);
+
+    return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+}
+
+export function personalRecommendationHistoryToPanelItemsMapper(
+    histories: readonly PersonalRecommendationHistory[],
+) {
+    return histories.map((history) => ({
+        id: history.id,
+        recommendedDate: formatKoreanDate(history.closedAt ?? history.requestedAt),
+    }));
+}

--- a/src/features/preference/application/mapper/getPreferenceSummaryKeywords.ts
+++ b/src/features/preference/application/mapper/getPreferenceSummaryKeywords.ts
@@ -1,0 +1,12 @@
+import type { UserPreference } from "@/features/preference/domain/model/UserPreference";
+
+export function getPreferenceSummaryKeywords(
+    preference: UserPreference | null,
+): readonly string[] {
+    if (!preference) return [];
+
+    return Object.values(preference.selections)
+        .flat()
+        .map((option) => option.name)
+        .slice(0, 5);
+}

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -2,77 +2,122 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useAtomValue } from "jotai";
 import {
-  Home,
-  User,
-  Users,
-  UtensilsCrossed,
-  Settings,
+    Home,
+    User,
+    Users,
+    UtensilsCrossed,
+    Settings,
 } from "lucide-react";
 
 import {
-  sidebarStyles,
-  sidebarMenuItemStyles,
+    sidebarStyles,
+    sidebarMenuItemStyles,
 } from "@/ui/styles/sidebarStyles";
 
+import { isPersonalRecommendationLoadingAtom } from "@/features/personalRecommendation/application/selectors/personalRecommendationSelectors";
+
 const MENUS = [
-  { href: "/home", label: "홈", icon: Home, enabled: true },
-  { href: "/personal-recommendation", label: "개인 메뉴 추천", icon: User, enabled: true },
-  { href: "/group", label: "그룹 메뉴 추천", icon: Users, enabled: false },
-  { href: "/preference", label: "취향 관리", icon: UtensilsCrossed, enabled: true },
-  { href: "/settings", label: "설정", icon: Settings, enabled: true },
+    { href: "/home", label: "홈", icon: Home, enabled: true },
+    {
+        href: "/personal-recommendation",
+        label: "개인 메뉴 추천",
+        icon: User,
+        enabled: true,
+    },
+    { href: "/group", label: "그룹 메뉴 추천", icon: Users, enabled: false },
+    {
+        href: "/preference",
+        label: "취향 관리",
+        icon: UtensilsCrossed,
+        enabled: true,
+    },
+    { href: "/settings", label: "설정", icon: Settings, enabled: true },
 ];
 
 export default function Sidebar() {
-  const pathname = usePathname();
+    const pathname = usePathname();
 
-  const handleNotReady = () => {
-    alert("준비중인 기능입니다.");
-  };
+    const isRecommendationLoading = useAtomValue(
+        isPersonalRecommendationLoadingAtom,
+    );
 
-  return (
-    <aside className={sidebarStyles.container}>
-      <div className={sidebarStyles.brandSection}>
-        <Link href="/home" className={sidebarStyles.brandLink}>
-          <UtensilsCrossed className={sidebarStyles.brandIcon} />
-          <span className={sidebarStyles.brandText}>Matchuri</span>
-        </Link>
-      </div>
+    const handleNotReady = () => {
+        alert("준비중인 기능입니다.");
+    };
 
-      <nav className={sidebarStyles.nav}>
-        {MENUS.map((menu) => {
-          const active = pathname === menu.href;
-          const Icon = menu.icon;
-          const className = active
-            ? `${sidebarMenuItemStyles.base} ${sidebarMenuItemStyles.active}`
-            : `${sidebarMenuItemStyles.base} ${sidebarMenuItemStyles.inactive}`;
+    const handleMenuClick = (
+        event: React.MouseEvent<HTMLAnchorElement>,
+        href: string,
+    ) => {
+        if (!isRecommendationLoading) return;
 
-          if (menu.enabled) {
-            return (
-              <Link
-                key={menu.href}
-                href={menu.href}
-                className={className}
-              >
-                <Icon className={sidebarMenuItemStyles.icon} />
-                <span>{menu.label}</span>
-              </Link>
-            );
-          }
+        if (href === "/personal-recommendation") {
+            return;
+        }
 
-          return (
-            <button
-              key={menu.href}
-              type="button"
-              onClick={handleNotReady}
-              className={`${className} w-full text-left`}
-            >
-              <Icon className={sidebarMenuItemStyles.icon} />
-              <span>{menu.label}</span>
-            </button>
-          );
-        })}
-      </nav>
-    </aside>
-  );
+        event.preventDefault();
+        alert("메뉴 추천을 위한 취향 분석이 진행중입니다.");
+    };
+
+    return (
+        <aside className={sidebarStyles.container}>
+            <div className={sidebarStyles.brandSection}>
+                <Link
+                    href="/home"
+                    className={sidebarStyles.brandLink}
+                    onClick={(event) => handleMenuClick(event, "/home")}
+                >
+                    <UtensilsCrossed className={sidebarStyles.brandIcon} />
+                    <span className={sidebarStyles.brandText}>Matchuri</span>
+                </Link>
+            </div>
+
+            <nav className={sidebarStyles.nav}>
+                {MENUS.map((menu) => {
+                    const active = pathname === menu.href;
+                    const Icon = menu.icon;
+                    const className = active
+                        ? `${sidebarMenuItemStyles.base} ${sidebarMenuItemStyles.active}`
+                        : `${sidebarMenuItemStyles.base} ${sidebarMenuItemStyles.inactive}`;
+
+                    if (menu.enabled) {
+                        return (
+                            <Link
+                                key={menu.href}
+                                href={menu.href}
+                                className={className}
+                                onClick={(event) =>
+                                    handleMenuClick(event, menu.href)
+                                }
+                            >
+                                <Icon className={sidebarMenuItemStyles.icon} />
+                                <span>{menu.label}</span>
+                            </Link>
+                        );
+                    }
+
+                    return (
+                        <button
+                            key={menu.href}
+                            type="button"
+                            onClick={
+                                isRecommendationLoading
+                                    ? () =>
+                                          alert(
+                                              "메뉴 추천을 위한 취향 분석이 진행중입니다.",
+                                          )
+                                    : handleNotReady
+                            }
+                            className={`${className} w-full text-left`}
+                        >
+                            <Icon className={sidebarMenuItemStyles.icon} />
+                            <span>{menu.label}</span>
+                        </button>
+                    );
+                })}
+            </nav>
+        </aside>
+    );
 }

--- a/src/ui/styles/personalRecommendationLoadingStyles.ts
+++ b/src/ui/styles/personalRecommendationLoadingStyles.ts
@@ -1,0 +1,16 @@
+export const personalRecommendationLoadingStyles = {
+    container:
+        "flex min-h-screen items-center justify-center bg-[#fbf9f9] px-10",
+    card:
+        "flex h-[520px] w-full max-w-[1160px] flex-col items-center justify-center rounded-[32px] bg-white shadow-md",
+    iconWrapper:
+        "relative flex h-[180px] w-[180px] items-center justify-center",
+    spinner:
+        "absolute h-[150px] w-[150px] animate-spin rounded-full border-4 border-orange-100 border-t-orange-400",
+    iconCircle:
+        "relative flex h-[124px] w-[124px] items-center justify-center rounded-full bg-orange-100 text-orange-400 shadow-md",
+    title:
+        "mt-8 text-4xl font-bold text-zinc-950",
+    description:
+        "mt-5 text-base font-medium text-slate-700",
+} as const;

--- a/src/ui/styles/personalRecommendationPageStyles.ts
+++ b/src/ui/styles/personalRecommendationPageStyles.ts
@@ -34,5 +34,7 @@ export const personalRecommendationPageStyles = {
         "flex h-16 w-16 items-center justify-center rounded-full bg-[#eaf1fb] text-[#b5c4d7]",
     historyList: "flex w-full flex-col gap-3",
     historyItem:
-        "flex flex-col gap-1 rounded-2xl bg-zinc-50 px-4 py-3 text-sm text-zinc-700",
+        "flex items-center justify-between rounded-2xl bg-zinc-100 px-5 py-4 text-left text-zinc-500 transition hover:bg-zinc-200",
+    historyDetailButton:
+        "text-sm font-semibold text-orange-500",
 } as const;

--- a/src/ui/styles/personalRecommendationResultActionButtonsStyles.ts
+++ b/src/ui/styles/personalRecommendationResultActionButtonsStyles.ts
@@ -1,0 +1,7 @@
+export const personalRecommendationResultActionButtonsStyles = {
+    container: "mt-14 flex justify-end gap-4",
+    retryRecommendationButton:
+        "h-16 w-[150px] rounded-full bg-orange-100 text-base font-semibold text-orange-500 shadow-sm transition hover:bg-orange-200 disabled:cursor-not-allowed disabled:opacity-60",
+    completeSelectionButton:
+        "h-16 w-[150px] rounded-full bg-zinc-300 text-base font-semibold text-zinc-800 shadow-sm transition hover:bg-zinc-400 disabled:cursor-not-allowed disabled:opacity-60",
+} as const;

--- a/src/ui/styles/personalRecommendationResultCardStyles.ts
+++ b/src/ui/styles/personalRecommendationResultCardStyles.ts
@@ -1,11 +1,18 @@
 export const personalRecommendationResultCardStyles = {
-    card: "overflow-hidden rounded-3xl bg-white shadow-md",
+    card:
+        "overflow-hidden rounded-3xl bg-white shadow-md transition hover:-translate-y-1 hover:shadow-lg",
+    selectedCard:
+        "overflow-hidden rounded-3xl bg-white shadow-md ring-4 ring-blue-400 transition hover:-translate-y-1 hover:shadow-lg",
     imagePlaceholder:
         "relative flex h-[260px] items-center justify-center bg-zinc-200",
     matchBadge:
         "absolute left-5 top-5 rounded-full bg-orange-700 px-5 py-2 text-sm font-semibold text-white",
-    content: "flex flex-col gap-5 px-7 py-7",
-    menuName: "text-lg font-semibold text-zinc-900",
+    selectedBadge:
+        "absolute right-5 top-5 rounded-full bg-blue-500 px-5 py-2 text-sm font-semibold text-white",
+    content:
+        "flex flex-col gap-5 px-7 py-7",
+    menuName:
+        "text-lg font-semibold text-zinc-900",
     restaurantButton:
         "h-14 rounded-full bg-green-200 text-base font-semibold text-zinc-900 transition hover:bg-green-300",
 } as const;

--- a/src/ui/styles/personalRecommendationResultCardStyles.ts
+++ b/src/ui/styles/personalRecommendationResultCardStyles.ts
@@ -1,0 +1,11 @@
+export const personalRecommendationResultCardStyles = {
+    card: "overflow-hidden rounded-3xl bg-white shadow-md",
+    imagePlaceholder:
+        "relative flex h-[260px] items-center justify-center bg-zinc-200",
+    matchBadge:
+        "absolute left-5 top-5 rounded-full bg-orange-700 px-5 py-2 text-sm font-semibold text-white",
+    content: "flex flex-col gap-5 px-7 py-7",
+    menuName: "text-lg font-semibold text-zinc-900",
+    restaurantButton:
+        "h-14 rounded-full bg-green-200 text-base font-semibold text-zinc-900 transition hover:bg-green-300",
+} as const;

--- a/src/ui/styles/personalRecommendationResultPageStyles.ts
+++ b/src/ui/styles/personalRecommendationResultPageStyles.ts
@@ -1,0 +1,14 @@
+export const personalRecommendationResultPageStyles = {
+    container: "min-h-screen bg-[#fbf9f9] px-12 py-10",
+    backButton:
+        "flex h-10 w-10 items-center justify-center rounded-full text-zinc-800 transition hover:bg-zinc-100",
+    title: "mt-8 text-4xl font-semibold text-zinc-950",
+    summaryCard:
+        "mt-20 rounded-[32px] bg-white px-10 py-8 shadow-sm",
+    summaryTitle: "text-xl font-bold text-zinc-950",
+    keywordGroup: "mt-7 flex flex-wrap gap-5",
+    keywordChip:
+        "rounded-full border border-blue-400 bg-blue-100 px-8 py-3 text-base font-semibold text-zinc-800",
+    emptyText: "text-sm font-medium text-zinc-500",
+    cardGrid: "mt-16 grid grid-cols-3 gap-8",
+} as const;

--- a/src/ui/styles/personalRecommendationResultPageStyles.ts
+++ b/src/ui/styles/personalRecommendationResultPageStyles.ts
@@ -1,14 +1,22 @@
 export const personalRecommendationResultPageStyles = {
-    container: "min-h-screen bg-[#fbf9f9] px-12 py-10",
+    container:
+        "min-h-screen bg-[#fbf9f9] px-12 py-10",
     backButton:
         "flex h-10 w-10 items-center justify-center rounded-full text-zinc-800 transition hover:bg-zinc-100",
-    title: "mt-8 text-4xl font-semibold text-zinc-950",
+    title:
+        "mt-8 text-4xl font-semibold text-zinc-950",
+    closedMessage:
+        "mt-4 text-base font-semibold text-blue-600",
     summaryCard:
-        "mt-20 rounded-[32px] bg-white px-10 py-8 shadow-sm",
-    summaryTitle: "text-xl font-bold text-zinc-950",
-    keywordGroup: "mt-7 flex flex-wrap gap-5",
+        "mt-16 rounded-[32px] bg-white px-10 py-8 shadow-sm",
+    summaryTitle:
+        "text-xl font-bold text-zinc-950",
+    keywordGroup:
+        "mt-7 flex flex-wrap gap-5",
     keywordChip:
         "rounded-full border border-blue-400 bg-blue-100 px-8 py-3 text-base font-semibold text-zinc-800",
-    emptyText: "text-sm font-medium text-zinc-500",
-    cardGrid: "mt-16 grid grid-cols-3 gap-8",
+    emptyText:
+        "text-sm font-medium text-zinc-500",
+    cardGrid:
+        "mt-16 grid grid-cols-3 gap-8",
 } as const;

--- a/src/ui/styles/personalRecommendationStartAlertModalStyles.ts
+++ b/src/ui/styles/personalRecommendationStartAlertModalStyles.ts
@@ -1,0 +1,12 @@
+export const personalRecommendationStartAlertModalStyles = {
+    overlay:
+        "fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 backdrop-blur-sm",
+    modal:
+        "flex w-full max-w-md flex-col items-center rounded-3xl bg-white px-8 py-10 text-center shadow-2xl",
+    title:
+        "text-xl font-bold text-zinc-900",
+    description:
+        "mt-4 text-sm font-medium leading-6 text-zinc-600",
+    confirmButton:
+        "mt-8 h-12 w-full rounded-full bg-black text-sm font-semibold text-white transition hover:bg-zinc-800",
+} as const;


### PR DESCRIPTION
## 관련 이슈
Closes #115
Closes #116 
Closes #117 
Closes #118 
Closes #119 
Closes #120  

## 요약
- 무엇을 변경했나요?
개인 메뉴 추천 시작 조건 확인 기능 추가
개인 메뉴 추천 요청 API 연결
추천 진행 중 로딩 화면 및 상태 관리 구현
개인 메뉴 추천 결과 화면 UI 구현
추천 메뉴 선택 완료 처리 및 최근 기록 연동
진행 중인 추천 재진입 및 결과 조회 기능 구현

- 왜 이 변경이 필요한가요?
사용자가 취향/위치 기반 개인 메뉴 추천을 요청하고 결과를 확인할 수 있도록 하기 위함
진행 중인 추천 상태를 유지하여 중복 추천 요청을 방지하고 사용자 흐름을 개선하기 위함
추천 완료 이력을 조회하고 다시 확인할 수 있도록 하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
