### PR TITLE
[Fix] 그룹 위치 수정 후 위치 정보 미갱신 문제 수정 (#155)

### DIFF
--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -130,13 +130,7 @@ export default function GroupPage() {
         isUpdating: isUpdatingLocation,
         update: updateLocation,
         clearMessage: clearLocationUpdateMessage,
-    } = useUpdateGroupLocation({
-        onSuccess: () => {
-            refetchGroupDetail();
-            setIsLocationEditModalOpen(false);
-            setEditingLocation(null);
-        },
-    });
+    } = useUpdateGroupLocation();
 
     const { isDeleting, removeGroup } = useDeleteGroup({
         onSuccess: () => {
@@ -200,15 +194,32 @@ export default function GroupPage() {
         setIsLocationEditModalOpen(true);
     };
 
-    const handleUpdateLocation = async () => {
-        if (selectedGroupId === null || !editingLocation) return;
+    const handleUpdateLocation = async (
+        location: LocationSetting,
+    ) => {
+        if (selectedGroupId === null) return;
+
+        console.log("수정 요청 위치", {
+            groupId: selectedGroupId,
+            latitude: location.latitude,
+            longitude: location.longitude,
+            address: location.address,
+            level: location.level,
+        });
 
         await updateLocation(
             selectedGroupId,
-            editingLocation.latitude,
-            editingLocation.longitude,
-            editingLocation.level,
+            location.latitude,
+            location.longitude,
+            location.level,
         );
+
+        // 위치 수정 후 최신 상세 정보를 다시 조회
+        await refetchGroupDetail();
+
+        // 상세 재조회 이후 모달 상태 초기화
+        setIsLocationEditModalOpen(false);
+        setEditingLocation(null);
     };
 
     const openDeleteModal = () => {
@@ -395,7 +406,6 @@ export default function GroupPage() {
                     location={editingLocation}
                     isUpdating={isUpdatingLocation}
                     onClose={closeLocationEditModal}
-                    onChangeLocation={setEditingLocation}
                     onSubmit={handleUpdateLocation}
                 />
             )}

--- a/src/features/group/application/hooks/useGroupDetail.ts
+++ b/src/features/group/application/hooks/useGroupDetail.ts
@@ -18,7 +18,7 @@ export function useGroupDetail(groupId: number | null) {
             setGroupDetailState({ status: "LOADING" });
 
             const groupDetail = await fetchGroupDetail(groupId);
-            console.log("그룹 정보?:", groupDetail);
+            console.log("그룹 상세 패널 열림:", groupDetail);
 
             setGroupDetailState({
                 status: "SUCCESS",

--- a/src/features/group/application/selectors/groupDetailSelectors.ts
+++ b/src/features/group/application/selectors/groupDetailSelectors.ts
@@ -1,6 +1,4 @@
 import { atom } from "jotai";
-
-import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
 import { groupDetailAtom } from "@/features/group/application/atoms/groupDetailAtom";
 
 export const groupDetailAtomValue = atom((get) => {
@@ -17,34 +15,17 @@ export const groupDetailErrorMessageAtom = atom((get) => {
     return state.status === "ERROR" ? state.message : null;
 });
 
-// TODO: 서버에서 isMe 정보를 보내주면 주석 처리한 걸로 수정 필요
 export const myGroupMemberAtom = atom((get) => {
     const groupDetail = get(groupDetailAtomValue);
-    const member = get(memberAtom);
 
-    if (!groupDetail || !member) {
+    if (!groupDetail) {
         return null;
     }
 
     return (
-        groupDetail.members.find(
-            (groupMember) =>
-                groupMember.memberId === member.id,
-        ) ?? null
+        groupDetail.members.find((groupMember) => groupMember.isMe) ?? null
     );
 });
-
-// export const myGroupMemberAtom = atom((get) => {
-//     const groupDetail = get(groupDetailAtomValue);
-//
-//     if (!groupDetail) {
-//         return null;
-//     }
-//
-//     return (
-//         groupDetail.members.find((groupMember) => groupMember.isMe) ?? null
-//     );
-// });
 
 export const myGroupRoleAtom = atom((get) => {
     return get(myGroupMemberAtom)?.role ?? null;

--- a/src/features/group/infrastructure/api/groupApi.ts
+++ b/src/features/group/infrastructure/api/groupApi.ts
@@ -76,11 +76,17 @@ export const groupApi = {
         groupId: number,
         request: GroupUpdateRequest,
     ) {
+        console.log("PATCH 요청", {
+            groupId,
+            request,
+        });
         const response =
             await httpClient.patch<GroupUpdateResponse>(
                 `/api/v1/groups/${groupId}`,
                 request,
             );
+
+        console.log("그룹 수정 성공 response:", response.data);
 
         if (!response.success) {
             throw new Error(

--- a/src/features/group/ui/components/GroupLocationEditModal.tsx
+++ b/src/features/group/ui/components/GroupLocationEditModal.tsx
@@ -13,7 +13,6 @@ interface GroupLocationEditModalProps {
     readonly location: LocationSetting;
     readonly isUpdating: boolean;
     readonly onClose: () => void;
-    readonly onChangeLocation: (location: LocationSetting) => void;
     readonly onSubmit: (location: LocationSetting) => void;
 }
 
@@ -21,7 +20,6 @@ export default function GroupLocationEditModal({
     location,
     isUpdating,
     onClose,
-    onChangeLocation,
     onSubmit,
 }: GroupLocationEditModalProps) {
     const {
@@ -33,28 +31,15 @@ export default function GroupLocationEditModal({
         handleSearchFailed,
     } = useLocationSearch();
 
-    // address와 좌표 state를 하나로 통합
-    // 모달이 열릴 때 전달받은 기존 그룹 위치가 초기값으로 들어감
     const [selectedLocation, setSelectedLocation] =
-        useState<LocationSetting | null>(location);
+        useState<LocationSetting>(location);
 
-    // KakaoMapView 재생성을 막기 위해 지도 초기 중심값을 고정
-    const [initialLocation] = useState<LocationSetting>(location);
-
-    if (!selectedLocation) {
-        return null;
-    }
+    const [initialLocation] =
+        useState<LocationSetting>(location);
 
     const isDisabled =
         selectedLocation.address.trim().length === 0 ||
         isUpdating;
-
-    const handleChangeLocation = (
-        nextLocation: LocationSetting,
-    ) => {
-        setSelectedLocation(nextLocation);
-        onChangeLocation(nextLocation);
-    };
 
     const handleUpdate = () => {
         if (isDisabled) {
@@ -125,18 +110,18 @@ export default function GroupLocationEditModal({
                             level={initialLocation.level}
                             searchKeyword={searchKeyword}
                             onCenterChanged={(center) => {
-                                handleChangeLocation({
-                                    address: selectedLocation.address,
+                                setSelectedLocation((prev) => ({
+                                    ...prev,
                                     latitude: center.latitude,
                                     longitude: center.longitude,
                                     level: center.level,
-                                });
+                                }));
                             }}
                             onAddressChanged={(address) => {
-                                handleChangeLocation({
-                                    ...selectedLocation,
+                                setSelectedLocation((prev) => ({
+                                    ...prev,
                                     address,
-                                });
+                                }));
                             }}
                             onSearchFailed={handleSearchFailed}
                         />


### PR DESCRIPTION
## 관련 이슈
Closes #155 

## 요약
- 무엇을 변경했나요?
  - 그룹 위치 수정 후 최신 그룹 상세 정보를 다시 조회하도록 수정했
  - 위치 수정 모달에서 선택한 최신 위치 정보가 정상적으로 PATCH 요청에 반영되도록 수정
- 왜 이 변경이 필요한가요?
  - 위치 수정 성공 후에도 상세 패널과 위치 수정 모달에 이전 위치 정보가 표시되는 문제가 있었음
  - 수정된 위치가 즉시 반영되도록 하여 사용자 경험을 개선하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
