### PR TITLE
[Feat] 그룹 메뉴 추천 결과 화면 및 조회 기능 구현

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import { useAtomValue } from "jotai";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
+
+import { useGroupRecommendationSessionDetail } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationSessionDetail";
+import {
+    groupRecommendationSessionDetailAtomValue,
+    isGroupRecommendationSessionDetailLoadingAtom,
+    groupRecommendationSessionDetailErrorMessageAtom,
+} from "@/features/groupRecommendation/application/selectors/groupRecommendationSessionDetailSelectors";
 
 import GroupRecommendationResultVoteStatusCard from "@/features/groupRecommendation/ui/components/GroupRecommendationResultVoteStatusCard";
 import GroupRecommendationResultMemberList from "@/features/groupRecommendation/ui/components/GroupRecommendationResultMemberList";
@@ -21,28 +29,107 @@ export default function GroupRecommendationResultPage() {
     const router = useRouter();
 
     const groupId = Number(params.groupId);
+    const sessionId = Number(params.sessionId);
 
     const [selectedCandidateId, setSelectedCandidateId] =
         useState<number | null>(null);
 
-    const [isVoteClosed, setIsVoteClosed] = useState(
-        mockGroupRecommendationResult.status === "FINALIZED",
+    const [isVoteClosed, setIsVoteClosed] = useState(false);
+
+    useGroupRecommendationSessionDetail(groupId, sessionId);
+
+    const sessionDetail = useAtomValue(
+        groupRecommendationSessionDetailAtomValue,
+    );
+    const isSessionDetailLoading = useAtomValue(
+        isGroupRecommendationSessionDetailLoadingAtom,
+    );
+    const sessionDetailErrorMessage = useAtomValue(
+        groupRecommendationSessionDetailErrorMessageAtom,
     );
 
-    const selectedCandidate = mockGroupRecommendationResult.candidates.find(
+    const handleClickBack = () => {
+        router.push(`/group?selectedGroupId=${groupId}`);
+    };
+
+    const handleClickVote = (candidateId: number) => {
+        if (isVoteClosed || sessionDetail?.status === "FINALIZED") {
+            return;
+        }
+
+        setSelectedCandidateId(candidateId);
+    };
+
+    const handleClickCloseVote = () => {
+        setIsVoteClosed(true);
+    };
+
+    const handleClickMoveVoteResult = () => {
+        alert("투표 결과 상세 화면 구현 예정");
+    };
+
+    if (isSessionDetailLoading) {
+        return (
+            <main className={groupRecommendationResultPageStyles.container}>
+                <div className={groupRecommendationResultPageStyles.content}>
+                    그룹 추천 결과를 불러오는 중...
+                </div>
+            </main>
+        );
+    }
+
+    if (sessionDetailErrorMessage) {
+        return (
+            <main className={groupRecommendationResultPageStyles.container}>
+                <div className={groupRecommendationResultPageStyles.content}>
+                    {sessionDetailErrorMessage}
+                </div>
+            </main>
+        );
+    }
+
+    if (!sessionDetail) {
+        return null;
+    }
+
+    if (sessionDetail.status === "PREPARING") {
+        return (
+            <main className={groupRecommendationResultPageStyles.container}>
+                <div className={groupRecommendationResultPageStyles.content}>
+                    <button
+                        type="button"
+                        onClick={handleClickBack}
+                        className={groupRecommendationResultPageStyles.backButton}
+                    >
+                        <ArrowLeft size={30} strokeWidth={2.5} />
+                    </button>
+
+                    <h1 className={groupRecommendationResultPageStyles.title}>
+                        아직 추천 후보를 생성하는 중입니다.
+                    </h1>
+                </div>
+            </main>
+        );
+    }
+
+    const isFinalized =
+        sessionDetail.status === "FINALIZED" || isVoteClosed;
+
+    const selectedCandidate = sessionDetail.candidates.find(
         (candidate) => candidate.candidateId === selectedCandidateId,
     );
 
     const votedMemberCount = selectedCandidate
-        ? mockGroupRecommendationResult.voteProgress.votedMemberCount + 1
-        : mockGroupRecommendationResult.voteProgress.votedMemberCount;
+        ? (sessionDetail.voteProgress?.votedMemberCount ?? 0) + 1
+        : sessionDetail.voteProgress?.votedMemberCount ?? 0;
 
-    const candidates = mockGroupRecommendationResult.candidates.map(
-        (candidate) => ({
-            ...candidate,
-            selected: candidate.candidateId === selectedCandidateId,
-        }),
-    );
+    const totalMemberCount =
+        sessionDetail.voteProgress?.totalMemberCount ?? 0;
+
+    const candidates = sessionDetail.candidates.map((candidate) => ({
+        ...candidate,
+        selected: candidate.candidateId === selectedCandidateId,
+    }));
 
     const members = mockGroupRecommendationResult.members.map((member) =>
         member.isMe && selectedCandidate
@@ -53,24 +140,6 @@ export default function GroupRecommendationResultPage() {
             : member,
     );
 
-    const handleClickBack = () => {
-        router.push(`/group?selectedGroupId=${groupId}`);
-    };
-
-    const handleClickVote = (candidateId: number) => {
-        if (isVoteClosed) return;
-
-        setSelectedCandidateId(candidateId);
-    };
-
-    const handleClickCloseVote = () => {
-        setIsVoteClosed(true);
-    };
-
-    const handleClickMoveVoteResult = () => {
-        alert("투표 결과 화면 구현 예정");
-    };
-
     return (
         <main className={groupRecommendationResultPageStyles.container}>
             <div className={groupRecommendationResultPageStyles.content}>
@@ -79,7 +148,7 @@ export default function GroupRecommendationResultPage() {
                     onClick={handleClickBack}
                     className={groupRecommendationResultPageStyles.backButton}
                 >
-                    <ArrowLeft size={28} />
+                    <ArrowLeft size={30} strokeWidth={2.5} />
                 </button>
 
                 <header className={groupRecommendationResultPageStyles.titleSection}>
@@ -94,13 +163,10 @@ export default function GroupRecommendationResultPage() {
 
                 <div className={groupRecommendationResultPageStyles.topSection}>
                     <GroupRecommendationResultVoteStatusCard
-                        totalMemberCount={
-                            mockGroupRecommendationResult.voteProgress
-                                .totalMemberCount
-                        }
+                        totalMemberCount={totalMemberCount}
                         votedMemberCount={votedMemberCount}
                         isOwner={mockGroupRecommendationResult.isOwner}
-                        isVoteClosed={isVoteClosed}
+                        isVoteClosed={isFinalized}
                         onClickCloseVote={handleClickCloseVote}
                         onClickMoveVoteResult={handleClickMoveVoteResult}
                     />
@@ -115,7 +181,7 @@ export default function GroupRecommendationResultPage() {
                             menuName={candidate.menuName}
                             matchPercent={Math.round(candidate.score)}
                             selected={candidate.selected}
-                            isVoteClosed={isVoteClosed}
+                            isVoteClosed={isFinalized}
                             onClickVote={() =>
                                 handleClickVote(candidate.candidateId)
                             }

--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -1,12 +1,127 @@
-import { groupRecommendationPreparationPageStyles } from "@/ui/styles/groupRecommendationPreparationPageStyles";
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+import GroupRecommendationResultVoteStatusCard from "@/features/groupRecommendation/ui/components/GroupRecommendationResultVoteStatusCard";
+import GroupRecommendationResultMemberList from "@/features/groupRecommendation/ui/components/GroupRecommendationResultMemberList";
+import GroupRecommendationResultCandidateCard from "@/features/groupRecommendation/ui/components/GroupRecommendationResultCandidateCard";
+
+import { mockGroupRecommendationResult } from "@/features/groupRecommendation/ui/mock/mockGroupRecommendationResult";
+
+import { groupRecommendationResultPageStyles } from "@/ui/styles/groupRecommendationResultPageStyles";
 
 export default function GroupRecommendationResultPage() {
+    const params = useParams<{
+        groupId: string;
+        sessionId: string;
+    }>();
+
+    const router = useRouter();
+
+    const groupId = Number(params.groupId);
+
+    const [selectedCandidateId, setSelectedCandidateId] =
+        useState<number | null>(null);
+
+    const [isVoteClosed, setIsVoteClosed] = useState(
+        mockGroupRecommendationResult.status === "FINALIZED",
+    );
+
+    const selectedCandidate = mockGroupRecommendationResult.candidates.find(
+        (candidate) => candidate.candidateId === selectedCandidateId,
+    );
+
+    const votedMemberCount = selectedCandidate
+        ? mockGroupRecommendationResult.voteProgress.votedMemberCount + 1
+        : mockGroupRecommendationResult.voteProgress.votedMemberCount;
+
+    const candidates = mockGroupRecommendationResult.candidates.map(
+        (candidate) => ({
+            ...candidate,
+            selected: candidate.candidateId === selectedCandidateId,
+        }),
+    );
+
+    const members = mockGroupRecommendationResult.members.map((member) =>
+        member.isMe && selectedCandidate
+            ? {
+                  ...member,
+                  voted: true,
+              }
+            : member,
+    );
+
+    const handleClickBack = () => {
+        router.push(`/group?selectedGroupId=${groupId}`);
+    };
+
+    const handleClickVote = (candidateId: number) => {
+        if (isVoteClosed) return;
+
+        setSelectedCandidateId(candidateId);
+    };
+
+    const handleClickCloseVote = () => {
+        setIsVoteClosed(true);
+    };
+
+    const handleClickMoveVoteResult = () => {
+        alert("투표 결과 화면 구현 예정");
+    };
+
     return (
-        <main className={groupRecommendationPreparationPageStyles.container}>
-            <div className={groupRecommendationPreparationPageStyles.content}>
-                <h1 className={groupRecommendationPreparationPageStyles.title}>
-                    그룹 메뉴 추천 결과
-                </h1>
+        <main className={groupRecommendationResultPageStyles.container}>
+            <div className={groupRecommendationResultPageStyles.content}>
+                <button
+                    type="button"
+                    onClick={handleClickBack}
+                    className={groupRecommendationResultPageStyles.backButton}
+                >
+                    <ArrowLeft size={28} />
+                </button>
+
+                <header className={groupRecommendationResultPageStyles.titleSection}>
+                    <h1 className={groupRecommendationResultPageStyles.title}>
+                        그룹 메뉴 추천 결과
+                    </h1>
+
+                    <p className={groupRecommendationResultPageStyles.description}>
+                        먹고 싶은 메뉴에 투표하세요.
+                    </p>
+                </header>
+
+                <div className={groupRecommendationResultPageStyles.topSection}>
+                    <GroupRecommendationResultVoteStatusCard
+                        totalMemberCount={
+                            mockGroupRecommendationResult.voteProgress
+                                .totalMemberCount
+                        }
+                        votedMemberCount={votedMemberCount}
+                        isOwner={mockGroupRecommendationResult.isOwner}
+                        isVoteClosed={isVoteClosed}
+                        onClickCloseVote={handleClickCloseVote}
+                        onClickMoveVoteResult={handleClickMoveVoteResult}
+                    />
+
+                    <GroupRecommendationResultMemberList members={members} />
+                </div>
+
+                <section className={groupRecommendationResultPageStyles.candidateGrid}>
+                    {candidates.map((candidate) => (
+                        <GroupRecommendationResultCandidateCard
+                            key={candidate.candidateId}
+                            menuName={candidate.menuName}
+                            matchPercent={Math.round(candidate.score)}
+                            selected={candidate.selected}
+                            isVoteClosed={isVoteClosed}
+                            onClickVote={() =>
+                                handleClickVote(candidate.candidateId)
+                            }
+                        />
+                    ))}
+                </section>
             </div>
         </main>
     );

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -244,8 +244,19 @@ export default function GroupPage() {
             return;
         }
 
+        const sessionId = groupDetail.activeRecommendation.sessionId;
+
+        // 추천 상태가 OPEN이면 결과 페이지로 이동
+        if (groupDetail.activeRecommendation.status === "OPEN") {
+            router.push(
+                `/group/${selectedGroupId}/recommendations/${sessionId}/result`,
+            );
+            return;
+        }
+
+        // PREPARING 상태이면 준비 페이지로 이동
         router.push(
-            `/group/${selectedGroupId}/recommendations/${groupDetail.activeRecommendation.sessionId}`,
+            `/group/${selectedGroupId}/recommendations/${sessionId}`,
         );
     };
 

--- a/src/features/group/ui/components/GroupDetailPanel.tsx
+++ b/src/features/group/ui/components/GroupDetailPanel.tsx
@@ -42,6 +42,11 @@ export default function GroupDetailPanel({
     const visibleMembers = group.members.slice(0, 3);
     const isOwner = useAtomValue(isGroupOwnerAtom);
 
+    const activeRecommendationButtonLabel =
+        group.activeRecommendation?.status === "OPEN"
+            ? "투표 현황 확인하기"
+            : "진행중인 메뉴 추천 페이지 이동";
+
     return (
         <aside className={groupDetailPanelStyles.panel}>
             <div className={groupDetailPanelStyles.content}>
@@ -77,7 +82,7 @@ export default function GroupDetailPanel({
 
                 {group.activeRecommendation ? (
                     <GroupRecommendationStartButton
-                        label="진행중인 메뉴 추천 페이지 이동"
+                        label={activeRecommendationButtonLabel}
                         onClick={onClickMoveActiveRecommendation}
                     />
                 ) : isOwner ? (

--- a/src/features/groupRecommendation/application/atoms/groupRecommendationSessionDetailAtom.ts
+++ b/src/features/groupRecommendation/application/atoms/groupRecommendationSessionDetailAtom.ts
@@ -1,0 +1,8 @@
+import { atom } from "jotai";
+
+import type { GroupRecommendationSessionDetailState } from "@/features/groupRecommendation/domain/state/GroupRecommendationSessionDetailState";
+
+export const groupRecommendationSessionDetailAtom =
+    atom<GroupRecommendationSessionDetailState>({
+        status: "LOADING",
+    });

--- a/src/features/groupRecommendation/application/hooks/useGroupRecommendationSessionDetail.ts
+++ b/src/features/groupRecommendation/application/hooks/useGroupRecommendationSessionDetail.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { useSetAtom } from "jotai";
+
+import { groupRecommendationSessionDetailAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationSessionDetailAtom";
+import { fetchGroupRecommendationSessionDetail } from "@/features/groupRecommendation/application/usecase/fetchGroupRecommendationSessionDetail";
+
+export function useGroupRecommendationSessionDetail(
+    groupId: number,
+    sessionId: number,
+) {
+    const setSessionDetailState = useSetAtom(
+        groupRecommendationSessionDetailAtom,
+    );
+
+    const fetchSessionDetail = useCallback(async () => {
+        setSessionDetailState({ status: "LOADING" });
+
+        try {
+            const data = await fetchGroupRecommendationSessionDetail(
+                groupId,
+                sessionId,
+            );
+
+            setSessionDetailState({
+                status: "SUCCESS",
+                data,
+            });
+        } catch {
+            setSessionDetailState({
+                status: "ERROR",
+                message: "그룹 추천 세션 정보를 불러오지 못했습니다.",
+            });
+        }
+    }, [groupId, sessionId, setSessionDetailState]);
+
+    useEffect(() => {
+        fetchSessionDetail();
+    }, [fetchSessionDetail]);
+
+    return {
+        refetchSessionDetail: fetchSessionDetail,
+    };
+}

--- a/src/features/groupRecommendation/application/selectors/groupRecommendationSessionDetailSelectors.ts
+++ b/src/features/groupRecommendation/application/selectors/groupRecommendationSessionDetailSelectors.ts
@@ -1,0 +1,19 @@
+import { atom } from "jotai";
+
+import { groupRecommendationSessionDetailAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationSessionDetailAtom";
+
+export const groupRecommendationSessionDetailAtomValue = atom((get) => {
+    const state = get(groupRecommendationSessionDetailAtom);
+
+    return state.status === "SUCCESS" ? state.data : null;
+});
+
+export const isGroupRecommendationSessionDetailLoadingAtom = atom(
+    (get) => get(groupRecommendationSessionDetailAtom).status === "LOADING",
+);
+
+export const groupRecommendationSessionDetailErrorMessageAtom = atom((get) => {
+    const state = get(groupRecommendationSessionDetailAtom);
+
+    return state.status === "ERROR" ? state.message : null;
+});

--- a/src/features/groupRecommendation/application/usecase/fetchGroupRecommendationSessionDetail.ts
+++ b/src/features/groupRecommendation/application/usecase/fetchGroupRecommendationSessionDetail.ts
@@ -1,0 +1,8 @@
+import { groupRecommendationApi } from "@/features/groupRecommendation/infrastructure/api/groupRecommendationApi";
+
+export async function fetchGroupRecommendationSessionDetail(
+    groupId: number,
+    sessionId: number,
+) {
+    return groupRecommendationApi.fetchSessionDetail(groupId, sessionId);
+}

--- a/src/features/groupRecommendation/domain/model/GroupRecommendationSessionDetail.ts
+++ b/src/features/groupRecommendation/domain/model/GroupRecommendationSessionDetail.ts
@@ -1,0 +1,30 @@
+export type GroupRecommendationSessionStatus =
+    | "PREPARING"
+    | "OPEN"
+    | "FINALIZED";
+
+export interface GroupRecommendationSessionCandidate {
+    readonly candidateId: number;
+    readonly menuId: number;
+    readonly menuName: string;
+    readonly rankNo: number;
+    readonly score: number;
+    readonly voteCount: number;
+}
+
+export interface GroupRecommendationSessionProgress {
+    readonly totalMemberCount: number;
+    readonly readyMemberCount?: number;
+    readonly votedMemberCount?: number;
+    readonly allReady?: boolean;
+}
+
+export interface GroupRecommendationSessionDetail {
+    readonly sessionId: number;
+    readonly status: GroupRecommendationSessionStatus;
+    readonly readiness: GroupRecommendationSessionProgress | null;
+    readonly candidates: readonly GroupRecommendationSessionCandidate[];
+    readonly voteProgress: GroupRecommendationSessionProgress | null;
+    readonly finalCandidate: GroupRecommendationSessionCandidate | null;
+    readonly createdAt: string;
+}

--- a/src/features/groupRecommendation/domain/state/GroupRecommendationSessionDetailState.ts
+++ b/src/features/groupRecommendation/domain/state/GroupRecommendationSessionDetailState.ts
@@ -1,0 +1,6 @@
+import type { GroupRecommendationSessionDetail } from "@/features/groupRecommendation/domain/model/GroupRecommendationSessionDetail";
+
+export type GroupRecommendationSessionDetailState =
+    | { readonly status: "LOADING" }
+    | { readonly status: "SUCCESS"; readonly data: GroupRecommendationSessionDetail }
+    | { readonly status: "ERROR"; readonly message: string };

--- a/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationSessionDetailResponse.ts
+++ b/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationSessionDetailResponse.ts
@@ -1,0 +1,41 @@
+export interface GroupRecommendationSessionDetailResponse {
+    readonly success: boolean;
+
+    readonly data: {
+        readonly sessionId: number;
+        readonly status: "PREPARING" | "OPEN" | "FINALIZED";
+        readonly readiness: {
+            readonly totalMemberCount: number;
+            readonly readyMemberCount: number;
+            readonly allReady: boolean;
+        } | null;
+        readonly candidates: readonly {
+            readonly candidateId: number;
+            readonly menuId: number;
+            readonly menuName: string;
+            readonly rankNo: number;
+            readonly score: number;
+            readonly voteCount: number;
+        }[];
+        readonly voteProgress: {
+            readonly totalMemberCount: number;
+            readonly votedMemberCount: number;
+        } | null;
+        readonly finalCandidate: {
+            readonly candidateId: number;
+            readonly menuId: number;
+            readonly menuName: string;
+            readonly rankNo: number;
+            readonly score: number;
+            readonly voteCount: number;
+        } | null;
+        readonly createdAt: string;
+    };
+
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
+++ b/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
@@ -4,7 +4,10 @@ import type { GroupRecommendationStartRequest } from "@/features/groupRecommenda
 import type { GroupRecommendationStartResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationStartResponse";
 import type { GroupRecommendationReadinessResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationReadinessResponse";
 import type { CompleteGroupRecommendationPreparationResponse } from "@/features/groupRecommendation/infrastructure/api/dto/CompleteGroupRecommendationPreparationResponse";
+import type { GroupRecommendationSessionDetailResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationSessionDetailResponse";
+
 import type { GroupRecommendationReadiness } from "@/features/groupRecommendation/domain/model/GroupRecommendationReadiness";
+import type { GroupRecommendationSessionDetail } from "@/features/groupRecommendation/domain/model/GroupRecommendationSessionDetail";
 
 export const groupRecommendationApi = {
     async startRecommendation(
@@ -59,6 +62,25 @@ export const groupRecommendationApi = {
             throw new Error(
                 response.error?.message ??
                     "그룹 추천 준비 완료에 실패했습니다.",
+            );
+        }
+
+        return response.data;
+    },
+
+    async fetchSessionDetail(
+        groupId: number,
+        sessionId: number,
+    ): Promise<GroupRecommendationSessionDetail> {
+        const response =
+            await httpClient.get<GroupRecommendationSessionDetailResponse>(
+                `/api/v1/groups/${groupId}/recommendations/${sessionId}`,
+            );
+
+        if (!response.success) {
+            throw new Error(
+                response.error?.message ??
+                    "그룹 추천 세션 상세 조회에 실패했습니다.",
             );
         }
 

--- a/src/features/groupRecommendation/ui/components/GroupRecommendationResultCandidateCard.tsx
+++ b/src/features/groupRecommendation/ui/components/GroupRecommendationResultCandidateCard.tsx
@@ -1,0 +1,52 @@
+import { groupRecommendationResultPageStyles } from "@/ui/styles/groupRecommendationResultPageStyles";
+
+interface GroupRecommendationResultCandidateCardProps {
+    readonly menuName: string;
+    readonly matchPercent: number;
+    readonly selected: boolean;
+    readonly isVoteClosed: boolean;
+    readonly onClickVote: () => void;
+}
+
+export default function GroupRecommendationResultCandidateCard({
+    menuName,
+    matchPercent,
+    selected,
+    isVoteClosed,
+    onClickVote,
+}: GroupRecommendationResultCandidateCardProps) {
+    return (
+        <article
+            className={
+                selected
+                    ? groupRecommendationResultPageStyles.selectedCandidateCard
+                    : groupRecommendationResultPageStyles.candidateCard
+            }
+        >
+            <div className={groupRecommendationResultPageStyles.candidateImagePlaceholder}>
+                <span className={groupRecommendationResultPageStyles.matchBadge}>
+                    {matchPercent}% Match
+                </span>
+            </div>
+
+            <div className={groupRecommendationResultPageStyles.candidateBody}>
+                <h3 className={groupRecommendationResultPageStyles.candidateName}>
+                    {menuName}
+                </h3>
+
+                <button
+                    type="button"
+                    onClick={onClickVote}
+                    disabled={isVoteClosed}
+                    className={
+                        isVoteClosed
+                            ? groupRecommendationResultPageStyles.disabledVoteButton
+                            : groupRecommendationResultPageStyles.voteButton
+                    }
+                >
+                    투표하기
+                </button>
+            </div>
+        </article>
+    );
+}

--- a/src/features/groupRecommendation/ui/components/GroupRecommendationResultMemberList.tsx
+++ b/src/features/groupRecommendation/ui/components/GroupRecommendationResultMemberList.tsx
@@ -1,0 +1,72 @@
+import { Check, User } from "lucide-react";
+
+import { groupRecommendationResultPageStyles } from "@/ui/styles/groupRecommendationResultPageStyles";
+
+interface GroupRecommendationResultMember {
+    readonly memberId: number;
+    readonly nickname: string;
+    readonly isMe: boolean;
+    readonly voted: boolean;
+}
+
+interface GroupRecommendationResultMemberListProps {
+    readonly members: readonly GroupRecommendationResultMember[];
+}
+
+export default function GroupRecommendationResultMemberList({
+    members,
+}: GroupRecommendationResultMemberListProps) {
+    // 멤버가 6명 이상이면 가로 스크롤 영역으로 렌더링
+    const isScrollable = members.length >= 5;
+
+    return (
+        <section className={groupRecommendationResultPageStyles.memberStatusCard}>
+            <h2 className={groupRecommendationResultPageStyles.memberStatusTitle}>
+                멤버 목록
+            </h2>
+
+            <div
+                // 5명 이하는 가운데 정렬, 6명 이상은 가로 스크롤
+                className={
+                    isScrollable
+                        ? groupRecommendationResultPageStyles.memberListScrollable
+                        : groupRecommendationResultPageStyles.memberList
+                }
+            >
+                {members.map((member) => (
+                    <div
+                        key={member.memberId}
+                        className={groupRecommendationResultPageStyles.memberItem}
+                    >
+                        <div className={groupRecommendationResultPageStyles.memberAvatarWrapper}>
+                            <div className={groupRecommendationResultPageStyles.memberAvatar}>
+                                <User size={36} />
+                            </div>
+
+                            {member.voted && (
+                                <span className={groupRecommendationResultPageStyles.memberCheckIcon}>
+                                    <Check size={14} />
+                                </span>
+                            )}
+                        </div>
+
+                        <strong className={groupRecommendationResultPageStyles.memberNickname}>
+                            {member.nickname}
+                            {member.isMe && " (나)"}
+                        </strong>
+
+                        <span
+                            className={
+                                member.voted
+                                    ? groupRecommendationResultPageStyles.memberStatusReady
+                                    : groupRecommendationResultPageStyles.memberStatusWaiting
+                            }
+                        >
+                            {member.voted ? "투표 완료" : "투표 중"}
+                        </span>
+                    </div>
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/src/features/groupRecommendation/ui/components/GroupRecommendationResultVoteStatusCard.tsx
+++ b/src/features/groupRecommendation/ui/components/GroupRecommendationResultVoteStatusCard.tsx
@@ -1,0 +1,68 @@
+import { groupRecommendationResultPageStyles } from "@/ui/styles/groupRecommendationResultPageStyles";
+
+interface GroupRecommendationResultVoteStatusCardProps {
+    readonly totalMemberCount: number;
+    readonly votedMemberCount: number;
+    readonly isOwner: boolean;
+    readonly isVoteClosed: boolean;
+    readonly onClickCloseVote: () => void;
+    readonly onClickMoveVoteResult: () => void;
+}
+
+export default function GroupRecommendationResultVoteStatusCard({
+    totalMemberCount,
+    votedMemberCount,
+    isOwner,
+    isVoteClosed,
+    onClickCloseVote,
+    onClickMoveVoteResult,
+}: GroupRecommendationResultVoteStatusCardProps) {
+    const progressPercent =
+        totalMemberCount === 0
+            ? 0
+            : (votedMemberCount / totalMemberCount) * 100;
+
+    const allVoted =
+        totalMemberCount > 0 && totalMemberCount === votedMemberCount;
+
+    return (
+        <section className={groupRecommendationResultPageStyles.voteStatusCard}>
+            <div className={groupRecommendationResultPageStyles.voteStatusHeader}>
+                <h2 className={groupRecommendationResultPageStyles.voteStatusTitle}>
+                    투표 진행 현황
+                </h2>
+
+                <span className={groupRecommendationResultPageStyles.voteStatusCount}>
+                    {votedMemberCount}/{totalMemberCount}
+                </span>
+            </div>
+
+            <div className={groupRecommendationResultPageStyles.progressTrack}>
+                <div
+                    className={groupRecommendationResultPageStyles.progressFill}
+                    style={{ width: `${progressPercent}%` }}
+                />
+            </div>
+
+            {isVoteClosed && (
+                <button
+                    type="button"
+                    onClick={onClickMoveVoteResult}
+                    className={groupRecommendationResultPageStyles.resultActionButton}
+                >
+                    투표 결과 보러 가기
+                </button>
+            )}
+
+            {!isVoteClosed && allVoted && isOwner && (
+                <button
+                    type="button"
+                    onClick={onClickCloseVote}
+                    className={groupRecommendationResultPageStyles.voteActionButton}
+                >
+                    투표 종료
+                </button>
+            )}
+        </section>
+    );
+}

--- a/src/features/groupRecommendation/ui/mock/mockGroupRecommendationResult.ts
+++ b/src/features/groupRecommendation/ui/mock/mockGroupRecommendationResult.ts
@@ -1,0 +1,54 @@
+type GroupRecommendationResultStatus = "OPEN" | "FINALIZED";
+
+export const mockGroupRecommendationResult = {
+    sessionId: 5001,
+    status: "OPEN" as GroupRecommendationResultStatus,
+    readiness: null,
+
+    candidates: [
+        {
+            candidateId: 8001,
+            menuId: 1001,
+            menuName: "비빔밥",
+            rankNo: 1,
+            score: 91.5,
+            voteCount: 3,
+        },
+        {
+            candidateId: 8002,
+            menuId: 1002,
+            menuName: "돈까스",
+            rankNo: 2,
+            score: 84,
+            voteCount: 1,
+        },
+        {
+            candidateId: 8003,
+            menuId: 1003,
+            menuName: "쌀국수",
+            rankNo: 3,
+            score: 79.5,
+            voteCount: 0,
+        },
+    ],
+
+    voteProgress: {
+        totalMemberCount: 4,
+        votedMemberCount: 3,
+    },
+
+    finalCandidate: null,
+
+    createdAt: "2026-05-06T12:05:00",
+
+    members: [
+        { memberId: 1, nickname: "김철수", isMe: true, voted: false },
+        { memberId: 2, nickname: "김덕배", isMe: false, voted: false },
+        { memberId: 3, nickname: "도쿠", isMe: false, voted: true },
+        { memberId: 4, nickname: "돈나룸마", isMe: false, voted: true },
+//         { memberId: 5, nickname: "포든", isMe: false, voted: true },
+//         { memberId: 6, nickname: "홀란드", isMe: false, voted: true },
+    ],
+
+    isOwner: true,
+} as const;

--- a/src/ui/styles/groupRecommendationResultPageStyles.ts
+++ b/src/ui/styles/groupRecommendationResultPageStyles.ts
@@ -1,0 +1,48 @@
+export const groupRecommendationResultPageStyles = {
+    container: "min-h-screen bg-slate-50",
+    content: "mx-auto max-w-[1360px] px-16 py-10",
+
+    backButton: "flex h-14 w-14 cursor-pointer items-center justify-center rounded-full text-zinc-900 transition-colors hover:bg-slate-200",
+
+    titleSection: "mt-8",
+    title: "text-5xl font-bold text-zinc-900",
+    description: "mt-3 text-xl text-slate-700",
+
+    topSection: "mt-14 grid grid-cols-[1fr_1.45fr] gap-16",
+
+    voteStatusCard: "rounded-[36px] bg-white px-10 py-10 shadow-[0_2px_8px_rgba(15,23,42,0.12)]",
+    voteStatusHeader: "flex items-center justify-between",
+    voteStatusTitle: "text-2xl font-bold text-zinc-900",
+    voteStatusCount: "text-2xl font-bold text-blue-500",
+    progressTrack: "mt-8 h-4 rounded-full bg-zinc-200",
+    progressFill: "h-full rounded-full bg-blue-500",
+    voteActionButton: "mt-8 h-16 w-full cursor-pointer rounded-[20px] bg-indigo-950 text-2xl font-bold text-white",
+    resultActionButton: "mt-8 h-16 w-full cursor-pointer rounded-[20px] bg-indigo-950 text-2xl font-bold text-white",
+
+    memberStatusCard: "min-w-0 rounded-[36px] bg-white px-12 py-8 shadow-[0_2px_8px_rgba(15,23,42,0.12)]",
+    memberStatusTitle: "text-center text-2xl font-bold text-zinc-900",
+    memberList: "mt-8 flex justify-center gap-10", // 멤버 5명 이하일 때 가운데 정렬
+    memberListScrollable: "mt-8 flex max-w-full min-w-0 flex-nowrap gap-10 overflow-x-auto pb-3", // 멤버 6명 이상일 때 가로 스크롤 적용
+    memberItem: "flex w-[88px] min-w-[88px] shrink-0 flex-col items-center",
+    memberAvatarWrapper: "relative",
+    memberAvatar:
+        "flex h-16 w-16 items-center justify-center rounded-full bg-slate-200 text-slate-500",
+    memberCheckIcon:
+        "absolute -bottom-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-green-600 text-white",
+    memberNickname: "mt-3 text-sm font-bold text-zinc-900",
+    memberStatusReady: "mt-1 text-sm font-semibold text-green-700",
+    memberStatusWaiting: "mt-1 text-sm text-zinc-400",
+
+    candidateGrid: "mt-20 grid grid-cols-3 gap-8",
+    candidateCard: "overflow-hidden rounded-[24px] bg-white shadow-[0_4px_10px_rgba(15,23,42,0.14)]",
+    selectedCandidateCard:
+        "overflow-hidden rounded-[24px] border-2 border-blue-500 bg-white shadow-[0_4px_10px_rgba(15,23,42,0.14)]",
+    candidateImagePlaceholder: "relative flex h-[260px] items-center justify-center bg-zinc-200",
+    matchBadge: "absolute left-5 top-5 rounded-full bg-amber-800 px-5 py-2 text-base text-white",
+    candidateBody: "px-8 py-7",
+    candidateName: "text-xl font-semibold text-zinc-900",
+    voteButton:
+        "mt-5 h-14 w-full rounded-full bg-slate-100 text-lg font-semibold text-zinc-900 transition-colors hover:bg-blue-200 hover:text-blue-700 active:bg-blue-200",
+    disabledVoteButton:
+        "mt-5 h-14 w-full cursor-not-allowed rounded-full bg-zinc-300 text-lg font-semibold text-zinc-500",
+} as const;


### PR DESCRIPTION
## 관련 이슈
Closes #175 
Closes #176 

## 요약
- 무엇을 변경했나요?
  - 그룹 메뉴 추천 결과 화면 UI 렌더링
  - 그룹 추천 결과 조회 API를 연동하여 결과 화면 데이터를 조회하도록 구현
  - 후보 메뉴 목록, 투표 진행률, 추천 상태(PREPARING / OPEN / FINALIZED)를 화면에 반영하도록 구현
  - 추천 상태에 따라 결과 화면을 분기하도록 구현
  - 뒤로 가기, 투표 종료, 투표 결과 보기 등 상태별 UI 구현
 
- 왜 이 변경이 필요한가요?
  - 그룹 메뉴 추천 결과를 사용자에게 제공하기 위한 결과 화면 필요
  - 서버의 그룹 추천 상태와 후보 메뉴, 투표 진행 현황을 기반으로 결과 화면을 렌더링하기 위한 조회 기능 필요

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
