### PR TITLE
[Feat] 그룹 추천 준비 상태 조회 및 준비 완료 기능 구현

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
@@ -1,11 +1,21 @@
 "use client";
 
 import { useState } from "react";
+import { useAtomValue } from "jotai";
+import { useParams } from "next/navigation";
 
 import PreferenceModal from "@/features/preference/ui/components/PreferenceModal";
 
 import { usePreferenceList } from "@/features/preference/application/hooks/usePreferenceList";
 import { hasRequiredPreference } from "@/features/preference/domain/validator/hasRequiredPreference";
+import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
+
+import { useGroupRecommendationReadiness } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationReadiness";
+import {
+    groupRecommendationReadinessAtomValue,
+    isGroupRecommendationReadinessLoadingAtom,
+    groupRecommendationReadinessErrorMessageAtom,
+} from "@/features/groupRecommendation/application/selectors/groupRecommendationReadinessSelectors";
 
 import GroupRecommendationPreparationStatusCard from "@/features/groupRecommendation/ui/components/GroupRecommendationPreparationStatusCard";
 import GroupRecommendationPreparationInfoCard from "@/features/groupRecommendation/ui/components/GroupRecommendationPreparationInfoCard";
@@ -16,7 +26,27 @@ import { mockGroupRecommendationPreparation } from "@/features/groupRecommendati
 import { groupRecommendationPreparationPageStyles } from "@/ui/styles/groupRecommendationPreparationPageStyles";
 
 export default function GroupRecommendationPreparationPage() {
+    const params = useParams<{
+        groupId: string;
+        sessionId: string;
+    }>();
+
+    const groupId = Number(params.groupId);
+    const sessionId = Number(params.sessionId);
+
     const [isPreferenceModalOpen, setIsPreferenceModalOpen] = useState(false);
+
+    const member = useAtomValue(memberAtom);
+
+    useGroupRecommendationReadiness(groupId, sessionId);
+
+    const readiness = useAtomValue(groupRecommendationReadinessAtomValue);
+    const isReadinessLoading = useAtomValue(
+        isGroupRecommendationReadinessLoadingAtom,
+    );
+    const readinessErrorMessage = useAtomValue(
+        groupRecommendationReadinessErrorMessageAtom,
+    );
 
     const { preferenceState } = usePreferenceList();
 
@@ -34,6 +64,45 @@ export default function GroupRecommendationPreparationPage() {
         alert("준비 완료 API 연동 예정");
     };
 
+    if (isReadinessLoading) {
+        return (
+            <main className={groupRecommendationPreparationPageStyles.container}>
+                <div className={groupRecommendationPreparationPageStyles.content}>
+                    준비 상태를 불러오는 중...
+                </div>
+            </main>
+        );
+    }
+
+    if (readinessErrorMessage) {
+        return (
+            <main className={groupRecommendationPreparationPageStyles.container}>
+                <div className={groupRecommendationPreparationPageStyles.content}>
+                    {readinessErrorMessage}
+                </div>
+            </main>
+        );
+    }
+
+    if (!readiness) {
+        return null;
+    }
+
+    const sortedMembers = [...readiness.members].sort((a, b) => {
+        if (member?.id === a.memberId) {
+            return -1;
+        }
+
+        if (member?.id === b.memberId) {
+            return 1;
+        }
+
+        return 0;
+    });
+
+    // TODO: 현재는 그룹 메뉴 추천 페이지에서 멤버 카드 최대 4개만 표시. 나중에 바꿀 수도 있음
+    const visibleMembers = sortedMembers.slice(0, 4);
+
     return (
         <>
             <main className={groupRecommendationPreparationPageStyles.container}>
@@ -46,35 +115,40 @@ export default function GroupRecommendationPreparationPage() {
                         <section className={groupRecommendationPreparationPageStyles.mainSection}>
                             <GroupRecommendationPreparationStatusCard
                                 totalMemberCount={
-                                    groupRecommendation.readiness.totalMemberCount
+                                    readiness.progress.totalMemberCount
                                 }
                                 readyMemberCount={
-                                    groupRecommendation.readiness.readyMemberCount
+                                    readiness.progress.readyMemberCount
                                 }
                             />
 
                             <div className={groupRecommendationPreparationPageStyles.memberGrid}>
-                                {groupRecommendation.members.map((member) => (
-                                    <GroupRecommendationPreparationMemberCard
-                                        key={member.memberId}
-                                        nickname={member.nickname}
-                                        isMe={member.isMe}
-                                        isReady={member.isReady}
-                                        hasPreference={
-                                            member.isMe ? hasPreference : false
-                                        }
-                                        onClickEditPreference={
-                                            member.isMe
-                                                ? handleClickEditPreference
-                                                : undefined
-                                        }
-                                        onClickReady={
-                                            member.isMe
-                                                ? handleClickReady
-                                                : undefined
-                                        }
-                                    />
-                                ))}
+                                {visibleMembers.map((readinessMember) => {
+                                    const isMe =
+                                        member?.id === readinessMember.memberId;
+
+                                    return (
+                                        <GroupRecommendationPreparationMemberCard
+                                            key={readinessMember.memberId}
+                                            nickname={readinessMember.nickname}
+                                            isMe={isMe}
+                                            isReady={readinessMember.ready}
+                                            hasPreference={
+                                                isMe ? hasPreference : false
+                                            }
+                                            onClickEditPreference={
+                                                isMe
+                                                    ? handleClickEditPreference
+                                                    : undefined
+                                            }
+                                            onClickReady={
+                                                isMe
+                                                    ? handleClickReady
+                                                    : undefined
+                                            }
+                                        />
+                                    );
+                                })}
                             </div>
                         </section>
 
@@ -82,7 +156,9 @@ export default function GroupRecommendationPreparationPage() {
                             name={groupRecommendation.group.name}
                             createdAt={groupRecommendation.group.createdAt}
                             address={groupRecommendation.group.address}
-                            memberCount={groupRecommendation.group.memberCount}
+                            memberCount={
+                                readiness.progress.totalMemberCount
+                            }
                         />
                     </div>
                 </div>

--- a/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useAtomValue } from "jotai";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 
 import PreferenceModal from "@/features/preference/ui/components/PreferenceModal";
 
@@ -11,6 +11,7 @@ import { hasRequiredPreference } from "@/features/preference/domain/validator/ha
 import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
 
 import { useGroupRecommendationReadiness } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationReadiness";
+import { useCompleteGroupRecommendationPreparation } from "@/features/groupRecommendation/application/hooks/useCompleteGroupRecommendationPreparation";
 import {
     groupRecommendationReadinessAtomValue,
     isGroupRecommendationReadinessLoadingAtom,
@@ -31,14 +32,25 @@ export default function GroupRecommendationPreparationPage() {
         sessionId: string;
     }>();
 
+    const router = useRouter();
+
     const groupId = Number(params.groupId);
     const sessionId = Number(params.sessionId);
 
-    const [isPreferenceModalOpen, setIsPreferenceModalOpen] = useState(false);
+    const [isPreferenceModalOpen, setIsPreferenceModalOpen] =
+        useState(false);
 
     const member = useAtomValue(memberAtom);
 
-    useGroupRecommendationReadiness(groupId, sessionId);
+    const { refetchReadiness } = useGroupRecommendationReadiness(
+        groupId,
+        sessionId,
+    );
+
+    const {
+        isCompletingPreparation,
+        completePreparation,
+    } = useCompleteGroupRecommendationPreparation();
 
     const readiness = useAtomValue(groupRecommendationReadinessAtomValue);
     const isReadinessLoading = useAtomValue(
@@ -60,8 +72,45 @@ export default function GroupRecommendationPreparationPage() {
         setIsPreferenceModalOpen(true);
     };
 
-    const handleClickReady = () => {
-        alert("준비 완료 API 연동 예정");
+    const moveToResultPage = () => {
+        router.push(
+            `/group/${groupId}/recommendations/${sessionId}/result`,
+        );
+    };
+
+    const handleClickCompletePreparation = async () => {
+        if (!member) {
+            alert("회원 정보를 불러오는 중입니다.");
+            return;
+        }
+
+        if (!hasPreference) {
+            alert("필수 취향 정보를 먼저 등록해주세요.");
+            setIsPreferenceModalOpen(true);
+            return;
+        }
+
+        try {
+            const result = await completePreparation(
+                groupId,
+                sessionId,
+                member.id,
+            );
+
+            if (result.status === "OPEN") {
+                window.setTimeout(() => {
+                    moveToResultPage();
+                }, 2500);
+
+                return;
+            }
+
+            await refetchReadiness({
+                showLoading: false,
+            });
+        } catch {
+            alert("준비 완료 처리에 실패했습니다.");
+        }
     };
 
     if (isReadinessLoading) {
@@ -100,7 +149,6 @@ export default function GroupRecommendationPreparationPage() {
         return 0;
     });
 
-    // TODO: 현재는 그룹 메뉴 추천 페이지에서 멤버 카드 최대 4개만 표시. 나중에 바꿀 수도 있음
     const visibleMembers = sortedMembers.slice(0, 4);
 
     return (
@@ -114,6 +162,7 @@ export default function GroupRecommendationPreparationPage() {
                     <div className={groupRecommendationPreparationPageStyles.layout}>
                         <section className={groupRecommendationPreparationPageStyles.mainSection}>
                             <GroupRecommendationPreparationStatusCard
+                                status={readiness.status}
                                 totalMemberCount={
                                     readiness.progress.totalMemberCount
                                 }
@@ -125,25 +174,35 @@ export default function GroupRecommendationPreparationPage() {
                             <div className={groupRecommendationPreparationPageStyles.memberGrid}>
                                 {visibleMembers.map((readinessMember) => {
                                     const isMe =
-                                        member?.id === readinessMember.memberId;
+                                        member?.id ===
+                                        readinessMember.memberId;
 
                                     return (
                                         <GroupRecommendationPreparationMemberCard
                                             key={readinessMember.memberId}
-                                            nickname={readinessMember.nickname}
+                                            nickname={
+                                                readinessMember.nickname
+                                            }
                                             isMe={isMe}
                                             isReady={readinessMember.ready}
                                             hasPreference={
-                                                isMe ? hasPreference : false
+                                                isMe
+                                                    ? hasPreference
+                                                    : false
+                                            }
+                                            isCompletingPreparation={
+                                                isMe
+                                                    ? isCompletingPreparation
+                                                    : false
                                             }
                                             onClickEditPreference={
                                                 isMe
                                                     ? handleClickEditPreference
                                                     : undefined
                                             }
-                                            onClickReady={
+                                            onClickCompletePreparation={
                                                 isMe
-                                                    ? handleClickReady
+                                                    ? handleClickCompletePreparation
                                                     : undefined
                                             }
                                         />
@@ -154,7 +213,9 @@ export default function GroupRecommendationPreparationPage() {
 
                         <GroupRecommendationPreparationInfoCard
                             name={groupRecommendation.group.name}
-                            createdAt={groupRecommendation.group.createdAt}
+                            createdAt={
+                                groupRecommendation.group.createdAt
+                            }
                             address={groupRecommendation.group.address}
                             memberCount={
                                 readiness.progress.totalMemberCount

--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -1,0 +1,13 @@
+import { groupRecommendationPreparationPageStyles } from "@/ui/styles/groupRecommendationPreparationPageStyles";
+
+export default function GroupRecommendationResultPage() {
+    return (
+        <main className={groupRecommendationPreparationPageStyles.container}>
+            <div className={groupRecommendationPreparationPageStyles.content}>
+                <h1 className={groupRecommendationPreparationPageStyles.title}>
+                    그룹 메뉴 추천 결과
+                </h1>
+            </div>
+        </main>
+    );
+}

--- a/src/features/group/domain/model/GroupDetail.ts
+++ b/src/features/group/domain/model/GroupDetail.ts
@@ -8,12 +8,16 @@ export interface GroupDetailLocation {
     readonly address: string;
 }
 
-export interface GroupDetailRecommendation {
-    readonly sessionId: number;
-    readonly status: GroupRecommendationStatus;
+export interface GroupDetailRecommendationReadiness {
     readonly totalMemberCount: number;
     readonly readyMemberCount: number;
     readonly allReady: boolean;
+}
+
+export interface GroupDetailRecommendation {
+    readonly sessionId: number;
+    readonly status: Exclude<GroupRecommendationStatus, null>;
+    readonly readiness: GroupDetailRecommendationReadiness | null;
 }
 
 export interface GroupDetail {

--- a/src/features/group/infrastructure/api/dto/GroupDetailResponse.ts
+++ b/src/features/group/infrastructure/api/dto/GroupDetailResponse.ts
@@ -8,7 +8,7 @@ export interface GroupDetailResponse {
         readonly latitude: number;
         readonly longitude: number;
         readonly radiusMeters: number;
-        readonly address: string;
+        readonly address: string | null;
 
         readonly status: "ACTIVE";
 
@@ -33,7 +33,7 @@ export interface GroupDetailResponse {
                 readonly totalMemberCount: number;
                 readonly readyMemberCount: number;
                 readonly allReady: boolean;
-            };
+            } | null;
         } | null;
     };
 

--- a/src/features/group/infrastructure/api/mapper/groupDetailMapper.ts
+++ b/src/features/group/infrastructure/api/mapper/groupDetailMapper.ts
@@ -28,12 +28,19 @@ export function mapGroupDetail(
             ? {
                   sessionId: response.activeRecommendation.sessionId,
                   status: response.activeRecommendation.status,
-                  totalMemberCount:
-                      response.activeRecommendation.readiness.totalMemberCount,
-                  readyMemberCount:
-                      response.activeRecommendation.readiness.readyMemberCount,
-                  allReady:
-                      response.activeRecommendation.readiness.allReady,
+                  readiness: response.activeRecommendation.readiness
+                      ? {
+                            totalMemberCount:
+                                response.activeRecommendation.readiness
+                                    .totalMemberCount,
+                            readyMemberCount:
+                                response.activeRecommendation.readiness
+                                    .readyMemberCount,
+                            allReady:
+                                response.activeRecommendation.readiness
+                                    .allReady,
+                        }
+                      : null,
               }
             : null,
     };

--- a/src/features/groupRecommendation/application/atoms/groupRecommendationReadinessAtom.ts
+++ b/src/features/groupRecommendation/application/atoms/groupRecommendationReadinessAtom.ts
@@ -1,0 +1,8 @@
+import { atom } from "jotai";
+
+import type { GroupRecommendationReadinessState } from "@/features/groupRecommendation/domain/state/GroupRecommendationReadinessState";
+
+export const groupRecommendationReadinessAtom =
+    atom<GroupRecommendationReadinessState>({
+        status: "LOADING",
+    });

--- a/src/features/groupRecommendation/application/hooks/useCompleteGroupRecommendationPreparation.ts
+++ b/src/features/groupRecommendation/application/hooks/useCompleteGroupRecommendationPreparation.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+
+import { groupRecommendationReadinessAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationReadinessAtom";
+import { completeGroupRecommendationPreparation } from "@/features/groupRecommendation/application/usecase/completeGroupRecommendationPreparation";
+
+export function useCompleteGroupRecommendationPreparation() {
+    const [isCompletingPreparation, setIsCompletingPreparation] = useState(false);
+
+    const setReadinessState = useSetAtom(groupRecommendationReadinessAtom);
+
+    const completePreparation = async (
+        groupId: number,
+        sessionId: number,
+        memberId: number,
+    ) => {
+        try {
+            setIsCompletingPreparation(true);
+
+            const result = await completeGroupRecommendationPreparation(
+                groupId,
+                sessionId,
+            );
+
+            setReadinessState((prev) => {
+                if (prev.status !== "SUCCESS") {
+                    return prev;
+                }
+
+                return {
+                    status: "SUCCESS",
+                    data: {
+                        ...prev.data,
+                        status: result.status,
+                        progress: {
+                            totalMemberCount: result.readiness.totalMemberCount,
+                            readyMemberCount: result.readiness.readyMemberCount,
+                            allReady: result.readiness.allReady,
+                        },
+                        members: prev.data.members.map((member) =>
+                            member.memberId === memberId
+                                ? {
+                                      ...member,
+                                      ready: true,
+                                  }
+                                : member,
+                        ),
+                    },
+                };
+            });
+
+            return result;
+        } finally {
+            setIsCompletingPreparation(false);
+        }
+    };
+
+    return {
+        isCompletingPreparation,
+        completePreparation,
+    };
+}

--- a/src/features/groupRecommendation/application/hooks/useGroupRecommendationReadiness.ts
+++ b/src/features/groupRecommendation/application/hooks/useGroupRecommendationReadiness.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { useSetAtom } from "jotai";
+
+import { groupRecommendationReadinessAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationReadinessAtom";
+import { fetchGroupRecommendationReadiness } from "@/features/groupRecommendation/application/usecase/fetchGroupRecommendationReadiness";
+
+export function useGroupRecommendationReadiness(
+    groupId: number,
+    sessionId: number,
+) {
+    const setReadinessState = useSetAtom(groupRecommendationReadinessAtom);
+
+    const fetchReadiness = useCallback(async () => {
+        setReadinessState({ status: "LOADING" });
+
+        try {
+            const data = await fetchGroupRecommendationReadiness(
+                groupId,
+                sessionId,
+            );
+
+            setReadinessState({
+                status: "SUCCESS",
+                data,
+            });
+        } catch {
+            setReadinessState({
+                status: "ERROR",
+                message: "그룹 추천 준비 상태를 불러오지 못했습니다.",
+            });
+        }
+    }, [groupId, sessionId, setReadinessState]);
+
+    useEffect(() => {
+        fetchReadiness();
+    }, [fetchReadiness]);
+
+    return {
+        refetchReadiness: fetchReadiness,
+    };
+}

--- a/src/features/groupRecommendation/application/hooks/useGroupRecommendationReadiness.ts
+++ b/src/features/groupRecommendation/application/hooks/useGroupRecommendationReadiness.ts
@@ -6,32 +6,44 @@ import { useSetAtom } from "jotai";
 import { groupRecommendationReadinessAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationReadinessAtom";
 import { fetchGroupRecommendationReadiness } from "@/features/groupRecommendation/application/usecase/fetchGroupRecommendationReadiness";
 
+interface FetchReadinessOptions {
+    readonly showLoading?: boolean;
+}
+
 export function useGroupRecommendationReadiness(
     groupId: number,
     sessionId: number,
 ) {
-    const setReadinessState = useSetAtom(groupRecommendationReadinessAtom);
+    const setReadinessState = useSetAtom(
+        groupRecommendationReadinessAtom,
+    );
 
-    const fetchReadiness = useCallback(async () => {
-        setReadinessState({ status: "LOADING" });
+    const fetchReadiness = useCallback(
+        async ({ showLoading = true }: FetchReadinessOptions = {}) => {
+            if (showLoading) {
+                setReadinessState({ status: "LOADING" });
+            }
 
-        try {
-            const data = await fetchGroupRecommendationReadiness(
-                groupId,
-                sessionId,
-            );
+            try {
+                const data = await fetchGroupRecommendationReadiness(
+                    groupId,
+                    sessionId,
+                );
 
-            setReadinessState({
-                status: "SUCCESS",
-                data,
-            });
-        } catch {
-            setReadinessState({
-                status: "ERROR",
-                message: "그룹 추천 준비 상태를 불러오지 못했습니다.",
-            });
-        }
-    }, [groupId, sessionId, setReadinessState]);
+                setReadinessState({
+                    status: "SUCCESS",
+                    data,
+                });
+            } catch {
+                setReadinessState({
+                    status: "ERROR",
+                    message:
+                        "그룹 추천 준비 상태를 불러오지 못했습니다.",
+                });
+            }
+        },
+        [groupId, sessionId, setReadinessState],
+    );
 
     useEffect(() => {
         fetchReadiness();

--- a/src/features/groupRecommendation/application/selectors/groupRecommendationReadinessSelectors.ts
+++ b/src/features/groupRecommendation/application/selectors/groupRecommendationReadinessSelectors.ts
@@ -1,0 +1,29 @@
+import { atom } from "jotai";
+
+import { groupRecommendationReadinessAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationReadinessAtom";
+
+export const groupRecommendationReadinessAtomValue = atom((get) => {
+    const state = get(groupRecommendationReadinessAtom);
+
+    return state.status === "SUCCESS" ? state.data : null;
+});
+
+export const isGroupRecommendationReadinessLoadingAtom = atom(
+    (get) => get(groupRecommendationReadinessAtom).status === "LOADING",
+);
+
+export const groupRecommendationReadinessErrorMessageAtom = atom((get) => {
+    const state = get(groupRecommendationReadinessAtom);
+
+    return state.status === "ERROR" ? state.message : null;
+});
+
+// 준비 진행률
+export const groupRecommendationReadinessProgressAtom = atom((get) => {
+    return get(groupRecommendationReadinessAtomValue)?.progress ?? null;
+});
+
+// 멤버 준비 상태 목록
+export const groupRecommendationReadinessMembersAtom = atom((get) => {
+    return get(groupRecommendationReadinessAtomValue)?.members ?? [];
+});

--- a/src/features/groupRecommendation/application/usecase/completeGroupRecommendationPreparation.ts
+++ b/src/features/groupRecommendation/application/usecase/completeGroupRecommendationPreparation.ts
@@ -1,0 +1,11 @@
+import { groupRecommendationApi } from "@/features/groupRecommendation/infrastructure/api/groupRecommendationApi";
+
+export async function completeGroupRecommendationPreparation(
+    groupId: number,
+    sessionId: number,
+) {
+    return groupRecommendationApi.completePreparation(
+        groupId,
+        sessionId,
+    );
+}

--- a/src/features/groupRecommendation/application/usecase/fetchGroupRecommendationReadiness.ts
+++ b/src/features/groupRecommendation/application/usecase/fetchGroupRecommendationReadiness.ts
@@ -1,0 +1,8 @@
+import { groupRecommendationApi } from "@/features/groupRecommendation/infrastructure/api/groupRecommendationApi";
+
+export async function fetchGroupRecommendationReadiness(
+    groupId: number,
+    sessionId: number,
+) {
+    return groupRecommendationApi.fetchReadiness(groupId, sessionId);
+}

--- a/src/features/groupRecommendation/domain/model/GroupRecommendationReadiness.ts
+++ b/src/features/groupRecommendation/domain/model/GroupRecommendationReadiness.ts
@@ -1,0 +1,21 @@
+export type GroupRecommendationReadinessStatus = "PREPARING";
+
+export interface GroupRecommendationReadinessProgress {
+    readonly totalMemberCount: number;
+    readonly readyMemberCount: number;
+    readonly allReady: boolean;
+}
+
+export interface GroupRecommendationReadinessMember {
+    readonly memberId: number;
+    readonly nickname: string;
+    readonly role: "OWNER" | "MEMBER";
+    readonly ready: boolean;
+}
+
+export interface GroupRecommendationReadiness {
+    readonly sessionId: number;
+    readonly status: GroupRecommendationReadinessStatus;
+    readonly progress: GroupRecommendationReadinessProgress;
+    readonly members: readonly GroupRecommendationReadinessMember[];
+}

--- a/src/features/groupRecommendation/domain/model/GroupRecommendationReadiness.ts
+++ b/src/features/groupRecommendation/domain/model/GroupRecommendationReadiness.ts
@@ -1,4 +1,6 @@
-export type GroupRecommendationReadinessStatus = "PREPARING";
+export type GroupRecommendationReadinessStatus =
+    | "PREPARING"
+    | "OPEN";
 
 export interface GroupRecommendationReadinessProgress {
     readonly totalMemberCount: number;

--- a/src/features/groupRecommendation/domain/state/GroupRecommendationReadinessState.ts
+++ b/src/features/groupRecommendation/domain/state/GroupRecommendationReadinessState.ts
@@ -1,0 +1,6 @@
+import type { GroupRecommendationReadiness } from "@/features/groupRecommendation/domain/model/GroupRecommendationReadiness";
+
+export type GroupRecommendationReadinessState =
+    | { readonly status: "LOADING" }
+    | { readonly status: "SUCCESS"; readonly data: GroupRecommendationReadiness }
+    | { readonly status: "ERROR"; readonly message: string };

--- a/src/features/groupRecommendation/infrastructure/api/dto/CompleteGroupRecommendationPreparationResponse.ts
+++ b/src/features/groupRecommendation/infrastructure/api/dto/CompleteGroupRecommendationPreparationResponse.ts
@@ -1,0 +1,28 @@
+export interface CompleteGroupRecommendationPreparationResponse {
+    readonly success: boolean;
+
+    readonly data: {
+        readonly sessionId: number;
+        readonly status: "PREPARING" | "OPEN";
+        readonly readiness: {
+            readonly totalMemberCount: number;
+            readonly readyMemberCount: number;
+            readonly allReady: boolean;
+        };
+        readonly candidates: readonly {
+            readonly candidateId: number;
+            readonly menuId: number;
+            readonly menuName: string;
+            readonly rankNo: number;
+            readonly score: number;
+            readonly voteCount: number;
+        }[];
+    };
+
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationReadinessResponse.ts
+++ b/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationReadinessResponse.ts
@@ -1,0 +1,26 @@
+export interface GroupRecommendationReadinessResponse {
+    readonly success: boolean;
+
+    readonly data: {
+        readonly sessionId: number;
+        readonly status: "PREPARING";
+        readonly progress: {
+            readonly totalMemberCount: number;
+            readonly readyMemberCount: number;
+            readonly allReady: boolean;
+        };
+        readonly members: readonly {
+            readonly memberId: number;
+            readonly nickname: string;
+            readonly role: "OWNER" | "MEMBER";
+            readonly ready: boolean;
+        }[];
+    };
+
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
+++ b/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
@@ -3,6 +3,7 @@ import { httpClient } from "@/infrastructure/http/httpClient";
 import type { GroupRecommendationStartRequest } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationStartRequest";
 import type { GroupRecommendationStartResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationStartResponse";
 import type { GroupRecommendationReadinessResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationReadinessResponse";
+import type { CompleteGroupRecommendationPreparationResponse } from "@/features/groupRecommendation/infrastructure/api/dto/CompleteGroupRecommendationPreparationResponse";
 import type { GroupRecommendationReadiness } from "@/features/groupRecommendation/domain/model/GroupRecommendationReadiness";
 
 export const groupRecommendationApi = {
@@ -39,6 +40,25 @@ export const groupRecommendationApi = {
             throw new Error(
                 response.error?.message ??
                     "그룹 추천 준비 상태 조회에 실패했습니다.",
+            );
+        }
+
+        return response.data;
+    },
+
+    async completePreparation(
+        groupId: number,
+        sessionId: number,
+    ) {
+        const response =
+            await httpClient.post<CompleteGroupRecommendationPreparationResponse>(
+                `/api/v1/groups/${groupId}/recommendations/${sessionId}/ready`,
+            );
+
+        if (!response.success) {
+            throw new Error(
+                response.error?.message ??
+                    "그룹 추천 준비 완료에 실패했습니다.",
             );
         }
 

--- a/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
+++ b/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
@@ -2,6 +2,8 @@ import { httpClient } from "@/infrastructure/http/httpClient";
 
 import type { GroupRecommendationStartRequest } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationStartRequest";
 import type { GroupRecommendationStartResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationStartResponse";
+import type { GroupRecommendationReadinessResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationReadinessResponse";
+import type { GroupRecommendationReadiness } from "@/features/groupRecommendation/domain/model/GroupRecommendationReadiness";
 
 export const groupRecommendationApi = {
     async startRecommendation(
@@ -18,6 +20,25 @@ export const groupRecommendationApi = {
             throw new Error(
                 response.error?.message ??
                     "그룹 추천 시작에 실패했습니다.",
+            );
+        }
+
+        return response.data;
+    },
+
+    async fetchReadiness(
+        groupId: number,
+        sessionId: number,
+    ): Promise<GroupRecommendationReadiness> {
+        const response =
+            await httpClient.get<GroupRecommendationReadinessResponse>(
+                `/api/v1/groups/${groupId}/recommendations/${sessionId}/readiness`,
+            );
+
+        if (!response.success) {
+            throw new Error(
+                response.error?.message ??
+                    "그룹 추천 준비 상태 조회에 실패했습니다.",
             );
         }
 

--- a/src/features/groupRecommendation/ui/components/GroupRecommendationPreparationMemberCard.tsx
+++ b/src/features/groupRecommendation/ui/components/GroupRecommendationPreparationMemberCard.tsx
@@ -7,8 +7,9 @@ interface GroupRecommendationPreparationMemberCardProps {
     readonly isMe: boolean;
     readonly isReady: boolean;
     readonly hasPreference: boolean;
+    readonly isCompletingPreparation?: boolean;
     readonly onClickEditPreference?: () => void;
-    readonly onClickReady?: () => void;
+    readonly onClickCompletePreparation?: () => void;
 }
 
 export default function GroupRecommendationPreparationMemberCard({
@@ -16,8 +17,9 @@ export default function GroupRecommendationPreparationMemberCard({
     isMe,
     isReady,
     hasPreference,
+    isCompletingPreparation = false,
     onClickEditPreference,
-    onClickReady,
+    onClickCompletePreparation,
 }: GroupRecommendationPreparationMemberCardProps) {
     return (
         <article
@@ -51,10 +53,13 @@ export default function GroupRecommendationPreparationMemberCard({
 
                         <button
                             type="button"
-                            onClick={onClickReady}
+                            onClick={onClickCompletePreparation}
+                            disabled={isCompletingPreparation}
                             className={groupRecommendationPreparationPageStyles.readyButton}
                         >
-                            준비 완료
+                            {isCompletingPreparation
+                                ? "처리 중"
+                                : "준비 완료"}
                         </button>
                     </>
                 )}

--- a/src/features/groupRecommendation/ui/components/GroupRecommendationPreparationStatusCard.tsx
+++ b/src/features/groupRecommendation/ui/components/GroupRecommendationPreparationStatusCard.tsx
@@ -1,11 +1,15 @@
+import type { GroupRecommendationReadinessStatus } from "@/features/groupRecommendation/domain/model/GroupRecommendationReadiness";
+
 import { groupRecommendationPreparationPageStyles } from "@/ui/styles/groupRecommendationPreparationPageStyles";
 
 interface GroupRecommendationPreparationStatusCardProps {
+    readonly status: GroupRecommendationReadinessStatus;
     readonly totalMemberCount: number;
     readonly readyMemberCount: number;
 }
 
 export default function GroupRecommendationPreparationStatusCard({
+    status,
     totalMemberCount,
     readyMemberCount,
 }: GroupRecommendationPreparationStatusCardProps) {
@@ -14,11 +18,15 @@ export default function GroupRecommendationPreparationStatusCard({
             ? 0
             : (readyMemberCount / totalMemberCount) * 100;
 
+    const isAnalyzing = status === "OPEN";
+
     return (
         <section className={groupRecommendationPreparationPageStyles.preferenceStatusCard}>
             <div className={groupRecommendationPreparationPageStyles.preferenceStatusHeader}>
                 <h2 className={groupRecommendationPreparationPageStyles.preferenceStatusTitle}>
-                    취향을 등록하는 중...
+                    {isAnalyzing
+                        ? "취향을 분석하는 중..."
+                        : "취향을 등록하는 중..."}
                 </h2>
 
                 <span className={groupRecommendationPreparationPageStyles.preferenceStatusCount}>
@@ -34,9 +42,19 @@ export default function GroupRecommendationPreparationStatusCard({
             </div>
 
             <p className={groupRecommendationPreparationPageStyles.preferenceStatusDescription}>
-                그룹원 모두가 취향을 입력하면,
-                <br />
-                모두가 만족할 수 있는 메뉴를 추천해드릴게요.
+                {isAnalyzing ? (
+                    <>
+                        취향 분석이 완료되면 자동으로 결과 화면으로 이동합니다.
+                        <br />
+                        잠시만 기다려주세요..
+                    </>
+                ) : (
+                    <>
+                        그룹원 모두가 취향을 입력하면,
+                        <br />
+                        모두가 만족할 수 있는 메뉴를 추천해드릴게요.
+                    </>
+                )}
             </p>
         </section>
     );

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -25,7 +25,8 @@ export default function Sidebar() {
 
     const isGroupRecommendationPage =
         pathname.startsWith("/group/") &&
-        pathname.includes("/recommendations/");
+        pathname.includes("/recommendations/") &&
+        !pathname.endsWith("/result");
 
     const isRecommendationLoading = useAtomValue(
         isPersonalRecommendationLoadingAtom,

--- a/src/ui/styles/groupRecommendationPreparationPageStyles.ts
+++ b/src/ui/styles/groupRecommendationPreparationPageStyles.ts
@@ -28,7 +28,7 @@ export const groupRecommendationPreparationPageStyles = {
     preferenceEditButton:
         "h-9 min-w-[96px] cursor-pointer whitespace-nowrap rounded-full border border-blue-400 bg-white px-5 text-sm font-semibold text-slate-600",
     readyButton:
-        "h-9 min-w-[96px] cursor-pointer whitespace-nowrap rounded-full bg-blue-400 px-5 text-sm font-semibold text-white",
+        "h-9 min-w-[96px] cursor-pointer whitespace-nowrap rounded-full bg-blue-400 px-5 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-zinc-300",
     readyIcon: "flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-green-300 text-zinc-950",
     waitingIcon:
         "flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-zinc-950",

--- a/src/ui/styles/groupRecommendationPreparationPageStyles.ts
+++ b/src/ui/styles/groupRecommendationPreparationPageStyles.ts
@@ -26,9 +26,9 @@ export const groupRecommendationPreparationPageStyles = {
     memberActionArea: "flex shrink-0 flex-col items-end gap-2",
 
     preferenceEditButton:
-        "h-9 min-w-[96px] whitespace-nowrap rounded-full border border-blue-400 bg-white px-5 text-sm font-semibold text-slate-600",
+        "h-9 min-w-[96px] cursor-pointer whitespace-nowrap rounded-full border border-blue-400 bg-white px-5 text-sm font-semibold text-slate-600",
     readyButton:
-        "h-9 min-w-[96px] whitespace-nowrap rounded-full bg-blue-400 px-5 text-sm font-semibold text-white",
+        "h-9 min-w-[96px] cursor-pointer whitespace-nowrap rounded-full bg-blue-400 px-5 text-sm font-semibold text-white",
     readyIcon: "flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-green-300 text-zinc-950",
     waitingIcon:
         "flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-zinc-950",


### PR DESCRIPTION
## 관련 이슈
Closes #171 
Closes #172 

## 요약
- 무엇을 변경했나요?
  - 그룹 추천 준비 상태 조회 API 연동
  - 그룹 추천 준비 화면에 준비 진행률과 그룹원 준비 상태를 API 응답 기준으로 표시하도록 구현
  - 그룹 추천 준비 완료 API 연동
  - 그룹 추천 준비 완료 시 내 카드 상태와 준비 진행률이 즉시 갱신되도록 구현
  - 모든 그룹원이 준비 완료되어 추천 상태가 `OPEN`으로 변경되면 상태 문구를 변경하고 일정 시간 후 결과 화면으로 이동하도록 구현
  - 그룹 추천 결과 페이지의 기본 라우트 추가
  
- 왜 이 변경이 필요한가요?
  - 그룹 추천 준비 단계의 진행 현황을 서버 데이터와 동기화하기 위함
  - 사용자의 준비 완료 상태를 서버에 반영하고 모든 그룹원의 준비가 완료되면 자연스럽게 추천 결과 단계로 전환하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
