### PR TITLE
[Feat] 그룹 추천 결과 화면 상태 복원 및 그룹 상세 패널에 최종 추천 결과 표시 기능 구현

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useAtomValue } from "jotai";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
@@ -9,7 +8,6 @@ import { useGroupDetail } from "@/features/group/application/hooks/useGroupDetai
 import { isGroupOwnerAtom } from "@/features/group/application/selectors/groupDetailSelectors";
 
 import { useGroupRecommendationSessionDetail } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationSessionDetail";
-import { useGroupRecommendationReadiness } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationReadiness";
 import { useVoteGroupRecommendationCandidate } from "@/features/groupRecommendation/application/hooks/useVoteGroupRecommendationCandidate";
 import { useFinalizeGroupRecommendation } from "@/features/groupRecommendation/application/hooks/useFinalizeGroupRecommendation";
 
@@ -18,8 +16,6 @@ import {
     isGroupRecommendationSessionDetailLoadingAtom,
     groupRecommendationSessionDetailErrorMessageAtom,
 } from "@/features/groupRecommendation/application/selectors/groupRecommendationSessionDetailSelectors";
-import { groupRecommendationReadinessAtomValue } from "@/features/groupRecommendation/application/selectors/groupRecommendationReadinessSelectors";
-import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
 
 import GroupRecommendationResultVoteStatusCard from "@/features/groupRecommendation/ui/components/GroupRecommendationResultVoteStatusCard";
 import GroupRecommendationResultMemberList from "@/features/groupRecommendation/ui/components/GroupRecommendationResultMemberList";
@@ -28,78 +24,42 @@ import GroupRecommendationResultCandidateCard from "@/features/groupRecommendati
 import { groupRecommendationResultPageStyles } from "@/ui/styles/groupRecommendationResultPageStyles";
 
 export default function GroupRecommendationResultPage() {
-    const params = useParams<{
-        groupId: string;
-        sessionId: string;
-    }>();
-
+    const params = useParams<{ groupId: string; sessionId: string }>();
     const router = useRouter();
 
     const groupId = Number(params.groupId);
     const sessionId = Number(params.sessionId);
 
-    const [selectedCandidateId, setSelectedCandidateId] =
-        useState<number | null>(null);
-
-    const [isVoteClosed, setIsVoteClosed] = useState(false);
-
-    const member = useAtomValue(memberAtom);
-
-    // 새로고침/직접 진입 시에도 방장 여부를 알 수 있도록 그룹 상세 조회
     useGroupDetail(groupId);
-
-    // 그룹 상세 조회 결과를 기반으로 방장 여부 판단
     const isOwner = useAtomValue(isGroupOwnerAtom);
 
-    // TODO: 나중에 확인 필요
-    // 결과 화면에서도 멤버 목록 확보를 위해 준비 상태 조회 (다른 api에서는 멤버 정보를 주는 게 없기 때문)
-    useGroupRecommendationReadiness(groupId, sessionId);
-
-    const readiness = useAtomValue(groupRecommendationReadinessAtomValue);
-
-    const { refetchSessionDetail } = useGroupRecommendationSessionDetail(
-        groupId,
-        sessionId,
-    );
+    const { refetchSessionDetail } = useGroupRecommendationSessionDetail(groupId, sessionId);
 
     const { isVoting, vote } = useVoteGroupRecommendationCandidate({
         onSuccess: async () => {
-            await refetchSessionDetail({
-                showLoading: false,
-            });
+            await refetchSessionDetail({ showLoading: false });
         },
     });
 
     const { isFinalizing, finalize } = useFinalizeGroupRecommendation({
         onSuccess: async () => {
-            await refetchSessionDetail({
-                showLoading: false,
-            });
+            await refetchSessionDetail({ showLoading: false });
         },
     });
 
-    const sessionDetail = useAtomValue(
-        groupRecommendationSessionDetailAtomValue,
-    );
-    const isSessionDetailLoading = useAtomValue(
-        isGroupRecommendationSessionDetailLoadingAtom,
-    );
-    const sessionDetailErrorMessage = useAtomValue(
-        groupRecommendationSessionDetailErrorMessageAtom,
-    );
+    const sessionDetail = useAtomValue(groupRecommendationSessionDetailAtomValue);
+    const isSessionDetailLoading = useAtomValue(isGroupRecommendationSessionDetailLoadingAtom);
+    const sessionDetailErrorMessage = useAtomValue(groupRecommendationSessionDetailErrorMessageAtom);
 
     const handleClickBack = () => {
         router.push(`/group?selectedGroupId=${groupId}`);
     };
 
     const handleClickVote = async (candidateId: number) => {
-        if (isVoteClosed || sessionDetail?.status === "FINALIZED") {
-            return;
-        }
+        if (sessionDetail?.status === "FINALIZED") return;
 
         try {
             await vote(groupId, sessionId, candidateId);
-            setSelectedCandidateId(candidateId);
         } catch {
             alert("투표에 실패했습니다.");
         }
@@ -108,8 +68,6 @@ export default function GroupRecommendationResultPage() {
     const handleClickCloseVote = async () => {
         try {
             await finalize(groupId, sessionId);
-
-            setIsVoteClosed(true);
         } catch {
             alert("투표 종료에 실패했습니다.");
         }
@@ -139,19 +97,13 @@ export default function GroupRecommendationResultPage() {
         );
     }
 
-    if (!sessionDetail) {
-        return null;
-    }
+    if (!sessionDetail) return null;
 
     if (sessionDetail.status === "PREPARING") {
         return (
             <main className={groupRecommendationResultPageStyles.container}>
                 <div className={groupRecommendationResultPageStyles.content}>
-                    <button
-                        type="button"
-                        onClick={handleClickBack}
-                        className={groupRecommendationResultPageStyles.backButton}
-                    >
+                    <button type="button" onClick={handleClickBack} className={groupRecommendationResultPageStyles.backButton}>
                         <ArrowLeft size={30} strokeWidth={2.5} />
                     </button>
 
@@ -163,39 +115,29 @@ export default function GroupRecommendationResultPage() {
         );
     }
 
-    const isFinalized =
-        sessionDetail.status === "FINALIZED" || isVoteClosed;
+    const isFinalized = sessionDetail.status === "FINALIZED";
+    const myVote = sessionDetail.memberVotes.find((memberVote) => memberVote.isMe);
+    const selectedCandidateId = myVote?.candidateId ?? null;
 
     const votedMemberCount = sessionDetail.voteProgress?.votedMemberCount ?? 0;
-
-    const totalMemberCount =
-        sessionDetail.voteProgress?.totalMemberCount ?? 0;
+    const totalMemberCount = sessionDetail.voteProgress?.totalMemberCount ?? 0;
 
     const candidates = sessionDetail.candidates.map((candidate) => ({
         ...candidate,
         selected: candidate.candidateId === selectedCandidateId,
     }));
 
-    const members =
-        readiness?.members.map((readinessMember) => {
-            const isMe = member?.id === readinessMember.memberId;
-
-            return {
-                memberId: readinessMember.memberId,
-                nickname: readinessMember.nickname,
-                isMe,
-                voted: isMe && selectedCandidateId !== null,
-            };
-        }) ?? [];
+    const members = sessionDetail.memberVotes.map((memberVote) => ({
+        memberId: memberVote.memberId,
+        nickname: memberVote.nickname,
+        isMe: memberVote.isMe,
+        voted: memberVote.voted,
+    }));
 
     return (
         <main className={groupRecommendationResultPageStyles.container}>
             <div className={groupRecommendationResultPageStyles.content}>
-                <button
-                    type="button"
-                    onClick={handleClickBack}
-                    className={groupRecommendationResultPageStyles.backButton}
-                >
+                <button type="button" onClick={handleClickBack} className={groupRecommendationResultPageStyles.backButton}>
                     <ArrowLeft size={30} strokeWidth={2.5} />
                 </button>
 
@@ -232,9 +174,7 @@ export default function GroupRecommendationResultPage() {
                             selected={candidate.selected}
                             isVoteClosed={isFinalized}
                             isVoting={isVoting}
-                            onClickVote={() =>
-                                handleClickVote(candidate.candidateId)
-                            }
+                            onClickVote={() => handleClickVote(candidate.candidateId)}
                         />
                     ))}
                 </section>

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -317,13 +317,13 @@ export default function GroupPage() {
     };
 
     const handleMoveActiveRecommendation = () => {
-        if (selectedGroupId === null || !groupDetail?.activeRecommendation) {
+        if (selectedGroupId === null || !groupDetail?.recentlyRecommendation) {
             return;
         }
 
-        const sessionId = groupDetail.activeRecommendation.sessionId;
+        const { sessionId, status } = groupDetail.recentlyRecommendation;
 
-        if (groupDetail.activeRecommendation.status === "PREPARING") {
+        if (status === "PREPARING") {
             router.push(`/group/${selectedGroupId}/recommendations/${sessionId}`);
             return;
         }
@@ -336,7 +336,11 @@ export default function GroupPage() {
             return;
         }
 
-        if (groupDetail.activeRecommendation) {
+        const runningRecommendation =
+            groupDetail.recentlyRecommendation?.status === "PREPARING" ||
+            groupDetail.recentlyRecommendation?.status === "OPEN";
+
+        if (runningRecommendation) {
             handleMoveActiveRecommendation();
             return;
         }
@@ -350,7 +354,7 @@ export default function GroupPage() {
             latitude: groupDetail.location.latitude,
             longitude: groupDetail.location.longitude,
             address: groupDetail.location.address,
-            radiusMeters: 1000,
+            radiusMeters: groupDetail.location.radiusMeters,
         });
     };
 

--- a/src/features/group/domain/model/GroupDetail.ts
+++ b/src/features/group/domain/model/GroupDetail.ts
@@ -22,6 +22,7 @@ export interface GroupDetailRecommendationCandidate {
     readonly candidateId: number;
     readonly menuId: number;
     readonly menuName: string;
+    readonly thumbnailUrl: string | null;
     readonly rankNo: number;
     readonly score: number;
     readonly voteCount: number;
@@ -43,5 +44,5 @@ export interface GroupDetail {
     readonly inviteCode: string;
     readonly location: GroupDetailLocation;
     readonly members: readonly GroupDetailMember[];
-    readonly activeRecommendation: GroupDetailRecommendation | null;
+    readonly recentlyRecommendation: GroupDetailRecommendation | null;
 }

--- a/src/features/group/infrastructure/api/dto/GroupDetailResponse.ts
+++ b/src/features/group/infrastructure/api/dto/GroupDetailResponse.ts
@@ -20,7 +20,7 @@ export interface GroupDetailResponse {
             readonly isMe: boolean;
         }[];
 
-        readonly activeRecommendation: {
+        readonly recentlyRecommendation: {
             readonly sessionId: number;
             readonly status: "PREPARING" | "OPEN" | "FINALIZED";
 
@@ -34,6 +34,7 @@ export interface GroupDetailResponse {
                 readonly candidateId: number;
                 readonly menuId: number;
                 readonly menuName: string;
+                readonly thumbnailUrl: string | null;
                 readonly rankNo: number;
                 readonly score: number;
                 readonly voteCount: number;
@@ -48,6 +49,7 @@ export interface GroupDetailResponse {
                 readonly candidateId: number;
                 readonly menuId: number;
                 readonly menuName: string;
+                readonly thumbnailUrl: string | null;
                 readonly rankNo: number;
                 readonly score: number;
                 readonly voteCount: number;

--- a/src/features/group/infrastructure/api/mapper/groupDetailMapper.ts
+++ b/src/features/group/infrastructure/api/mapper/groupDetailMapper.ts
@@ -22,55 +22,58 @@ export function mapGroupDetail(
             joinedAt: member.joinedAt,
             isMe: member.isMe,
         })),
-        activeRecommendation: response.activeRecommendation
+        recentlyRecommendation: response.recentlyRecommendation
             ? {
-                  sessionId: response.activeRecommendation.sessionId,
-                  status: response.activeRecommendation.status,
-                  readiness: response.activeRecommendation.readiness
+                  sessionId: response.recentlyRecommendation.sessionId,
+                  status: response.recentlyRecommendation.status,
+                  readiness: response.recentlyRecommendation.readiness
                       ? {
                             totalMemberCount:
-                                response.activeRecommendation.readiness.totalMemberCount,
+                                response.recentlyRecommendation.readiness.totalMemberCount,
                             readyMemberCount:
-                                response.activeRecommendation.readiness.readyMemberCount,
+                                response.recentlyRecommendation.readiness.readyMemberCount,
                             allReady:
-                                response.activeRecommendation.readiness.allReady,
+                                response.recentlyRecommendation.readiness.allReady,
                         }
                       : null,
-                  candidates: response.activeRecommendation.candidates.map(
+                  candidates: response.recentlyRecommendation.candidates.map(
                       (candidate) => ({
                           candidateId: candidate.candidateId,
                           menuId: candidate.menuId,
                           menuName: candidate.menuName,
+                          thumbnailUrl: candidate.thumbnailUrl,
                           rankNo: candidate.rankNo,
                           score: candidate.score,
                           voteCount: candidate.voteCount,
                       }),
                   ),
-                  voteProgress: response.activeRecommendation.voteProgress
+                  voteProgress: response.recentlyRecommendation.voteProgress
                       ? {
                             totalMemberCount:
-                                response.activeRecommendation.voteProgress.totalMemberCount,
+                                response.recentlyRecommendation.voteProgress.totalMemberCount,
                             votedMemberCount:
-                                response.activeRecommendation.voteProgress.votedMemberCount,
+                                response.recentlyRecommendation.voteProgress.votedMemberCount,
                         }
                       : null,
-                  finalCandidate: response.activeRecommendation.finalCandidate
+                  finalCandidate: response.recentlyRecommendation.finalCandidate
                       ? {
                             candidateId:
-                                response.activeRecommendation.finalCandidate.candidateId,
+                                response.recentlyRecommendation.finalCandidate.candidateId,
                             menuId:
-                                response.activeRecommendation.finalCandidate.menuId,
+                                response.recentlyRecommendation.finalCandidate.menuId,
                             menuName:
-                                response.activeRecommendation.finalCandidate.menuName,
+                                response.recentlyRecommendation.finalCandidate.menuName,
+                            thumbnailUrl:
+                                response.recentlyRecommendation.finalCandidate.thumbnailUrl,
                             rankNo:
-                                response.activeRecommendation.finalCandidate.rankNo,
+                                response.recentlyRecommendation.finalCandidate.rankNo,
                             score:
-                                response.activeRecommendation.finalCandidate.score,
+                                response.recentlyRecommendation.finalCandidate.score,
                             voteCount:
-                                response.activeRecommendation.finalCandidate.voteCount,
+                                response.recentlyRecommendation.finalCandidate.voteCount,
                         }
                       : null,
-                  createdAt: response.activeRecommendation.createdAt,
+                  createdAt: response.recentlyRecommendation.createdAt,
               }
             : null,
     };

--- a/src/features/group/ui/components/GroupDetailPanel.tsx
+++ b/src/features/group/ui/components/GroupDetailPanel.tsx
@@ -45,7 +45,7 @@ export default function GroupDetailPanel({
     const visibleMembers = group.members.slice(0, 3);
     const isOwner = useAtomValue(isGroupOwnerAtom);
 
-    const activeRecommendation = group.activeRecommendation;
+    const recentlyRecommendation = group.recentlyRecommendation;
 
     return (
         <aside className={groupDetailPanelStyles.panel}>
@@ -80,19 +80,19 @@ export default function GroupDetailPanel({
                     )}
                 </section>
 
-                {!activeRecommendation && isOwner && (
+                {!recentlyRecommendation && isOwner && (
                     <GroupRecommendationStartButton
                         onClick={onClickStartRecommendation}
                     />
                 )}
 
-                {!activeRecommendation && !isOwner && (
+                {!recentlyRecommendation && !isOwner && (
                     <p className={groupDetailPanelStyles.recommendationGuideText}>
                         방장이 추천을 시작하면 참여할 수 있어요.
                     </p>
                 )}
 
-                {activeRecommendation?.status === "PREPARING" && (
+                {recentlyRecommendation?.status === "PREPARING" && (
                     <GroupRecommendationStartButton
                         label="진행중인 메뉴 추천 페이지로 이동"
                         variant="preparing"
@@ -100,7 +100,7 @@ export default function GroupDetailPanel({
                     />
                 )}
 
-                {activeRecommendation?.status === "OPEN" && (
+                {recentlyRecommendation?.status === "OPEN" && (
                     <>
                         <GroupRecommendationStartButton
                             label="투표 현황 확인하기"
@@ -109,13 +109,13 @@ export default function GroupDetailPanel({
                         />
 
                         <GroupRecommendationStatusCard
-                            recommendation={activeRecommendation}
+                            recommendation={recentlyRecommendation}
                             onClickOpenRestaurantMap={onClickOpenRestaurantMap}
                         />
                     </>
                 )}
 
-                {activeRecommendation?.status === "FINALIZED" && (
+                {recentlyRecommendation?.status === "FINALIZED" && (
                     <>
                         {isOwner ? (
                             <GroupRecommendationStartButton
@@ -128,7 +128,7 @@ export default function GroupDetailPanel({
                         )}
 
                         <GroupRecommendationStatusCard
-                            recommendation={activeRecommendation}
+                            recommendation={recentlyRecommendation}
                             onClickOpenRestaurantMap={onClickOpenRestaurantMap}
                         />
                     </>

--- a/src/features/groupRecommendation/domain/model/GroupRecommendationSessionDetail.ts
+++ b/src/features/groupRecommendation/domain/model/GroupRecommendationSessionDetail.ts
@@ -19,12 +19,22 @@ export interface GroupRecommendationSessionProgress {
     readonly allReady?: boolean;
 }
 
+export interface GroupRecommendationSessionMemberVote {
+    readonly memberId: number;
+    readonly nickname: string;
+    readonly role: "OWNER" | "MEMBER";
+    readonly isMe: boolean;
+    readonly voted: boolean;
+    readonly candidateId: number | null;
+}
+
 export interface GroupRecommendationSessionDetail {
     readonly sessionId: number;
     readonly status: GroupRecommendationSessionStatus;
     readonly readiness: GroupRecommendationSessionProgress | null;
     readonly candidates: readonly GroupRecommendationSessionCandidate[];
     readonly voteProgress: GroupRecommendationSessionProgress | null;
+    readonly memberVotes: readonly GroupRecommendationSessionMemberVote[];
     readonly finalCandidate: GroupRecommendationSessionCandidate | null;
     readonly createdAt: string;
 }

--- a/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationSessionDetailResponse.ts
+++ b/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationSessionDetailResponse.ts
@@ -29,6 +29,14 @@ export interface GroupRecommendationSessionDetailResponse {
             readonly score: number;
             readonly voteCount: number;
         } | null;
+        readonly memberVotes: readonly {
+            readonly memberId: number;
+            readonly nickname: string;
+            readonly role: "OWNER" | "MEMBER";
+            readonly isMe: boolean;
+            readonly voted: boolean;
+            readonly candidateId: number | null;
+        }[];
         readonly createdAt: string;
     };
 

--- a/src/ui/styles/groupDetailMoreButtonStyles.ts
+++ b/src/ui/styles/groupDetailMoreButtonStyles.ts
@@ -1,13 +1,13 @@
 export const groupDetailMoreButtonStyles = {
     wrapper: "relative",
     button:
-        "flex h-11 w-11 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-100",
+        "flex h-11 w-11 cursor-pointer items-center justify-center rounded-full text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 active:bg-slate-200",
     menu:
         "absolute right-0 top-14 z-20 flex w-56 flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-xl",
     menuItem:
-        "flex items-center gap-3 px-5 py-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50",
+        "flex cursor-pointer items-center gap-3 px-5 py-4 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 active:bg-slate-200",
     deleteMenuItem:
-        "flex items-center gap-3 px-5 py-4 text-sm font-medium text-red-500 transition hover:bg-red-50",
+        "flex cursor-pointer items-center gap-3 px-5 py-4 text-sm font-medium text-red-500 transition-colors hover:bg-red-100 active:bg-red-200",
     leaveMenuItem:
-        "flex items-center gap-3 px-5 py-4 text-sm font-medium text-red-500 transition hover:bg-red-50",
+        "flex cursor-pointer items-center gap-3 px-5 py-4 text-sm font-medium text-red-500 transition-colors hover:bg-red-100 active:bg-red-200",
 };

--- a/src/ui/styles/groupDetailPanelStyles.ts
+++ b/src/ui/styles/groupDetailPanelStyles.ts
@@ -3,25 +3,29 @@ export const groupDetailPanelStyles = {
     content: "flex min-h-full flex-col px-12 py-10",
 
     header: "flex items-center justify-between",
-    backButton: "flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 text-zinc-700",
-    moreButton: "flex h-12 w-12 items-center justify-center rounded-full bg-white text-zinc-500",
+    backButton:
+        "flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-zinc-100 text-zinc-700 transition-colors hover:bg-zinc-200 active:bg-zinc-300",
+    moreButton:
+        "flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200",
 
     groupTitle: "mt-8 text-4xl font-bold text-zinc-900",
     address: "mt-4 flex items-center gap-2 text-base text-slate-600",
 
-    recommendationButton: "mt-10 h-16 rounded-full bg-zinc-950 text-lg font-bold text-white",
-    recommendationGuideText: "mt-10 rounded-[24px] bg-zinc-100 px-6 py-5 text-center text-base font-semibold text-slate-500",
+    recommendationButton:
+        "mt-10 h-16 cursor-pointer rounded-full bg-zinc-950 text-lg font-bold text-white transition-colors hover:bg-zinc-800 active:bg-zinc-700",
+    recommendationGuideText:
+        "mt-10 rounded-[24px] bg-zinc-100 px-6 py-5 text-center text-base font-semibold text-slate-500",
     preparingRecommendationButton:
-        "mt-10 h-16 rounded-full bg-orange-500 text-lg font-bold text-white transition-colors hover:bg-orange-600 active:bg-orange-700",
+        "mt-10 h-16 cursor-pointer rounded-full bg-orange-500 text-lg font-bold text-white transition-colors hover:bg-orange-600 active:bg-orange-700",
     openRecommendationButton:
-        "mt-10 h-16 rounded-full bg-emerald-700 text-lg font-bold text-white transition-colors hover:bg-emerald-800 active:bg-emerald-900",
-
+        "mt-10 h-16 cursor-pointer rounded-full bg-emerald-700 text-lg font-bold text-white transition-colors hover:bg-emerald-800 active:bg-emerald-900",
 
     memberSection: "mt-8 rounded-[28px] border border-zinc-200 p-8",
     memberSectionHeader: "flex items-start justify-between",
     memberSectionTitle: "text-xl font-bold text-zinc-900",
     memberCountText: "mt-1 text-sm text-slate-500",
-    memberInviteButton: "flex items-center gap-1 rounded-full bg-blue-100 px-5 py-2 text-sm font-semibold text-blue-600",
+    memberInviteButton:
+        "flex cursor-pointer items-center gap-1 rounded-full bg-blue-100 px-5 py-2 text-sm font-semibold text-blue-600 transition-colors hover:bg-blue-200 active:bg-blue-300",
     memberList: "mt-8 flex items-start gap-6",
     memberCard: "flex flex-col items-center gap-2",
     memberAvatar: "flex h-16 w-16 items-center justify-center rounded-full bg-slate-200 text-slate-500",
@@ -31,12 +35,14 @@ export const groupDetailPanelStyles = {
     memberRoleBadge: "rounded-full bg-zinc-200 px-3 py-1 text-xs font-semibold text-zinc-700",
 
     memberMoreButton:
-        "flex h-16 w-16 flex-col items-center justify-center rounded-full border border-dashed border-zinc-300 text-xs text-slate-500",
+        "flex h-16 w-16 cursor-pointer flex-col items-center justify-center rounded-full border border-dashed border-zinc-300 text-xs text-slate-500 transition-colors hover:bg-zinc-100 hover:text-slate-700 active:bg-zinc-200",
 
-    inviteCodeSection: "mt-8 flex items-center justify-between rounded-[28px] bg-blue-600 px-8 py-8 text-white",
+    inviteCodeSection:
+        "mt-8 flex items-center justify-between rounded-[28px] bg-blue-600 px-8 py-8 text-white",
     inviteCodeLabel: "text-sm text-blue-100",
     inviteCodeValue: "mt-2 block text-3xl font-bold",
-    copyInviteCodeButton: "flex h-14 w-14 items-center justify-center rounded-full bg-white text-blue-600",
+    copyInviteCodeButton:
+        "flex h-14 w-14 cursor-pointer items-center justify-center rounded-full bg-white text-blue-600 transition-colors hover:bg-blue-50 hover:text-blue-700 active:bg-blue-100",
 
     activitySection: "mt-8 flex-1",
     emptyActivityBox:

--- a/src/ui/styles/groupManagementPageStyles.ts
+++ b/src/ui/styles/groupManagementPageStyles.ts
@@ -7,7 +7,7 @@ export const groupManagementPageStyles = {
     title: "text-4xl font-bold text-zinc-900",
     description: "mt-3 text-lg text-slate-700",
     createButton:
-        "flex items-center gap-2 rounded-full bg-blue-300 px-8 py-3 text-lg font-bold text-zinc-900",
+        "flex cursor-pointer items-center gap-2 rounded-full bg-blue-300 px-8 py-3 text-lg font-bold text-zinc-900 transition-colors hover:bg-blue-400 active:bg-blue-500",
 
     section: "mt-10 shrink-0",
     sectionHeader: "mb-6 flex items-center justify-between",
@@ -17,7 +17,8 @@ export const groupManagementPageStyles = {
     inviteCount:
         "flex h-8 min-w-8 items-center justify-center rounded-full bg-blue-800 px-2 text-sm font-bold text-white",
 
-    viewAllButton: "text-base font-semibold text-slate-700",
+    viewAllButton:
+        "cursor-pointer text-base font-semibold text-slate-700 transition-colors hover:text-slate-900 active:text-slate-950",
 
     inviteList: "grid grid-cols-2 gap-10",
 
@@ -30,10 +31,10 @@ export const groupManagementPageStyles = {
         "flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto pr-2",
 
     groupCard:
-        "flex cursor-pointer items-center justify-between rounded-[32px] bg-[#F4F2F2] px-12 py-7",
+        "flex cursor-pointer items-center justify-between rounded-[32px] bg-[#F4F2F2] px-12 py-7 transition-colors hover:bg-zinc-200 active:bg-zinc-300",
 
     selectedGroupCard:
-        "flex cursor-pointer items-center justify-between rounded-[32px] border-2 border-blue-400 bg-white px-12 py-7 shadow-md",
+        "flex cursor-pointer items-center justify-between rounded-[32px] border-2 border-blue-400 bg-white px-12 py-7 shadow-md transition-colors hover:bg-blue-50 active:bg-blue-100",
 
     groupInfo: "flex flex-col gap-4",
     groupTop: "flex items-center gap-6",
@@ -50,17 +51,13 @@ export const groupManagementPageStyles = {
     groupMeta: "flex items-center gap-8 text-lg text-zinc-700",
 
     arrowButton:
-        "flex h-12 w-12 items-center justify-center rounded-full bg-zinc-300 text-2xl font-bold text-zinc-900",
+        "flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-zinc-300 text-2xl font-bold text-zinc-900 transition-colors hover:bg-zinc-400 active:bg-zinc-500",
 
     emptyGroupBox:
         "flex min-h-0 flex-1 items-center justify-center rounded-[24px] border border-zinc-300 bg-white px-4 text-center text-lg leading-8 text-zinc-500",
 
-    detailLoadingPanel:
-        "h-full w-[540px] shrink-0 overflow-y-auto border-l border-zinc-200 bg-white",
-    detailMessageBox:
-        "p-10 text-sm font-medium text-slate-500",
-    detailErrorBox:
-        "p-10 text-sm font-medium text-red-500",
-    realtimeNotice:
-        "mb-4 rounded-2xl border border-red-200 bg-red-50 px-5 py-4 text-sm font-semibold text-red-700",
+    detailLoadingPanel: "h-full w-[540px] shrink-0 overflow-y-auto border-l border-zinc-200 bg-white",
+    detailMessageBox: "p-10 text-sm font-medium text-slate-500",
+    detailErrorBox: "p-10 text-sm font-medium text-red-500",
+    realtimeNotice: "mb-4 rounded-2xl border border-red-200 bg-red-50 px-5 py-4 text-sm font-semibold text-red-700",
 } as const;

--- a/src/ui/styles/groupRecommendationStatusCardStyles.ts
+++ b/src/ui/styles/groupRecommendationStatusCardStyles.ts
@@ -11,5 +11,5 @@ export const groupRecommendationStatusCardStyles = {
     openProgressFill: "h-full rounded-full bg-emerald-700",
 
     mapButton:
-        "mt-6 h-12 w-full rounded-full bg-sky-500 text-base font-bold text-white transition-colors hover:bg-sky-600 active:bg-sky-700",
+        "mt-6 h-12 w-full cursor-pointer rounded-full bg-sky-500 text-base font-bold text-white transition-colors hover:bg-sky-600 active:bg-sky-700",
 } as const;


### PR DESCRIPTION
## 관련 이슈
Closes #188 
Closes #189 

## 요약
- 무엇을 변경했나요?
  - 그룹 추천 결과 화면 진입 시 세션 상세 조회 API 응답을 기준으로 투표 상태를 복원하도록 수정
  - 그룹 상세 조회 API의 recentlyRecommendation을 반영하도록 도메인 모델 및 DTO 수정
  - 그룹 상세 패널에서 추천 진행 상태 및 최종 추천 결과를 표시하도록 개선
  - 추천 상태에 따라 '그룹 메뉴 추천 시작하기', '투표 현황 확인하기' 등 버튼이 올바르게 표시되도록 수정

- 왜 이 변경이 필요한가요?
  - 그룹 추천 결과 화면을 다시 진입해도 기존 투표 상태 유지
  - 그룹 상세 패널에서 최근 추천 상태와 최종 추천 결과를 사용자에게 정확하게 제공

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
