### PR TITLE
[Feat] 그룹 SSE 이벤트 기반 멤버 참여/탈퇴 및 그룹 삭제 실시간 반영

### DIFF
--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -89,6 +89,11 @@ export default function GroupPage() {
             refetchGroups();
             refetchGroupDetail();
         },
+
+        onMemberLeft: () => {
+            refetchGroups();
+            refetchGroupDetail();
+        },
     });
 
     const groups = useAtomValue(groupsAtom);

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -76,14 +76,20 @@ export default function GroupPage() {
 
     const accessToken = useAtomValue(accessTokenAtom);
     useMyRealtimeEvents(accessToken);
-    useGroupRealtimeEvents({
-        accessToken,
-        groupId: selectedGroupId,
-    });
 
     const { refetchGroups } = useGroupList();
     const { refetchInvites } = useGroupInvites();
     const { refetchGroupDetail } = useGroupDetail(selectedGroupId);
+
+    useGroupRealtimeEvents({
+        accessToken,
+        groupId: selectedGroupId,
+
+        onMemberJoined: () => {
+            refetchGroups();
+            refetchGroupDetail();
+        },
+    });
 
     const groups = useAtomValue(groupsAtom);
     const hasGroups = useAtomValue(hasGroupsAtom);

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAtomValue } from "jotai";
 import { useRouter } from "next/navigation";
 
@@ -19,6 +19,7 @@ import { useLeaveGroup } from "@/features/group/application/hooks/useLeaveGroup"
 import { useMyRealtimeEvents } from "@/features/group/application/hooks/useMyRealtimeEvents";
 import { useStartGroupRecommendation } from "@/features/groupRecommendation/application/hooks/useStartGroupRecommendation";
 import { useGroupRealtimeEvents } from "@/features/group/application/hooks/useGroupRealtimeEvents";
+import type { GroupDeletedEvent } from "@/features/group/infrastructure/sse/dto/GroupDeletedEvent";
 
 import {
     groupsAtom,
@@ -38,7 +39,10 @@ import {
     isGroupDetailLoadingAtom,
     groupDetailErrorMessageAtom,
 } from "@/features/group/application/selectors/groupDetailSelectors";
-import { accessTokenAtom } from "@/features/auth/application/selectors/authSelectors";
+import {
+    accessTokenAtom,
+    memberAtom,
+} from "@/features/auth/application/selectors/authSelectors";
 
 import GroupCard from "@/features/group/ui/components/GroupCard";
 import GroupListEmpty from "@/features/group/ui/components/GroupListEmpty";
@@ -73,43 +77,100 @@ export default function GroupPage() {
     const [editingGroupName, setEditingGroupName] = useState("");
     const [editingLocation, setEditingLocation] = useState<LocationSetting | null>(null);
     const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
+    const [realtimeNoticeMessage, setRealtimeNoticeMessage] = useState<string | null>(null);
 
     const accessToken = useAtomValue(accessTokenAtom);
-    useMyRealtimeEvents(accessToken);
-
-    const { refetchGroups } = useGroupList();
-    const { refetchInvites } = useGroupInvites();
-    const { refetchGroupDetail } = useGroupDetail(selectedGroupId);
-
-    useGroupRealtimeEvents({
-        accessToken,
-        groupId: selectedGroupId,
-
-        onMemberJoined: () => {
-            refetchGroups();
-            refetchGroupDetail();
-        },
-
-        onMemberLeft: () => {
-            refetchGroups();
-            refetchGroupDetail();
-        },
-    });
+    const member = useAtomValue(memberAtom);
 
     const groups = useAtomValue(groupsAtom);
     const hasGroups = useAtomValue(hasGroupsAtom);
     const isGroupListLoading = useAtomValue(isGroupListLoadingAtom);
     const groupListErrorMessage = useAtomValue(groupListErrorMessageAtom);
 
+    const groupDetail = useAtomValue(groupDetailAtomValue);
+    const isGroupDetailLoading = useAtomValue(isGroupDetailLoadingAtom);
+    const groupDetailErrorMessage = useAtomValue(groupDetailErrorMessageAtom);
+
+    useMyRealtimeEvents(accessToken);
+
+    const { refetchGroups } = useGroupList();
+    const { refetchInvites } = useGroupInvites();
+
+    const handleGroupNotFound = useCallback(() => {
+        setSelectedGroupId(null);
+
+        refetchGroups();
+
+        setRealtimeNoticeMessage(
+            "그룹이 삭제되어 더 이상 접근할 수 없습니다.",
+        );
+    }, [refetchGroups]);
+
+    const { refetchGroupDetail } = useGroupDetail(selectedGroupId, {
+        onGroupNotFound: handleGroupNotFound,
+    });
+
+    const handleMemberJoined = useCallback(() => {
+        refetchGroups();
+        refetchGroupDetail();
+    }, [refetchGroups, refetchGroupDetail]);
+
+    const handleMemberLeft = useCallback(() => {
+        refetchGroups();
+        refetchGroupDetail();
+    }, [refetchGroups, refetchGroupDetail]);
+
+    const handleGroupDeleted = useCallback(
+        (event: GroupDeletedEvent) => {
+            const isCurrentGroupDeleted =
+                selectedGroupId === event.payload.groupId;
+
+            if (isCurrentGroupDeleted) {
+                setSelectedGroupId(null);
+
+                const isDeletedByMe =
+                    member?.id === event.payload.deletedByMemberId;
+
+                if (!isDeletedByMe) {
+                    setRealtimeNoticeMessage(
+                        "그룹이 삭제되어 더 이상 접근할 수 없습니다.",
+                    );
+                }
+            }
+
+            refetchGroups();
+        },
+        [member?.id, refetchGroups, selectedGroupId],
+    );
+
+    useGroupRealtimeEvents({
+        accessToken,
+        groupId: selectedGroupId,
+        onMemberJoined: handleMemberJoined,
+        onMemberLeft: handleMemberLeft,
+        onGroupDeleted: handleGroupDeleted,
+    });
+
+    // 실시간 그룹 삭제 안내 메시지 3초 후 자동 제거
+    useEffect(() => {
+        if (!realtimeNoticeMessage) {
+            return;
+        }
+
+        const timer = window.setTimeout(() => {
+            setRealtimeNoticeMessage(null);
+        }, 3000);
+
+        return () => {
+            window.clearTimeout(timer);
+        };
+    }, [realtimeNoticeMessage]);
+
     const invites = useAtomValue(invitesAtom);
     const hasInvites = useAtomValue(hasInvitesAtom);
     const isInviteListLoading = useAtomValue(isInviteListLoadingAtom);
     const inviteListErrorMessage = useAtomValue(inviteListErrorMessageAtom);
     const showViewAllButton = useAtomValue(shouldShowInviteViewAllButtonAtom);
-
-    const groupDetail = useAtomValue(groupDetailAtomValue);
-    const isGroupDetailLoading = useAtomValue(isGroupDetailLoadingAtom);
-    const groupDetailErrorMessage = useAtomValue(groupDetailErrorMessageAtom);
 
     const { start } = useStartGroupRecommendation({
         onSuccess: (sessionId) => {
@@ -349,6 +410,12 @@ export default function GroupPage() {
                 <div className={groupManagementPageStyles.layout}>
                     <div className={groupManagementPageStyles.mainContent}>
                         <div className={groupManagementPageStyles.content}>
+                            {realtimeNoticeMessage && (
+                                <div className={groupManagementPageStyles.realtimeNotice}>
+                                    {realtimeNoticeMessage}
+                                </div>
+                            )}
+
                             <GroupManagementHeader
                                 onClickCreate={() => setIsCreateModalOpen(true)}
                             />

--- a/src/features/group/application/hooks/useGroupDetail.ts
+++ b/src/features/group/application/hooks/useGroupDetail.ts
@@ -6,13 +6,34 @@ import { useSetAtom } from "jotai";
 import { groupDetailAtom } from "@/features/group/application/atoms/groupDetailAtom";
 import { fetchGroupDetail } from "@/features/group/application/usecase/fetchGroupDetail";
 
-export function useGroupDetail(groupId: number | null) {
+interface UseGroupDetailParams {
+    readonly onGroupNotFound?: () => void;
+}
+
+function isGroupNotFoundError(error: unknown) {
+    const httpError = error as {
+        status?: number;
+        body?: { error?: { code?: string } | null };
+        errorBody?: { error?: { code?: string } | null };
+        message?: string;
+    };
+
+    return (
+        httpError.status === 404 ||
+        httpError.body?.error?.code === "GROUP_NOT_FOUND" ||
+        httpError.errorBody?.error?.code === "GROUP_NOT_FOUND" ||
+        httpError.message?.includes("GROUP_NOT_FOUND")
+    );
+}
+
+export function useGroupDetail(
+    groupId: number | null,
+    { onGroupNotFound }: UseGroupDetailParams = {},
+) {
     const setGroupDetailState = useSetAtom(groupDetailAtom);
 
     const refetchGroupDetail = useCallback(async () => {
-        if (groupId === null) {
-            return;
-        }
+        if (groupId === null) return;
 
         try {
             setGroupDetailState({ status: "LOADING" });
@@ -25,6 +46,12 @@ export function useGroupDetail(groupId: number | null) {
                 data: groupDetail,
             });
         } catch (error) {
+            if (isGroupNotFoundError(error)) {
+                setGroupDetailState({ status: "LOADING" });
+                onGroupNotFound?.();
+                return;
+            }
+
             setGroupDetailState({
                 status: "ERROR",
                 message:
@@ -33,11 +60,16 @@ export function useGroupDetail(groupId: number | null) {
                         : "그룹 상세 정보를 불러오는데 실패했습니다.",
             });
         }
-    }, [groupId, setGroupDetailState]);
+    }, [groupId, onGroupNotFound, setGroupDetailState]);
 
     useEffect(() => {
+        if (groupId === null) {
+            setGroupDetailState({ status: "LOADING" });
+            return;
+        }
+
         refetchGroupDetail();
-    }, [refetchGroupDetail]);
+    }, [groupId, refetchGroupDetail, setGroupDetailState]);
 
     return {
         refetchGroupDetail,

--- a/src/features/group/application/hooks/useGroupRealtimeEvents.ts
+++ b/src/features/group/application/hooks/useGroupRealtimeEvents.ts
@@ -22,32 +22,50 @@ type GroupRealtimeEventSource = {
 interface UseGroupRealtimeEventsProps {
     readonly accessToken: string | null;
     readonly groupId: number | null;
+
+    readonly onMemberJoined?: () => void;
 }
 
 export function useGroupRealtimeEvents({
     accessToken,
     groupId,
+    onMemberJoined,
 }: UseGroupRealtimeEventsProps) {
     useEffect(() => {
         if (!accessToken || groupId === null) {
             return;
         }
 
-        const eventSource = createGroupRealtimeConnection(
-            accessToken,
-            groupId,
-        ) as unknown as GroupRealtimeEventSource;
+        const eventSource =
+            createGroupRealtimeConnection(
+                accessToken,
+                groupId,
+            ) as unknown as GroupRealtimeEventSource;
 
-        Object.values(GROUP_REALTIME_EVENT_TYPE).forEach((eventType) => {
-            eventSource.addEventListener(eventType, (event) => {
+        eventSource.addEventListener(
+            GROUP_REALTIME_EVENT_TYPE.CONNECTED,
+            () => {
                 if (process.env.NODE_ENV === "development") {
                     console.log(
-                        `[GROUP SSE] ${eventType}`,
+                        "[GROUP SSE] connected",
+                    );
+                }
+            },
+        );
+
+        eventSource.addEventListener(
+            GROUP_REALTIME_EVENT_TYPE.GROUP_MEMBER_JOINED,
+            (event) => {
+                if (process.env.NODE_ENV === "development") {
+                    console.log(
+                        "[GROUP SSE] GROUP_MEMBER_JOINED",
                         JSON.parse(event.data),
                     );
                 }
-            });
-        });
+
+                onMemberJoined?.();
+            },
+        );
 
         eventSource.onerror = (error) => {
             if (process.env.NODE_ENV === "development") {
@@ -61,5 +79,9 @@ export function useGroupRealtimeEvents({
         return () => {
             eventSource.close();
         };
-    }, [accessToken, groupId]);
+    }, [
+        accessToken,
+        groupId,
+        onMemberJoined,
+    ]);
 }

--- a/src/features/group/application/hooks/useGroupRealtimeEvents.ts
+++ b/src/features/group/application/hooks/useGroupRealtimeEvents.ts
@@ -3,7 +3,6 @@
 import { useEffect } from "react";
 
 import { createGroupRealtimeConnection } from "@/infrastructure/sse/groupRealtimeClient";
-
 import { GROUP_REALTIME_EVENT_TYPE } from "@/features/group/domain/model/GroupRealtimeEventType";
 
 type GroupRealtimeEventSource = {
@@ -24,31 +23,30 @@ interface UseGroupRealtimeEventsProps {
     readonly groupId: number | null;
 
     readonly onMemberJoined?: () => void;
+    readonly onMemberLeft?: () => void;
 }
 
 export function useGroupRealtimeEvents({
     accessToken,
     groupId,
     onMemberJoined,
+    onMemberLeft,
 }: UseGroupRealtimeEventsProps) {
     useEffect(() => {
         if (!accessToken || groupId === null) {
             return;
         }
 
-        const eventSource =
-            createGroupRealtimeConnection(
-                accessToken,
-                groupId,
-            ) as unknown as GroupRealtimeEventSource;
+        const eventSource = createGroupRealtimeConnection(
+            accessToken,
+            groupId,
+        ) as unknown as GroupRealtimeEventSource;
 
         eventSource.addEventListener(
             GROUP_REALTIME_EVENT_TYPE.CONNECTED,
             () => {
                 if (process.env.NODE_ENV === "development") {
-                    console.log(
-                        "[GROUP SSE] connected",
-                    );
+                    console.log("[GROUP SSE] connected");
                 }
             },
         );
@@ -67,21 +65,28 @@ export function useGroupRealtimeEvents({
             },
         );
 
+        eventSource.addEventListener(
+            GROUP_REALTIME_EVENT_TYPE.GROUP_MEMBER_LEFT,
+            (event) => {
+                if (process.env.NODE_ENV === "development") {
+                    console.log(
+                        "[GROUP SSE] GROUP_MEMBER_LEFT",
+                        JSON.parse(event.data),
+                    );
+                }
+
+                onMemberLeft?.();
+            },
+        );
+
         eventSource.onerror = (error) => {
             if (process.env.NODE_ENV === "development") {
-                console.error(
-                    "그룹 실시간 이벤트 스트림 에러",
-                    error,
-                );
+                console.error("그룹 실시간 이벤트 스트림 에러", error);
             }
         };
 
         return () => {
             eventSource.close();
         };
-    }, [
-        accessToken,
-        groupId,
-        onMemberJoined,
-    ]);
+    }, [accessToken, groupId, onMemberJoined, onMemberLeft]);
 }

--- a/src/features/group/application/hooks/useGroupRealtimeEvents.ts
+++ b/src/features/group/application/hooks/useGroupRealtimeEvents.ts
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 
 import { createGroupRealtimeConnection } from "@/infrastructure/sse/groupRealtimeClient";
 import { GROUP_REALTIME_EVENT_TYPE } from "@/features/group/domain/model/GroupRealtimeEventType";
+import type { GroupDeletedEvent } from "@/features/group/infrastructure/sse/dto/GroupDeletedEvent";
 
 type GroupRealtimeEventSource = {
     readonly readyState: number;
@@ -21,9 +22,9 @@ type GroupRealtimeEventSource = {
 interface UseGroupRealtimeEventsProps {
     readonly accessToken: string | null;
     readonly groupId: number | null;
-
     readonly onMemberJoined?: () => void;
     readonly onMemberLeft?: () => void;
+    readonly onGroupDeleted?: (event: GroupDeletedEvent) => void;
 }
 
 export function useGroupRealtimeEvents({
@@ -31,6 +32,7 @@ export function useGroupRealtimeEvents({
     groupId,
     onMemberJoined,
     onMemberLeft,
+    onGroupDeleted,
 }: UseGroupRealtimeEventsProps) {
     useEffect(() => {
         if (!accessToken || groupId === null) {
@@ -79,14 +81,35 @@ export function useGroupRealtimeEvents({
             },
         );
 
-        eventSource.onerror = (error) => {
+        eventSource.addEventListener(
+            GROUP_REALTIME_EVENT_TYPE.GROUP_DELETED,
+            (event) => {
+                const deletedEvent = JSON.parse(event.data) as GroupDeletedEvent;
+
+                if (process.env.NODE_ENV === "development") {
+                    console.log("[GROUP SSE] GROUP_DELETED", deletedEvent);
+                }
+
+                onGroupDeleted?.(deletedEvent);
+            },
+        );
+
+        eventSource.onerror = () => {
             if (process.env.NODE_ENV === "development") {
-                console.error("그룹 실시간 이벤트 스트림 에러", error);
+                console.debug("그룹 실시간 이벤트 스트림 연결이 종료되었습니다.");
             }
+
+            eventSource.close();
         };
 
         return () => {
             eventSource.close();
         };
-    }, [accessToken, groupId, onMemberJoined, onMemberLeft]);
+    }, [
+        accessToken,
+        groupId,
+        onMemberJoined,
+        onMemberLeft,
+        onGroupDeleted,
+    ]);
 }

--- a/src/features/group/infrastructure/sse/dto/GroupDeletedEvent.ts
+++ b/src/features/group/infrastructure/sse/dto/GroupDeletedEvent.ts
@@ -1,0 +1,13 @@
+export interface GroupDeletedEvent {
+    readonly eventId: string;
+    readonly eventType: "GROUP_DELETED";
+    readonly occurredAt: string;
+    readonly groupId: number;
+    readonly sessionId: null;
+    readonly actorMemberId: number;
+    readonly payload: {
+        readonly groupId: number;
+        readonly deletedByMemberId: number;
+        readonly deletedAt: string;
+    };
+}

--- a/src/infrastructure/http/httpClient.ts
+++ b/src/infrastructure/http/httpClient.ts
@@ -59,6 +59,21 @@ function shouldTryRefresh(path: string, isRetry: boolean) {
     return true;
 }
 
+function shouldSilenceErrorLog(
+    path: string,
+    errorBody: ErrorResponseBody | null,
+) {
+    if (SILENT_ERROR_LOG_PATHS.includes(path)) {
+        return true;
+    }
+
+    // 삭제된 그룹 상세 조회는 화면에서 fallback 처리하므로 로그 제외
+    if (errorBody?.error?.code === "GROUP_NOT_FOUND") {
+        return true;
+    }
+
+    return false;
+}
 async function refreshAccessToken(): Promise<RefreshResult> {
     const response = await fetch(`${clientEnv.apiBaseUrl}/api/v1/auth/refresh`, {
         method: "POST",
@@ -122,7 +137,7 @@ async function request<T>(
     if (!response.ok) {
         const errorBody = await response.json().catch(() => null);
         //  refresh는 로그 안 찍음
-        if (!SILENT_ERROR_LOG_PATHS.includes(path)) {
+        if (!shouldSilenceErrorLog(path, errorBody)) {
             console.error("[httpClient] 요청 실패 응답:", {
                 path,
                 status: response.status,

--- a/src/ui/styles/groupManagementPageStyles.ts
+++ b/src/ui/styles/groupManagementPageStyles.ts
@@ -61,4 +61,6 @@ export const groupManagementPageStyles = {
         "p-10 text-sm font-medium text-slate-500",
     detailErrorBox:
         "p-10 text-sm font-medium text-red-500",
+    realtimeNotice:
+        "mb-4 rounded-2xl border border-red-200 bg-red-50 px-5 py-4 text-sm font-semibold text-red-700",
 } as const;


### PR DESCRIPTION
## 관련 이슈
Closes #184 
Closes #185 
Closes #186 

## 요약
- 무엇을 변경했나요?
  - `GROUP_MEMBER_JOINED` 이벤트 수신 시 그룹 목록 및 그룹 상세 정보를 재조회하도록 구현
  - `GROUP_MEMBER_LEFT` 이벤트 수신 시 그룹 목록 및 그룹 상세 정보를 재조회하도록 구현
  - `GROUP_DELETED` 이벤트 수신 시 그룹 목록을 재조회하고, 현재 선택된 그룹이 삭제된 경우 상세 패널을 닫고 안내 메시지를 표시하도록 구현
 
- 왜 이 변경이 필요한가요?
  - 그룹 멤버 참여/탈퇴 및 그룹 삭제 상황을 모든 그룹원이 실시간으로 확인
  - 최신 그룹 정보와 멤버 수를 서버 데이터와 동기화하여 화면에 즉시 반영

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
