### PR TITLE
[Feat] 그룹 메뉴 추천 투표 및 투표 종료 기능 구현

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -11,6 +11,8 @@ import { isGroupOwnerAtom } from "@/features/group/application/selectors/groupDe
 import { useGroupRecommendationSessionDetail } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationSessionDetail";
 import { useGroupRecommendationReadiness } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationReadiness";
 import { useVoteGroupRecommendationCandidate } from "@/features/groupRecommendation/application/hooks/useVoteGroupRecommendationCandidate";
+import { useFinalizeGroupRecommendation } from "@/features/groupRecommendation/application/hooks/useFinalizeGroupRecommendation";
+
 import {
     groupRecommendationSessionDetailAtomValue,
     isGroupRecommendationSessionDetailLoadingAtom,
@@ -68,6 +70,14 @@ export default function GroupRecommendationResultPage() {
         },
     });
 
+    const { isFinalizing, finalize } = useFinalizeGroupRecommendation({
+        onSuccess: async () => {
+            await refetchSessionDetail({
+                showLoading: false,
+            });
+        },
+    });
+
     const sessionDetail = useAtomValue(
         groupRecommendationSessionDetailAtomValue,
     );
@@ -95,8 +105,14 @@ export default function GroupRecommendationResultPage() {
         }
     };
 
-    const handleClickCloseVote = () => {
-        setIsVoteClosed(true);
+    const handleClickCloseVote = async () => {
+        try {
+            await finalize(groupId, sessionId);
+
+            setIsVoteClosed(true);
+        } catch {
+            alert("투표 종료에 실패했습니다.");
+        }
     };
 
     const handleClickMoveVoteResult = () => {
@@ -199,6 +215,7 @@ export default function GroupRecommendationResultPage() {
                         votedMemberCount={votedMemberCount}
                         isOwner={isOwner}
                         isVoteClosed={isFinalized}
+                        isFinalizing={isFinalizing}
                         onClickCloseVote={handleClickCloseVote}
                         onClickMoveVoteResult={handleClickMoveVoteResult}
                     />

--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -5,19 +5,23 @@ import { useAtomValue } from "jotai";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 
+import { useGroupDetail } from "@/features/group/application/hooks/useGroupDetail";
+import { isGroupOwnerAtom } from "@/features/group/application/selectors/groupDetailSelectors";
+
 import { useGroupRecommendationSessionDetail } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationSessionDetail";
+import { useGroupRecommendationReadiness } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationReadiness";
 import { useVoteGroupRecommendationCandidate } from "@/features/groupRecommendation/application/hooks/useVoteGroupRecommendationCandidate";
 import {
     groupRecommendationSessionDetailAtomValue,
     isGroupRecommendationSessionDetailLoadingAtom,
     groupRecommendationSessionDetailErrorMessageAtom,
 } from "@/features/groupRecommendation/application/selectors/groupRecommendationSessionDetailSelectors";
+import { groupRecommendationReadinessAtomValue } from "@/features/groupRecommendation/application/selectors/groupRecommendationReadinessSelectors";
+import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
 
 import GroupRecommendationResultVoteStatusCard from "@/features/groupRecommendation/ui/components/GroupRecommendationResultVoteStatusCard";
 import GroupRecommendationResultMemberList from "@/features/groupRecommendation/ui/components/GroupRecommendationResultMemberList";
 import GroupRecommendationResultCandidateCard from "@/features/groupRecommendation/ui/components/GroupRecommendationResultCandidateCard";
-
-import { mockGroupRecommendationResult } from "@/features/groupRecommendation/ui/mock/mockGroupRecommendationResult";
 
 import { groupRecommendationResultPageStyles } from "@/ui/styles/groupRecommendationResultPageStyles";
 
@@ -37,7 +41,20 @@ export default function GroupRecommendationResultPage() {
 
     const [isVoteClosed, setIsVoteClosed] = useState(false);
 
-    // refetchSessionDetail을 받아 투표 성공 후 최신 결과를 다시 조회
+    const member = useAtomValue(memberAtom);
+
+    // 새로고침/직접 진입 시에도 방장 여부를 알 수 있도록 그룹 상세 조회
+    useGroupDetail(groupId);
+
+    // 그룹 상세 조회 결과를 기반으로 방장 여부 판단
+    const isOwner = useAtomValue(isGroupOwnerAtom);
+
+    // TODO: 나중에 확인 필요
+    // 결과 화면에서도 멤버 목록 확보를 위해 준비 상태 조회 (다른 api에서는 멤버 정보를 주는 게 없기 때문)
+    useGroupRecommendationReadiness(groupId, sessionId);
+
+    const readiness = useAtomValue(groupRecommendationReadinessAtomValue);
+
     const { refetchSessionDetail } = useGroupRecommendationSessionDetail(
         groupId,
         sessionId,
@@ -65,7 +82,6 @@ export default function GroupRecommendationResultPage() {
         router.push(`/group?selectedGroupId=${groupId}`);
     };
 
-    // 투표하기 버튼 클릭 시 투표 API 호출
     const handleClickVote = async (candidateId: number) => {
         if (isVoteClosed || sessionDetail?.status === "FINALIZED") {
             return;
@@ -73,8 +89,6 @@ export default function GroupRecommendationResultPage() {
 
         try {
             await vote(groupId, sessionId, candidateId);
-
-            // 투표 성공 후 선택된 후보 UI 표시
             setSelectedCandidateId(candidateId);
         } catch {
             alert("투표에 실패했습니다.");
@@ -136,10 +150,6 @@ export default function GroupRecommendationResultPage() {
     const isFinalized =
         sessionDetail.status === "FINALIZED" || isVoteClosed;
 
-    const selectedCandidate = sessionDetail.candidates.find(
-        (candidate) => candidate.candidateId === selectedCandidateId,
-    );
-
     const votedMemberCount = sessionDetail.voteProgress?.votedMemberCount ?? 0;
 
     const totalMemberCount =
@@ -150,14 +160,17 @@ export default function GroupRecommendationResultPage() {
         selected: candidate.candidateId === selectedCandidateId,
     }));
 
-    const members = mockGroupRecommendationResult.members.map((member) =>
-        member.isMe && selectedCandidate
-            ? {
-                  ...member,
-                  voted: true,
-              }
-            : member,
-    );
+    const members =
+        readiness?.members.map((readinessMember) => {
+            const isMe = member?.id === readinessMember.memberId;
+
+            return {
+                memberId: readinessMember.memberId,
+                nickname: readinessMember.nickname,
+                isMe,
+                voted: isMe && selectedCandidateId !== null,
+            };
+        }) ?? [];
 
     return (
         <main className={groupRecommendationResultPageStyles.container}>
@@ -184,7 +197,7 @@ export default function GroupRecommendationResultPage() {
                     <GroupRecommendationResultVoteStatusCard
                         totalMemberCount={totalMemberCount}
                         votedMemberCount={votedMemberCount}
-                        isOwner={mockGroupRecommendationResult.isOwner}
+                        isOwner={isOwner}
                         isVoteClosed={isFinalized}
                         onClickCloseVote={handleClickCloseVote}
                         onClickMoveVoteResult={handleClickMoveVoteResult}
@@ -201,8 +214,6 @@ export default function GroupRecommendationResultPage() {
                             matchPercent={Math.round(candidate.score)}
                             selected={candidate.selected}
                             isVoteClosed={isFinalized}
-
-                            // 투표 요청 중이면 버튼 비활성화 및 문구 변경
                             isVoting={isVoting}
                             onClickVote={() =>
                                 handleClickVote(candidate.candidateId)

--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 
 import { useGroupRecommendationSessionDetail } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationSessionDetail";
+import { useVoteGroupRecommendationCandidate } from "@/features/groupRecommendation/application/hooks/useVoteGroupRecommendationCandidate";
 import {
     groupRecommendationSessionDetailAtomValue,
     isGroupRecommendationSessionDetailLoadingAtom,
@@ -36,7 +37,19 @@ export default function GroupRecommendationResultPage() {
 
     const [isVoteClosed, setIsVoteClosed] = useState(false);
 
-    useGroupRecommendationSessionDetail(groupId, sessionId);
+    // refetchSessionDetail을 받아 투표 성공 후 최신 결과를 다시 조회
+    const { refetchSessionDetail } = useGroupRecommendationSessionDetail(
+        groupId,
+        sessionId,
+    );
+
+    const { isVoting, vote } = useVoteGroupRecommendationCandidate({
+        onSuccess: async () => {
+            await refetchSessionDetail({
+                showLoading: false,
+            });
+        },
+    });
 
     const sessionDetail = useAtomValue(
         groupRecommendationSessionDetailAtomValue,
@@ -52,12 +65,20 @@ export default function GroupRecommendationResultPage() {
         router.push(`/group?selectedGroupId=${groupId}`);
     };
 
-    const handleClickVote = (candidateId: number) => {
+    // 투표하기 버튼 클릭 시 투표 API 호출
+    const handleClickVote = async (candidateId: number) => {
         if (isVoteClosed || sessionDetail?.status === "FINALIZED") {
             return;
         }
 
-        setSelectedCandidateId(candidateId);
+        try {
+            await vote(groupId, sessionId, candidateId);
+
+            // 투표 성공 후 선택된 후보 UI 표시
+            setSelectedCandidateId(candidateId);
+        } catch {
+            alert("투표에 실패했습니다.");
+        }
     };
 
     const handleClickCloseVote = () => {
@@ -119,9 +140,7 @@ export default function GroupRecommendationResultPage() {
         (candidate) => candidate.candidateId === selectedCandidateId,
     );
 
-    const votedMemberCount = selectedCandidate
-        ? (sessionDetail.voteProgress?.votedMemberCount ?? 0) + 1
-        : sessionDetail.voteProgress?.votedMemberCount ?? 0;
+    const votedMemberCount = sessionDetail.voteProgress?.votedMemberCount ?? 0;
 
     const totalMemberCount =
         sessionDetail.voteProgress?.totalMemberCount ?? 0;
@@ -182,6 +201,9 @@ export default function GroupRecommendationResultPage() {
                             matchPercent={Math.round(candidate.score)}
                             selected={candidate.selected}
                             isVoteClosed={isFinalized}
+
+                            // 투표 요청 중이면 버튼 비활성화 및 문구 변경
+                            isVoting={isVoting}
                             onClickVote={() =>
                                 handleClickVote(candidate.candidateId)
                             }

--- a/src/features/groupRecommendation/application/hooks/useFinalizeGroupRecommendation.ts
+++ b/src/features/groupRecommendation/application/hooks/useFinalizeGroupRecommendation.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+
+import { finalizeGroupRecommendation } from "@/features/groupRecommendation/application/usecase/finalizeGroupRecommendation";
+
+interface UseFinalizeGroupRecommendationProps {
+    readonly onSuccess?: () => void;
+}
+
+export function useFinalizeGroupRecommendation({
+    onSuccess,
+}: UseFinalizeGroupRecommendationProps = {}) {
+    const [isFinalizing, setIsFinalizing] = useState(false);
+
+    const finalize = async (
+        groupId: number,
+        sessionId: number,
+    ) => {
+        try {
+            setIsFinalizing(true);
+
+            const result = await finalizeGroupRecommendation(
+                groupId,
+                sessionId,
+            );
+
+            onSuccess?.();
+
+            return result;
+        } finally {
+            setIsFinalizing(false);
+        }
+    };
+
+    return {
+        isFinalizing,
+        finalize,
+    };
+}

--- a/src/features/groupRecommendation/application/hooks/useGroupRecommendationSessionDetail.ts
+++ b/src/features/groupRecommendation/application/hooks/useGroupRecommendationSessionDetail.ts
@@ -6,6 +6,11 @@ import { useSetAtom } from "jotai";
 import { groupRecommendationSessionDetailAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationSessionDetailAtom";
 import { fetchGroupRecommendationSessionDetail } from "@/features/groupRecommendation/application/usecase/fetchGroupRecommendationSessionDetail";
 
+// 재조회 시 로딩 화면 표시 여부 옵션
+interface FetchSessionDetailOptions {
+    readonly showLoading?: boolean;
+}
+
 export function useGroupRecommendationSessionDetail(
     groupId: number,
     sessionId: number,
@@ -14,26 +19,31 @@ export function useGroupRecommendationSessionDetail(
         groupRecommendationSessionDetailAtom,
     );
 
-    const fetchSessionDetail = useCallback(async () => {
-        setSessionDetailState({ status: "LOADING" });
+    const fetchSessionDetail = useCallback(
+        async ({ showLoading = true }: FetchSessionDetailOptions = {}) => {
+            if (showLoading) {
+                setSessionDetailState({ status: "LOADING" });
+            }
 
-        try {
-            const data = await fetchGroupRecommendationSessionDetail(
-                groupId,
-                sessionId,
-            );
+            try {
+                const data = await fetchGroupRecommendationSessionDetail(
+                    groupId,
+                    sessionId,
+                );
 
-            setSessionDetailState({
-                status: "SUCCESS",
-                data,
-            });
-        } catch {
-            setSessionDetailState({
-                status: "ERROR",
-                message: "그룹 추천 세션 정보를 불러오지 못했습니다.",
-            });
-        }
-    }, [groupId, sessionId, setSessionDetailState]);
+                setSessionDetailState({
+                    status: "SUCCESS",
+                    data,
+                });
+            } catch {
+                setSessionDetailState({
+                    status: "ERROR",
+                    message: "그룹 추천 세션 정보를 불러오지 못했습니다.",
+                });
+            }
+        },
+        [groupId, sessionId, setSessionDetailState],
+    );
 
     useEffect(() => {
         fetchSessionDetail();

--- a/src/features/groupRecommendation/application/hooks/useVoteGroupRecommendationCandidate.ts
+++ b/src/features/groupRecommendation/application/hooks/useVoteGroupRecommendationCandidate.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+
+import { voteGroupRecommendationCandidate } from "@/features/groupRecommendation/application/usecase/voteGroupRecommendationCandidate";
+
+interface UseVoteGroupRecommendationCandidateProps {
+    readonly onSuccess?: () => void;
+}
+
+export function useVoteGroupRecommendationCandidate({
+    onSuccess,
+}: UseVoteGroupRecommendationCandidateProps = {}) {
+    const [isVoting, setIsVoting] = useState(false);
+
+    const vote = async (
+        groupId: number,
+        sessionId: number,
+        candidateId: number,
+    ) => {
+        try {
+            setIsVoting(true);
+
+            await voteGroupRecommendationCandidate(
+                groupId,
+                sessionId,
+                candidateId,
+            );
+
+            onSuccess?.();
+        } finally {
+            setIsVoting(false);
+        }
+    };
+
+    return {
+        isVoting,
+        vote,
+    };
+}

--- a/src/features/groupRecommendation/application/usecase/finalizeGroupRecommendation.ts
+++ b/src/features/groupRecommendation/application/usecase/finalizeGroupRecommendation.ts
@@ -1,0 +1,11 @@
+import { groupRecommendationApi } from "@/features/groupRecommendation/infrastructure/api/groupRecommendationApi";
+
+export async function finalizeGroupRecommendation(
+    groupId: number,
+    sessionId: number,
+) {
+    return groupRecommendationApi.finalizeRecommendation(
+        groupId,
+        sessionId,
+    );
+}

--- a/src/features/groupRecommendation/application/usecase/voteGroupRecommendationCandidate.ts
+++ b/src/features/groupRecommendation/application/usecase/voteGroupRecommendationCandidate.ts
@@ -1,0 +1,15 @@
+import { groupRecommendationApi } from "@/features/groupRecommendation/infrastructure/api/groupRecommendationApi";
+
+export async function voteGroupRecommendationCandidate(
+    groupId: number,
+    sessionId: number,
+    candidateId: number,
+) {
+    return groupRecommendationApi.voteCandidate(
+        groupId,
+        sessionId,
+        {
+            candidateId,
+        },
+    );
+}

--- a/src/features/groupRecommendation/infrastructure/api/dto/FinalizeGroupRecommendationResponse.ts
+++ b/src/features/groupRecommendation/infrastructure/api/dto/FinalizeGroupRecommendationResponse.ts
@@ -1,0 +1,24 @@
+export interface FinalizeGroupRecommendationResponse {
+    readonly success: boolean;
+
+    readonly data: {
+        readonly sessionId: number;
+        readonly status: "FINALIZED";
+        readonly finalCandidate: {
+            readonly candidateId: number;
+            readonly menuId: number;
+            readonly menuName: string;
+            readonly rankNo: number;
+            readonly score: number;
+            readonly voteCount: number;
+        };
+        readonly finalizedAt: string;
+    };
+
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationVoteRequest.ts
+++ b/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationVoteRequest.ts
@@ -1,0 +1,3 @@
+export interface GroupRecommendationVoteRequest {
+    readonly candidateId: number;
+}

--- a/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationVoteResponse.ts
+++ b/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationVoteResponse.ts
@@ -1,0 +1,16 @@
+export interface GroupRecommendationVoteResponse {
+    readonly success: boolean;
+
+    readonly data: {
+        readonly voteId: number;
+        readonly candidateId: number;
+        readonly votedAt: string;
+    };
+
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
+++ b/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
@@ -7,6 +7,7 @@ import type { CompleteGroupRecommendationPreparationResponse } from "@/features/
 import type { GroupRecommendationSessionDetailResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationSessionDetailResponse";
 import type { GroupRecommendationVoteRequest } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationVoteRequest";
 import type { GroupRecommendationVoteResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationVoteResponse";
+import type { FinalizeGroupRecommendationResponse } from "@/features/groupRecommendation/infrastructure/api/dto/FinalizeGroupRecommendationResponse";
 
 import type { GroupRecommendationReadiness } from "@/features/groupRecommendation/domain/model/GroupRecommendationReadiness";
 import type { GroupRecommendationSessionDetail } from "@/features/groupRecommendation/domain/model/GroupRecommendationSessionDetail";
@@ -104,6 +105,25 @@ export const groupRecommendationApi = {
             throw new Error(
                 response.error?.message ??
                     "메뉴 후보 투표에 실패했습니다.",
+            );
+        }
+
+        return response.data;
+    },
+
+    async finalizeRecommendation(
+        groupId: number,
+        sessionId: number,
+    ) {
+        const response =
+            await httpClient.patch<FinalizeGroupRecommendationResponse>(
+                `/api/v1/groups/${groupId}/recommendations/${sessionId}/finalize`,
+            );
+
+        if (!response.success) {
+            throw new Error(
+                response.error?.message ??
+                    "그룹 추천 최종 메뉴 확정에 실패했습니다.",
             );
         }
 

--- a/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
+++ b/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
@@ -5,6 +5,8 @@ import type { GroupRecommendationStartResponse } from "@/features/groupRecommend
 import type { GroupRecommendationReadinessResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationReadinessResponse";
 import type { CompleteGroupRecommendationPreparationResponse } from "@/features/groupRecommendation/infrastructure/api/dto/CompleteGroupRecommendationPreparationResponse";
 import type { GroupRecommendationSessionDetailResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationSessionDetailResponse";
+import type { GroupRecommendationVoteRequest } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationVoteRequest";
+import type { GroupRecommendationVoteResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationVoteResponse";
 
 import type { GroupRecommendationReadiness } from "@/features/groupRecommendation/domain/model/GroupRecommendationReadiness";
 import type { GroupRecommendationSessionDetail } from "@/features/groupRecommendation/domain/model/GroupRecommendationSessionDetail";
@@ -81,6 +83,27 @@ export const groupRecommendationApi = {
             throw new Error(
                 response.error?.message ??
                     "그룹 추천 세션 상세 조회에 실패했습니다.",
+            );
+        }
+
+        return response.data;
+    },
+
+    async voteCandidate(
+        groupId: number,
+        sessionId: number,
+        request: GroupRecommendationVoteRequest,
+    ) {
+        const response =
+            await httpClient.post<GroupRecommendationVoteResponse>(
+                `/api/v1/groups/${groupId}/recommendations/${sessionId}/votes`,
+                request,
+            );
+
+        if (!response.success) {
+            throw new Error(
+                response.error?.message ??
+                    "메뉴 후보 투표에 실패했습니다.",
             );
         }
 

--- a/src/features/groupRecommendation/ui/components/GroupRecommendationPreparationStatusCard.tsx
+++ b/src/features/groupRecommendation/ui/components/GroupRecommendationPreparationStatusCard.tsx
@@ -13,10 +13,20 @@ export default function GroupRecommendationPreparationStatusCard({
     totalMemberCount,
     readyMemberCount,
 }: GroupRecommendationPreparationStatusCardProps) {
+    // readyMemberCount가 totalMemberCount보다 커져도 100%를 넘지 않도록 방어
     const progressPercent =
         totalMemberCount === 0
             ? 0
-            : (readyMemberCount / totalMemberCount) * 100;
+            : Math.min(
+                  (readyMemberCount / totalMemberCount) * 100,
+                  100,
+              );
+
+    // 화면 표시용 count도 totalMemberCount를 넘지 않도록 방어
+    const safeReadyMemberCount = Math.min(
+        readyMemberCount,
+        totalMemberCount,
+    );
 
     const isAnalyzing = status === "OPEN";
 
@@ -30,7 +40,7 @@ export default function GroupRecommendationPreparationStatusCard({
                 </h2>
 
                 <span className={groupRecommendationPreparationPageStyles.preferenceStatusCount}>
-                    {readyMemberCount}/{totalMemberCount}
+                    {safeReadyMemberCount}/{totalMemberCount}
                 </span>
             </div>
 

--- a/src/features/groupRecommendation/ui/components/GroupRecommendationResultCandidateCard.tsx
+++ b/src/features/groupRecommendation/ui/components/GroupRecommendationResultCandidateCard.tsx
@@ -5,6 +5,10 @@ interface GroupRecommendationResultCandidateCardProps {
     readonly matchPercent: number;
     readonly selected: boolean;
     readonly isVoteClosed: boolean;
+
+    // 투표 API 요청 중인지 여부
+    readonly isVoting: boolean;
+
     readonly onClickVote: () => void;
 }
 
@@ -13,8 +17,11 @@ export default function GroupRecommendationResultCandidateCard({
     matchPercent,
     selected,
     isVoteClosed,
+    isVoting,
     onClickVote,
 }: GroupRecommendationResultCandidateCardProps) {
+    const isVoteButtonDisabled = isVoteClosed || isVoting;
+
     return (
         <article
             className={
@@ -37,14 +44,16 @@ export default function GroupRecommendationResultCandidateCard({
                 <button
                     type="button"
                     onClick={onClickVote}
-                    disabled={isVoteClosed}
+
+                    // 투표 종료 또는 투표 요청 중이면 버튼 비활성화
+                    disabled={isVoteButtonDisabled}
                     className={
-                        isVoteClosed
+                        isVoteButtonDisabled
                             ? groupRecommendationResultPageStyles.disabledVoteButton
                             : groupRecommendationResultPageStyles.voteButton
                     }
                 >
-                    투표하기
+                    {isVoting ? "투표 중..." : "투표하기"}
                 </button>
             </div>
         </article>

--- a/src/features/groupRecommendation/ui/components/GroupRecommendationResultVoteStatusCard.tsx
+++ b/src/features/groupRecommendation/ui/components/GroupRecommendationResultVoteStatusCard.tsx
@@ -5,6 +5,7 @@ interface GroupRecommendationResultVoteStatusCardProps {
     readonly votedMemberCount: number;
     readonly isOwner: boolean;
     readonly isVoteClosed: boolean;
+    readonly isFinalizing: boolean;
     readonly onClickCloseVote: () => void;
     readonly onClickMoveVoteResult: () => void;
 }
@@ -14,6 +15,7 @@ export default function GroupRecommendationResultVoteStatusCard({
     votedMemberCount,
     isOwner,
     isVoteClosed,
+    isFinalizing,
     onClickCloseVote,
     onClickMoveVoteResult,
 }: GroupRecommendationResultVoteStatusCardProps) {
@@ -60,7 +62,7 @@ export default function GroupRecommendationResultVoteStatusCard({
                     onClick={onClickCloseVote}
                     className={groupRecommendationResultPageStyles.voteActionButton}
                 >
-                    투표 종료
+                    {isFinalizing ? "투표 종료 중..." : "투표 종료"}
                 </button>
             )}
         </section>


### PR DESCRIPTION
## 관련 이슈
Closes #178 
Closes #179 

## 요약
- 무엇을 변경했나요?
  - 그룹 메뉴 추천 후보 투표 기능 구현
  - 재투표 시 기존 투표를 변경할 수 있도록 함
  - 투표 완료 후 투표 진행 현황 및 멤버 투표 상태 갱신
  - 방장 전용 투표 종료 기능 구현
  - 투표 종료 후 `투표 종료` 버튼을 `투표 결과 보러 가기` 버튼으로 변경

- 왜 이 변경이 필요한가요?
  - 그룹 메뉴 추천 결과 화면에서 그룹원들이 후보 메뉴에 투표할 수 있도록 하기 위함
  - 모든 그룹원의 투표가 완료되면 방장이 최종 메뉴를 확정하고 다음 단계로 진행할 수 있도록 하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
