### PR TITLE
[Feat] 그룹 초대 및 초대 응답 기능 구현

### DIFF
--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -10,6 +10,7 @@ import { useGroupInvites } from "@/features/group/application/hooks/useGroupInvi
 import { useCreateGroup } from "@/features/group/application/hooks/useCreateGroup";
 import { useGroupDetail } from "@/features/group/application/hooks/useGroupDetail";
 import { useCreateGroupInvite } from "@/features/group/application/hooks/useCreateGroupInvite";
+import { useRespondGroupInvite } from "@/features/group/application/hooks/useRespondGroupInvite";
 
 import {
     groupsAtom,
@@ -44,13 +45,13 @@ import { groupManagementPageStyles } from "@/ui/styles/groupManagementPageStyles
 export default function GroupPage() {
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
     const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
+    const [isAllInviteViewOpen, setIsAllInviteViewOpen] = useState(false);
     const [groupName, setGroupName] = useState("");
     const [inviteNickname, setInviteNickname] = useState("");
     const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
-    const [isAllInviteViewOpen, setIsAllInviteViewOpen] = useState(false);
 
     const { refetchGroups } = useGroupList();
-    useGroupInvites();
+    const { refetchInvites } = useGroupInvites();
     useGroupDetail(selectedGroupId);
 
     const groups = useAtomValue(groupsAtom);
@@ -87,6 +88,13 @@ export default function GroupPage() {
         },
     });
 
+    const { processingInviteId, respond } = useRespondGroupInvite({
+        onSuccess: () => {
+            refetchGroups();
+            refetchInvites();
+        },
+    });
+
     const handleCreateGroup = async (location: LocationSetting) => {
         await create(groupName, location);
     };
@@ -95,6 +103,14 @@ export default function GroupPage() {
         if (selectedGroupId === null) return;
 
         await invite(selectedGroupId, inviteNickname);
+    };
+
+    const handleAcceptInvite = async (inviteId: number) => {
+        await respond(inviteId, "ACCEPT");
+    };
+
+    const handleDeclineInvite = async (inviteId: number) => {
+        await respond(inviteId, "DECLINE");
     };
 
     const closeInviteModal = () => {
@@ -108,6 +124,9 @@ export default function GroupPage() {
             <GroupInviteAllView
                 invites={invites}
                 onBack={() => setIsAllInviteViewOpen(false)}
+                processingInviteId={processingInviteId}
+                onAcceptInvite={handleAcceptInvite}
+                onDeclineInvite={handleDeclineInvite}
             />
         );
     }
@@ -129,6 +148,9 @@ export default function GroupPage() {
                                 isLoading={isInviteListLoading}
                                 errorMessage={inviteListErrorMessage}
                                 onClickViewAll={() => setIsAllInviteViewOpen(true)}
+                                processingInviteId={processingInviteId}
+                                onAcceptInvite={handleAcceptInvite}
+                                onDeclineInvite={handleDeclineInvite}
                             />
 
                             <section className={groupManagementPageStyles.groupSection}>

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -6,9 +6,9 @@ import { useAtomValue } from "jotai";
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
 
 import { useGroupList } from "@/features/group/application/hooks/useGroupList";
+import { useGroupInvites } from "@/features/group/application/hooks/useGroupInvites";
 import { useCreateGroup } from "@/features/group/application/hooks/useCreateGroup";
 import { useGroupDetail } from "@/features/group/application/hooks/useGroupDetail";
-import { useGroupInvites } from "@/features/group/application/hooks/useGroupInvites";
 
 import {
     groupsAtom,
@@ -35,12 +35,15 @@ import GroupManagementHeader from "@/features/group/ui/components/GroupManagemen
 import GroupCreateModal from "@/features/group/ui/components/GroupCreateModal";
 import GroupDetailPanel from "@/features/group/ui/components/GroupDetailPanel";
 import GroupInviteSection from "@/features/group/ui/components/GroupInviteSection";
+import GroupInviteModal from "@/features/group/ui/components/GroupInviteModal";
 
 import { groupManagementPageStyles } from "@/ui/styles/groupManagementPageStyles";
 
 export default function GroupPage() {
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+    const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
     const [groupName, setGroupName] = useState("");
+    const [inviteNickname, setInviteNickname] = useState("");
     const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
 
     const { refetchGroups } = useGroupList();
@@ -72,6 +75,11 @@ export default function GroupPage() {
 
     const handleCreateGroup = async (location: LocationSetting) => {
         await create(groupName, location);
+    };
+
+    const closeInviteModal = () => {
+        setIsInviteModalOpen(false);
+        setInviteNickname("");
     };
 
     return (
@@ -151,6 +159,7 @@ export default function GroupPage() {
                         <GroupDetailPanel
                             group={groupDetail}
                             onClose={() => setSelectedGroupId(null)}
+                            onClickInvite={() => setIsInviteModalOpen(true)}
                         />
                     )}
                 </div>
@@ -163,6 +172,13 @@ export default function GroupPage() {
                 onClose={() => setIsCreateModalOpen(false)}
                 onChangeGroupName={setGroupName}
                 onCreate={handleCreateGroup}
+            />
+
+            <GroupInviteModal
+                isOpen={isInviteModalOpen}
+                nickname={inviteNickname}
+                onClose={closeInviteModal}
+                onChangeNickname={setInviteNickname}
             />
         </>
     );

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -37,6 +37,7 @@ import GroupCreateModal from "@/features/group/ui/components/GroupCreateModal";
 import GroupDetailPanel from "@/features/group/ui/components/GroupDetailPanel";
 import GroupInviteSection from "@/features/group/ui/components/GroupInviteSection";
 import GroupInviteModal from "@/features/group/ui/components/GroupInviteModal";
+import GroupInviteAllView from "@/features/group/ui/components/GroupInviteAllView";
 
 import { groupManagementPageStyles } from "@/ui/styles/groupManagementPageStyles";
 
@@ -46,6 +47,7 @@ export default function GroupPage() {
     const [groupName, setGroupName] = useState("");
     const [inviteNickname, setInviteNickname] = useState("");
     const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
+    const [isAllInviteViewOpen, setIsAllInviteViewOpen] = useState(false);
 
     const { refetchGroups } = useGroupList();
     useGroupInvites();
@@ -101,6 +103,15 @@ export default function GroupPage() {
         clearInviteMessage();
     };
 
+    if (isAllInviteViewOpen) {
+        return (
+            <GroupInviteAllView
+                invites={invites}
+                onBack={() => setIsAllInviteViewOpen(false)}
+            />
+        );
+    }
+
     return (
         <>
             <main className={groupManagementPageStyles.container}>
@@ -117,6 +128,7 @@ export default function GroupPage() {
                                 showViewAllButton={showViewAllButton}
                                 isLoading={isInviteListLoading}
                                 errorMessage={inviteListErrorMessage}
+                                onClickViewAll={() => setIsAllInviteViewOpen(true)}
                             />
 
                             <section className={groupManagementPageStyles.groupSection}>

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -9,6 +9,7 @@ import { useGroupList } from "@/features/group/application/hooks/useGroupList";
 import { useGroupInvites } from "@/features/group/application/hooks/useGroupInvites";
 import { useCreateGroup } from "@/features/group/application/hooks/useCreateGroup";
 import { useGroupDetail } from "@/features/group/application/hooks/useGroupDetail";
+import { useCreateGroupInvite } from "@/features/group/application/hooks/useCreateGroupInvite";
 
 import {
     groupsAtom,
@@ -73,13 +74,31 @@ export default function GroupPage() {
         },
     });
 
+    const {
+        isInviting,
+        inviteMessage,
+        invite,
+        clearInviteMessage,
+    } = useCreateGroupInvite({
+        onSuccess: () => {
+            setInviteNickname("");
+        },
+    });
+
     const handleCreateGroup = async (location: LocationSetting) => {
         await create(groupName, location);
+    };
+
+    const handleInviteFriend = async () => {
+        if (selectedGroupId === null) return;
+
+        await invite(selectedGroupId, inviteNickname);
     };
 
     const closeInviteModal = () => {
         setIsInviteModalOpen(false);
         setInviteNickname("");
+        clearInviteMessage();
     };
 
     return (
@@ -177,8 +196,11 @@ export default function GroupPage() {
             <GroupInviteModal
                 isOpen={isInviteModalOpen}
                 nickname={inviteNickname}
+                isInviting={isInviting}
+                message={inviteMessage}
                 onClose={closeInviteModal}
                 onChangeNickname={setInviteNickname}
+                onInvite={handleInviteFriend}
             />
         </>
     );

--- a/src/features/group/application/hooks/useCreateGroupInvite.ts
+++ b/src/features/group/application/hooks/useCreateGroupInvite.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+
+import { createGroupInviteByNickname } from "@/features/group/application/usecase/createGroupInviteByNickname";
+
+interface UseCreateGroupInviteParams {
+    readonly onSuccess?: () => void;
+}
+
+type GroupInviteErrorCode =
+    | "GROUP_INVITE_TARGET_NOT_FOUND"
+    | "GROUP_INVITE_SELF_NOT_ALLOWED"
+    | "GROUP_INVITE_TARGET_ALREADY_MEMBER"
+    | "GROUP_INVITE_ALREADY_PENDING";
+
+const groupInviteErrorMessages: Record<GroupInviteErrorCode, string> = {
+    GROUP_INVITE_TARGET_NOT_FOUND:
+        "초대 대상 회원을 찾을 수 없습니다.",
+    GROUP_INVITE_SELF_NOT_ALLOWED:
+        "자기 자신은 그룹에 초대할 수 없습니다.",
+    GROUP_INVITE_TARGET_ALREADY_MEMBER:
+        "이미 그룹에 속한 대상입니다.",
+    GROUP_INVITE_ALREADY_PENDING:
+        "이미 대기 중인 그룹 초대가 있습니다.",
+};
+
+function isGroupInviteErrorCode(
+    code: string | undefined,
+): code is GroupInviteErrorCode {
+    return Boolean(code && code in groupInviteErrorMessages);
+}
+
+function getGroupInviteErrorMessage(error: unknown) {
+    if (error instanceof Error) {
+        const httpError = error as Error & {
+            body?: {
+                error?: {
+                    code?: string;
+                    message?: string;
+                } | null;
+            };
+        };
+
+        const code = httpError.body?.error?.code;
+
+        if (isGroupInviteErrorCode(code)) {
+            return groupInviteErrorMessages[code];
+        }
+
+        return httpError.body?.error?.message ?? error.message;
+    }
+
+    return "친구 초대에 실패했습니다.";
+}
+
+export function useCreateGroupInvite({
+    onSuccess,
+}: UseCreateGroupInviteParams = {}) {
+    const [isInviting, setIsInviting] = useState(false);
+    const [inviteMessage, setInviteMessage] = useState<string | null>(null);
+
+    const invite = async (
+        groupId: number,
+        nickname: string,
+    ) => {
+        try {
+            setIsInviting(true);
+            setInviteMessage(null);
+
+            await createGroupInviteByNickname(
+                groupId,
+                nickname,
+            );
+
+            setInviteMessage("초대 요청을 보냈습니다.");
+            onSuccess?.();
+        } catch (error) {
+            console.log("친구 초대 에러", error);
+            setInviteMessage(getGroupInviteErrorMessage(error));
+        } finally {
+            setIsInviting(false);
+        }
+    };
+
+    const clearInviteMessage = () => {
+        setInviteMessage(null);
+    };
+
+    return {
+        isInviting,
+        inviteMessage,
+        invite,
+        clearInviteMessage,
+    };
+}

--- a/src/features/group/application/hooks/useRespondGroupInvite.ts
+++ b/src/features/group/application/hooks/useRespondGroupInvite.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+
+import type { GroupInviteResponseType } from "@/features/group/domain/model/GroupInviteResponseType";
+
+import { respondGroupInvite } from "@/features/group/application/usecase/respondGroupInvite";
+
+interface UseRespondGroupInviteParams {
+    readonly onSuccess?: () => void;
+}
+
+export function useRespondGroupInvite({
+    onSuccess,
+}: UseRespondGroupInviteParams = {}) {
+    const [processingInviteId, setProcessingInviteId] =
+        useState<number | null>(null);
+
+    const respond = async (
+        inviteId: number,
+        responseType: GroupInviteResponseType,
+    ) => {
+        try {
+            setProcessingInviteId(inviteId);
+
+            await respondGroupInvite(
+                inviteId,
+                responseType,
+            );
+
+            onSuccess?.();
+        } finally {
+            setProcessingInviteId(null);
+        }
+    };
+
+    return {
+        processingInviteId,
+        respond,
+    };
+}

--- a/src/features/group/application/usecase/createGroupInviteByNickname.ts
+++ b/src/features/group/application/usecase/createGroupInviteByNickname.ts
@@ -1,0 +1,11 @@
+import { groupInviteApi } from "@/features/group/infrastructure/api/groupInviteApi";
+
+export async function createGroupInviteByNickname(
+    groupId: number,
+    nickname: string,
+) {
+    return groupInviteApi.createInviteByNickname({
+        groupId,
+        nickname,
+    });
+}

--- a/src/features/group/application/usecase/respondGroupInvite.ts
+++ b/src/features/group/application/usecase/respondGroupInvite.ts
@@ -1,0 +1,13 @@
+import type { GroupInviteResponseType } from "@/features/group/domain/model/GroupInviteResponseType";
+
+import { groupInviteApi } from "@/features/group/infrastructure/api/groupInviteApi";
+
+export async function respondGroupInvite(
+    inviteId: number,
+    responseType: GroupInviteResponseType,
+) {
+    return groupInviteApi.respondInvite(
+        inviteId,
+        responseType,
+    );
+}

--- a/src/features/group/domain/model/GroupInviteResponseType.ts
+++ b/src/features/group/domain/model/GroupInviteResponseType.ts
@@ -1,0 +1,3 @@
+export type GroupInviteResponseType =
+    | "ACCEPT"
+    | "DECLINE";

--- a/src/features/group/infrastructure/api/dto/GroupInviteCreateRequest.ts
+++ b/src/features/group/infrastructure/api/dto/GroupInviteCreateRequest.ts
@@ -1,0 +1,4 @@
+export interface GroupInviteCreateRequest {
+    readonly groupId: number;
+    readonly nickname: string;
+}

--- a/src/features/group/infrastructure/api/dto/GroupInviteCreateResponse.ts
+++ b/src/features/group/infrastructure/api/dto/GroupInviteCreateResponse.ts
@@ -1,0 +1,22 @@
+import type { GroupInviteStatus } from "@/features/group/domain/model/GroupInvite";
+
+export interface GroupInviteCreateResponse {
+    readonly success: boolean;
+
+    readonly data: {
+        readonly inviteId: number;
+        readonly groupId: number;
+        readonly groupName: string;
+        readonly targetMemberId: number;
+        readonly targetNickname: string;
+        readonly expiresAt: string;
+        readonly status: GroupInviteStatus;
+    };
+
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/group/infrastructure/api/dto/GroupInviteRespondRequest.ts
+++ b/src/features/group/infrastructure/api/dto/GroupInviteRespondRequest.ts
@@ -1,0 +1,5 @@
+import type { GroupInviteResponseType } from "@/features/group/domain/model/GroupInviteResponseType";
+
+export interface GroupInviteRespondRequest {
+    readonly responseType: GroupInviteResponseType;
+}

--- a/src/features/group/infrastructure/api/dto/GroupInviteRespondResponse.ts
+++ b/src/features/group/infrastructure/api/dto/GroupInviteRespondResponse.ts
@@ -1,0 +1,18 @@
+export interface GroupInviteRespondResponse {
+    readonly success: boolean;
+
+    readonly data: {
+        readonly inviteId: number;
+        readonly groupId: number;
+        readonly inviteStatus: string;
+        readonly memberStatus: string;
+        readonly respondedAt: string;
+    };
+
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/group/infrastructure/api/groupInviteApi.ts
+++ b/src/features/group/infrastructure/api/groupInviteApi.ts
@@ -1,9 +1,13 @@
 import { httpClient } from "@/infrastructure/http/httpClient";
 
 import type { GroupInvite } from "@/features/group/domain/model/GroupInvite";
+import type { GroupInviteResponseType } from "@/features/group/domain/model/GroupInviteResponseType";
+
 import type { GroupInviteListResponse } from "@/features/group/infrastructure/api/dto/GroupInviteListResponse";
 import type { GroupInviteCreateRequest } from "@/features/group/infrastructure/api/dto/GroupInviteCreateRequest";
 import type { GroupInviteCreateResponse } from "@/features/group/infrastructure/api/dto/GroupInviteCreateResponse";
+import type { GroupInviteRespondRequest } from "@/features/group/infrastructure/api/dto/GroupInviteRespondRequest";
+import type { GroupInviteRespondResponse } from "@/features/group/infrastructure/api/dto/GroupInviteRespondResponse";
 
 import { mapGroupInviteListToModel } from "@/features/group/infrastructure/api/mapper/groupInviteMapper";
 
@@ -34,5 +38,20 @@ export const groupInviteApi = {
             );
 
         return response.data;
-    }
+    },
+
+    async respondInvite(
+        inviteId: number,
+        responseType: GroupInviteResponseType,
+    ) {
+        const response =
+            await httpClient.post<GroupInviteRespondResponse>(
+                `/api/v1/groups/invites/${inviteId}/response`,
+                {
+                    responseType,
+                } satisfies GroupInviteRespondRequest,
+            );
+
+        return response.data;
+    },
 };

--- a/src/features/group/infrastructure/api/groupInviteApi.ts
+++ b/src/features/group/infrastructure/api/groupInviteApi.ts
@@ -2,6 +2,8 @@ import { httpClient } from "@/infrastructure/http/httpClient";
 
 import type { GroupInvite } from "@/features/group/domain/model/GroupInvite";
 import type { GroupInviteListResponse } from "@/features/group/infrastructure/api/dto/GroupInviteListResponse";
+import type { GroupInviteCreateRequest } from "@/features/group/infrastructure/api/dto/GroupInviteCreateRequest";
+import type { GroupInviteCreateResponse } from "@/features/group/infrastructure/api/dto/GroupInviteCreateResponse";
 
 import { mapGroupInviteListToModel } from "@/features/group/infrastructure/api/mapper/groupInviteMapper";
 
@@ -19,8 +21,18 @@ export const groupInviteApi = {
             );
         }
 
-        return mapGroupInviteListToModel(
-            response.data.content,
-        );
+        return mapGroupInviteListToModel(response.data.content);
     },
+
+    async createInviteByNickname(
+        request: GroupInviteCreateRequest,
+    ) {
+        const response =
+            await httpClient.post<GroupInviteCreateResponse>(
+                "/api/v1/groups/invites/nickname",
+                request,
+            );
+
+        return response.data;
+    }
 };

--- a/src/features/group/ui/components/GroupDetailPanel.tsx
+++ b/src/features/group/ui/components/GroupDetailPanel.tsx
@@ -24,7 +24,7 @@ export default function GroupDetailPanel({
     onClose,
     onClickInvite,
 }: GroupDetailPanelProps) {
-    const visibleMembers = group.members.slice(0, 4);
+    const visibleMembers = group.members.slice(0, 3);
     const isOwner = useAtomValue(isGroupOwnerAtom);
 
     return (
@@ -103,7 +103,7 @@ export default function GroupDetailPanel({
                             </div>
                         ))}
 
-                        {group.members.length > 4 && (
+                        {group.members.length > 3 && (
                             <button
                                 type="button"
                                 className={groupDetailPanelStyles.memberMoreButton}

--- a/src/features/group/ui/components/GroupDetailPanel.tsx
+++ b/src/features/group/ui/components/GroupDetailPanel.tsx
@@ -16,11 +16,13 @@ import { groupDetailPanelStyles } from "@/ui/styles/groupDetailPanelStyles";
 interface GroupDetailPanelProps {
     readonly group: GroupDetail;
     readonly onClose: () => void;
+    readonly onClickInvite: () => void;
 }
 
 export default function GroupDetailPanel({
     group,
     onClose,
+    onClickInvite,
 }: GroupDetailPanelProps) {
     const visibleMembers = group.members.slice(0, 4);
     const isOwner = useAtomValue(isGroupOwnerAtom);
@@ -67,7 +69,11 @@ export default function GroupDetailPanel({
                             </p>
                         </div>
 
-                        {isOwner && <GroupMemberInviteButton />}
+                        {isOwner && (
+                            <GroupMemberInviteButton
+                                onClick={onClickInvite}
+                            />
+                        )}
                     </div>
 
                     <div className={groupDetailPanelStyles.memberList}>

--- a/src/features/group/ui/components/GroupInviteAcceptButton.tsx
+++ b/src/features/group/ui/components/GroupInviteAcceptButton.tsx
@@ -1,0 +1,22 @@
+import { groupInviteCardStyles } from "@/ui/styles/groupInviteCardStyles";
+
+interface GroupInviteAcceptButtonProps {
+    readonly disabled: boolean;
+    readonly onClick: () => void;
+}
+
+export default function GroupInviteAcceptButton({
+    disabled,
+    onClick,
+}: GroupInviteAcceptButtonProps) {
+    return (
+        <button
+            type="button"
+            disabled={disabled}
+            onClick={onClick}
+            className={groupInviteCardStyles.acceptButton}
+        >
+            수락
+        </button>
+    );
+}

--- a/src/features/group/ui/components/GroupInviteAllView.tsx
+++ b/src/features/group/ui/components/GroupInviteAllView.tsx
@@ -7,11 +7,18 @@ import { groupInviteAllViewStyles } from "@/ui/styles/groupInviteAllViewStyles";
 interface GroupInviteAllViewProps {
     readonly invites: readonly GroupInvite[];
     readonly onBack: () => void;
+
+    readonly processingInviteId: number | null;
+    readonly onAcceptInvite: (inviteId: number) => void;
+    readonly onDeclineInvite: (inviteId: number) => void;
 }
 
 export default function GroupInviteAllView({
     invites,
     onBack,
+    processingInviteId,
+    onAcceptInvite,
+    onDeclineInvite,
 }: GroupInviteAllViewProps) {
     return (
         <main className={groupInviteAllViewStyles.container}>
@@ -38,6 +45,15 @@ export default function GroupInviteAllView({
                         <GroupInviteCard
                             key={invite.inviteId}
                             invite={invite}
+                            isProcessing={
+                                processingInviteId === invite.inviteId
+                            }
+                            onAccept={() =>
+                                onAcceptInvite(invite.inviteId)
+                            }
+                            onDecline={() =>
+                                onDeclineInvite(invite.inviteId)
+                            }
                         />
                     ))}
                 </div>

--- a/src/features/group/ui/components/GroupInviteAllView.tsx
+++ b/src/features/group/ui/components/GroupInviteAllView.tsx
@@ -1,0 +1,47 @@
+import { ArrowLeft } from "lucide-react";
+
+import type { GroupInvite } from "@/features/group/domain/model/GroupInvite";
+import GroupInviteCard from "@/features/group/ui/components/GroupInviteCard";
+import { groupInviteAllViewStyles } from "@/ui/styles/groupInviteAllViewStyles";
+
+interface GroupInviteAllViewProps {
+    readonly invites: readonly GroupInvite[];
+    readonly onBack: () => void;
+}
+
+export default function GroupInviteAllView({
+    invites,
+    onBack,
+}: GroupInviteAllViewProps) {
+    return (
+        <main className={groupInviteAllViewStyles.container}>
+            <div className={groupInviteAllViewStyles.content}>
+                <header className={groupInviteAllViewStyles.header}>
+                    <button
+                        type="button"
+                        onClick={onBack}
+                        className={groupInviteAllViewStyles.backButton}
+                    >
+                        <ArrowLeft size={24} />
+                    </button>
+
+                    <h1 className={groupInviteAllViewStyles.title}>
+                        모든 초대{" "}
+                        <span className={groupInviteAllViewStyles.count}>
+                            ({invites.length})
+                        </span>
+                    </h1>
+                </header>
+
+                <div className={groupInviteAllViewStyles.inviteGrid}>
+                    {invites.map((invite) => (
+                        <GroupInviteCard
+                            key={invite.inviteId}
+                            invite={invite}
+                        />
+                    ))}
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/src/features/group/ui/components/GroupInviteCard.tsx
+++ b/src/features/group/ui/components/GroupInviteCard.tsx
@@ -2,13 +2,24 @@ import { User } from "lucide-react";
 
 import type { GroupInvite } from "@/features/group/domain/model/GroupInvite";
 
+import GroupInviteAcceptButton from "@/features/group/ui/components/GroupInviteAcceptButton";
+import GroupInviteDeclineButton from "@/features/group/ui/components/GroupInviteDeclineButton";
+
 import { groupInviteCardStyles } from "@/ui/styles/groupInviteCardStyles";
 
 interface GroupInviteCardProps {
     readonly invite: GroupInvite;
+    readonly isProcessing: boolean;
+    readonly onAccept: () => void;
+    readonly onDecline: () => void;
 }
 
-export default function GroupInviteCard({ invite }: GroupInviteCardProps) {
+export default function GroupInviteCard({
+    invite,
+    isProcessing,
+    onAccept,
+    onDecline,
+}: GroupInviteCardProps) {
     return (
         <article className={groupInviteCardStyles.card}>
             <div className={groupInviteCardStyles.info}>
@@ -28,19 +39,15 @@ export default function GroupInviteCard({ invite }: GroupInviteCardProps) {
             </div>
 
             <div className={groupInviteCardStyles.actions}>
-                <button
-                    type="button"
-                    className={groupInviteCardStyles.acceptButton}
-                >
-                    수락
-                </button>
+                <GroupInviteAcceptButton
+                    disabled={isProcessing}
+                    onClick={onAccept}
+                />
 
-                <button
-                    type="button"
-                    className={groupInviteCardStyles.declineButton}
-                >
-                    거절
-                </button>
+                <GroupInviteDeclineButton
+                    disabled={isProcessing}
+                    onClick={onDecline}
+                />
             </div>
         </article>
     );

--- a/src/features/group/ui/components/GroupInviteDeclineButton.tsx
+++ b/src/features/group/ui/components/GroupInviteDeclineButton.tsx
@@ -1,0 +1,22 @@
+import { groupInviteCardStyles } from "@/ui/styles/groupInviteCardStyles";
+
+interface GroupInviteDeclineButtonProps {
+    readonly disabled: boolean;
+    readonly onClick: () => void;
+}
+
+export default function GroupInviteDeclineButton({
+    disabled,
+    onClick,
+}: GroupInviteDeclineButtonProps) {
+    return (
+        <button
+            type="button"
+            disabled={disabled}
+            onClick={onClick}
+            className={groupInviteCardStyles.declineButton}
+        >
+            거절
+        </button>
+    );
+}

--- a/src/features/group/ui/components/GroupInviteModal.tsx
+++ b/src/features/group/ui/components/GroupInviteModal.tsx
@@ -7,19 +7,28 @@ import { groupInviteModalStyles } from "@/ui/styles/groupInviteModalStyles";
 interface GroupInviteModalProps {
     readonly isOpen: boolean;
     readonly nickname: string;
+    readonly isInviting: boolean;
+    readonly message: string | null;
     readonly onClose: () => void;
     readonly onChangeNickname: (value: string) => void;
+    readonly onInvite: () => void;
 }
 
 export default function GroupInviteModal({
     isOpen,
     nickname,
+    isInviting,
+    message,
     onClose,
     onChangeNickname,
+    onInvite,
 }: GroupInviteModalProps) {
     if (!isOpen) {
         return null;
     }
+
+    const isDisabled =
+        nickname.trim().length === 0 || isInviting;
 
     return (
         <div className={groupInviteModalStyles.overlay}>
@@ -29,7 +38,7 @@ export default function GroupInviteModal({
                     onClick={onClose}
                     className={groupInviteModalStyles.backButton}
                 >
-                    <ArrowLeft size={24} />
+                    <ArrowLeft size={22} />
                 </button>
 
                 <div className={groupInviteModalStyles.content}>
@@ -47,12 +56,24 @@ export default function GroupInviteModal({
                         className={groupInviteModalStyles.input}
                     />
 
+                    {message && (
+                        <p className={groupInviteModalStyles.message}>
+                            {message}
+                        </p>
+                    )}
+
                     <div className={groupInviteModalStyles.footer}>
                         <button
                             type="button"
-                            className={groupInviteModalStyles.inviteButton}
+                            disabled={isDisabled}
+                            onClick={onInvite}
+                            className={
+                                isDisabled
+                                    ? groupInviteModalStyles.disabledButton
+                                    : groupInviteModalStyles.inviteButton
+                            }
                         >
-                            초대
+                            {isInviting ? "초대 중..." : "초대"}
                         </button>
                     </div>
                 </div>

--- a/src/features/group/ui/components/GroupInviteModal.tsx
+++ b/src/features/group/ui/components/GroupInviteModal.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+
+import { groupInviteModalStyles } from "@/ui/styles/groupInviteModalStyles";
+
+interface GroupInviteModalProps {
+    readonly isOpen: boolean;
+    readonly nickname: string;
+    readonly onClose: () => void;
+    readonly onChangeNickname: (value: string) => void;
+}
+
+export default function GroupInviteModal({
+    isOpen,
+    nickname,
+    onClose,
+    onChangeNickname,
+}: GroupInviteModalProps) {
+    if (!isOpen) {
+        return null;
+    }
+
+    return (
+        <div className={groupInviteModalStyles.overlay}>
+            <div className={groupInviteModalStyles.modal}>
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className={groupInviteModalStyles.backButton}
+                >
+                    <ArrowLeft size={24} />
+                </button>
+
+                <div className={groupInviteModalStyles.content}>
+                    <h2 className={groupInviteModalStyles.title}>
+                        친구 초대
+                    </h2>
+
+                    <input
+                        type="text"
+                        value={nickname}
+                        onChange={(event) =>
+                            onChangeNickname(event.target.value)
+                        }
+                        placeholder="초대할 친구의 닉네임을 입력하세요."
+                        className={groupInviteModalStyles.input}
+                    />
+
+                    <div className={groupInviteModalStyles.footer}>
+                        <button
+                            type="button"
+                            className={groupInviteModalStyles.inviteButton}
+                        >
+                            초대
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/features/group/ui/components/GroupInviteSection.tsx
+++ b/src/features/group/ui/components/GroupInviteSection.tsx
@@ -12,6 +12,7 @@ interface GroupInviteSectionProps {
     //받은 초대 목록 조회 상태
     readonly isLoading: boolean;
     readonly errorMessage: string | null;
+    readonly onClickViewAll: () => void;
 }
 
 export default function GroupInviteSection({
@@ -20,6 +21,7 @@ export default function GroupInviteSection({
     showViewAllButton,
     isLoading,
     errorMessage,
+    onClickViewAll,
 }: GroupInviteSectionProps) {
     return (
         <section className={groupManagementPageStyles.section}>
@@ -39,6 +41,7 @@ export default function GroupInviteSection({
                 {showViewAllButton && (
                     <button
                         type="button"
+                        onClick={onClickViewAll}
                         className={groupManagementPageStyles.viewAllButton}
                     >
                         모두 보기

--- a/src/features/group/ui/components/GroupInviteSection.tsx
+++ b/src/features/group/ui/components/GroupInviteSection.tsx
@@ -13,6 +13,9 @@ interface GroupInviteSectionProps {
     readonly isLoading: boolean;
     readonly errorMessage: string | null;
     readonly onClickViewAll: () => void;
+    readonly processingInviteId: number | null;
+    readonly onAcceptInvite: (inviteId: number) => void;
+    readonly onDeclineInvite: (inviteId: number) => void;
 }
 
 export default function GroupInviteSection({
@@ -22,6 +25,9 @@ export default function GroupInviteSection({
     isLoading,
     errorMessage,
     onClickViewAll,
+    processingInviteId,
+    onAcceptInvite,
+    onDeclineInvite,
 }: GroupInviteSectionProps) {
     return (
         <section className={groupManagementPageStyles.section}>
@@ -72,6 +78,9 @@ export default function GroupInviteSection({
                             <GroupInviteCard
                                 key={invite.inviteId}
                                 invite={invite}
+                                isProcessing={processingInviteId === invite.inviteId}
+                                onAccept={() => onAcceptInvite(invite.inviteId)}
+                                onDecline={() => onDeclineInvite(invite.inviteId)}
                             />
                         ))}
                     </div>

--- a/src/features/group/ui/components/GroupMemberInviteButton.tsx
+++ b/src/features/group/ui/components/GroupMemberInviteButton.tsx
@@ -1,7 +1,11 @@
+"use client";
+
+import { Plus } from "lucide-react";
+
 import { groupDetailPanelStyles } from "@/ui/styles/groupDetailPanelStyles";
 
 interface GroupMemberInviteButtonProps {
-    readonly onClick?: () => void;
+    readonly onClick: () => void;
 }
 
 export default function GroupMemberInviteButton({
@@ -13,7 +17,8 @@ export default function GroupMemberInviteButton({
             onClick={onClick}
             className={groupDetailPanelStyles.memberInviteButton}
         >
-            + 초대
+            <Plus size={14} />
+            <span>초대</span>
         </button>
     );
 }

--- a/src/infrastructure/http/httpClient.ts
+++ b/src/infrastructure/http/httpClient.ts
@@ -7,10 +7,24 @@ import {
 import type { OnboardingState } from "@/features/auth/domain/model/Onboarding";
 import type { LoginMember } from "@/features/auth/domain/model/LoginMember";
 
+interface ErrorResponseBody {
+    readonly success?: boolean;
+
+    readonly data?: unknown;
+
+    readonly error?: {
+        readonly status?: number;
+        readonly code?: string;
+        readonly message?: string;
+        readonly details?: readonly unknown[];
+    } | null;
+}
+
 class HttpError extends Error {
     constructor(
         public readonly status: number,
         public readonly statusText: string,
+        public readonly body?: ErrorResponseBody,
     ) {
         super(`[httpClient] ${status} ${statusText}`);
         this.name = "HttpError";
@@ -35,6 +49,7 @@ const NO_REFRESH_PATHS = [
 const SILENT_ERROR_LOG_PATHS = [
     "/api/v1/auth/refresh",
     "/api/v1/auth/email/confirm",
+    "/api/v1/groups/invites/nickname",
 ];
 
 function shouldTryRefresh(path: string, isRetry: boolean) {
@@ -115,7 +130,7 @@ async function request<T>(
                 body: errorBody,
             });
         }
-        throw new HttpError(response.status, response.statusText);
+        throw new HttpError(response.status, response.statusText, errorBody,);
     }
 
     const text = await response.text();

--- a/src/ui/styles/groupDetailPanelStyles.ts
+++ b/src/ui/styles/groupDetailPanelStyles.ts
@@ -15,7 +15,7 @@ export const groupDetailPanelStyles = {
     memberSectionHeader: "flex items-start justify-between",
     memberSectionTitle: "text-xl font-bold text-zinc-900",
     memberCountText: "mt-1 text-sm text-slate-500",
-    memberInviteButton: "rounded-full bg-blue-100 px-5 py-2 text-sm font-semibold text-blue-600",
+    memberInviteButton: "flex items-center gap-1 rounded-full bg-blue-100 px-5 py-2 text-sm font-semibold text-blue-600",
     memberList: "mt-8 flex items-start gap-6",
     memberCard: "flex flex-col items-center gap-2",
     memberAvatar: "flex h-16 w-16 items-center justify-center rounded-full bg-slate-200 text-slate-500",

--- a/src/ui/styles/groupInviteAllViewStyles.ts
+++ b/src/ui/styles/groupInviteAllViewStyles.ts
@@ -1,0 +1,10 @@
+export const groupInviteAllViewStyles = {
+    container: "h-screen overflow-hidden bg-white",
+    content: "h-full px-14 py-28",
+    header: "mb-16 flex items-center gap-5",
+    backButton:
+        "flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 text-zinc-900 transition hover:bg-zinc-200",
+    title: "text-4xl font-bold text-zinc-900",
+    count: "text-blue-500",
+    inviteGrid: "grid grid-cols-2 gap-x-14 gap-y-8",
+} as const;

--- a/src/ui/styles/groupInviteModalStyles.ts
+++ b/src/ui/styles/groupInviteModalStyles.ts
@@ -1,0 +1,12 @@
+export const groupInviteModalStyles = {
+    overlay: "fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-[2px]",
+    modal: "w-full max-w-[520px] rounded-[28px] bg-white px-8 py-8 shadow-xl",
+    backButton:
+        "flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-slate-700 transition hover:bg-slate-200",
+    content: "mt-5 flex flex-col gap-6",
+    title: "text-2xl font-bold text-zinc-900",
+    input:
+        "h-12 rounded-xl border border-slate-200 px-4 text-sm text-zinc-700 outline-none transition placeholder:text-slate-400 focus:border-slate-400",
+    footer: "flex justify-end",
+    inviteButton: "h-11 rounded-full bg-black px-8 text-sm font-semibold text-white transition hover:bg-zinc-800",
+} as const;

--- a/src/ui/styles/groupInviteModalStyles.ts
+++ b/src/ui/styles/groupInviteModalStyles.ts
@@ -9,4 +9,6 @@ export const groupInviteModalStyles = {
         "h-12 rounded-xl border border-slate-200 px-4 text-sm text-zinc-700 outline-none transition placeholder:text-slate-400 focus:border-slate-400",
     footer: "flex justify-end",
     inviteButton: "h-11 rounded-full bg-black px-8 text-sm font-semibold text-white transition hover:bg-zinc-800",
+    message: "text-sm font-medium text-slate-600",
+    disabledButton: "h-11 cursor-not-allowed rounded-full bg-zinc-300 px-8 text-sm font-semibold text-zinc-500",
 } as const;


### PR DESCRIPTION
## 관련 이슈
Closes #145 
Closes #146 
Closes #147 
Closes #148 

## 요약
- 무엇을 변경했나요?
그룹 친구 초대 모달 UI 구현
닉네임 기반 그룹 초대 API 연동
그룹 초대 실패 케이스(자기 자신 초대, 중복 초대, 이미 참여 중인 회원 등)에 대한 에러 메시지 처리 추가
받은 초대가 3개 이상일 경우 이동 가능한 ‘모든 초대’ 화면 구현
그룹 초대 수락/거절 API 연동
초대 수락 시 초대 목록 및 그룹 목록 상태 갱신 처리
초대 카드의 수락/거절 버튼을 별도 컴포넌트로 분리

- 왜 이 변경이 필요한가요?
그룹 기능의 핵심 사용자 흐름인 초대 → 수락/거절 과정을 완성하기 위함
여러 개의 초대를 효율적으로 확인할 수 있도록 전체 초대 화면 필요
초대 실패 원인을 사용자에게 명확히 안내하여 UX를 개선하기 위해 에러 메시지 처리 추가
초대 관련 UI와 로직을 분리하여 유지보수성과 확장성을 높이기 위해 컴포넌트를 구조화

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
