### PR TITLE
[Feat] 그룹 추천 시작 및 준비 상태 SSE 실시간 반영 기능 구현

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
@@ -1,17 +1,25 @@
 "use client";
 
-import { useState } from "react";
-import { useAtomValue } from "jotai";
+import { useCallback, useRef, useState } from "react";
+import { useSetAtom, useAtomValue } from "jotai";
 import { useParams, useRouter } from "next/navigation";
 
 import PreferenceModal from "@/features/preference/ui/components/PreferenceModal";
 
+import type { GroupRecommendationReadinessUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationReadinessUpdatedEvent";
+
 import { usePreferenceList } from "@/features/preference/application/hooks/usePreferenceList";
 import { hasRequiredPreference } from "@/features/preference/domain/validator/hasRequiredPreference";
-import { memberAtom } from "@/features/auth/application/selectors/authSelectors";
+import {
+    accessTokenAtom,
+    memberAtom,
+} from "@/features/auth/application/selectors/authSelectors";
+import { groupRecommendationReadinessAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationReadinessAtom";
 
 import { useGroupRecommendationReadiness } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationReadiness";
 import { useCompleteGroupRecommendationPreparation } from "@/features/groupRecommendation/application/hooks/useCompleteGroupRecommendationPreparation";
+import { useGroupRealtimeEvents } from "@/features/group/application/hooks/useGroupRealtimeEvents";
+
 import {
     groupRecommendationReadinessAtomValue,
     isGroupRecommendationReadinessLoadingAtom,
@@ -40,7 +48,12 @@ export default function GroupRecommendationPreparationPage() {
     const [isPreferenceModalOpen, setIsPreferenceModalOpen] =
         useState(false);
 
+    const handledReadinessUpdatedEventIds = useRef<Set<string>>(new Set());
+
+    const accessToken = useAtomValue(accessTokenAtom);
     const member = useAtomValue(memberAtom);
+
+    const setReadinessState = useSetAtom(groupRecommendationReadinessAtom);
 
     const { refetchReadiness } = useGroupRecommendationReadiness(
         groupId,
@@ -67,6 +80,59 @@ export default function GroupRecommendationPreparationPage() {
     const hasPreference =
         preferenceState.status === "SUCCESS" &&
         hasRequiredPreference(preferenceState.data);
+
+    const handleRecommendationReadinessUpdated = useCallback(
+        (event: GroupRecommendationReadinessUpdatedEvent) => {
+            if (handledReadinessUpdatedEventIds.current.has(event.eventId)) {
+                return;
+            }
+
+            handledReadinessUpdatedEventIds.current.add(event.eventId);
+
+            if (event.groupId !== groupId ||event.sessionId !== sessionId) {
+                return;
+            }
+
+            setReadinessState((prev) => {
+                if (prev.status !== "SUCCESS") {
+                    return prev;
+                }
+
+                return {
+                    status: "SUCCESS",
+                    data: {
+                        ...prev.data,
+                        status: event.payload.status,
+                        progress: {
+                            totalMemberCount:
+                                event.payload.readinessProgress.totalMemberCount,
+                            readyMemberCount:
+                                event.payload.readinessProgress.readyMemberCount,
+                            allReady:
+                                event.payload.readinessProgress.allReady,
+                        },
+                        members: prev.data.members.map((readinessMember) =>
+                            readinessMember.memberId ===
+                            event.payload.readyMemberId
+                                ? {
+                                      ...readinessMember,
+                                      ready: true,
+                                  }
+                                : readinessMember,
+                        ),
+                    },
+                };
+            });
+        },
+        [groupId, sessionId, setReadinessState],
+    );
+
+    useGroupRealtimeEvents({
+        accessToken,
+        groupId,
+        onRecommendationReadinessUpdated:
+            handleRecommendationReadinessUpdated,
+    });
 
     const handleClickEditPreference = () => {
         setIsPreferenceModalOpen(true);

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomValue } from "jotai";
 import { useRouter } from "next/navigation";
 
@@ -20,6 +20,7 @@ import { useMyRealtimeEvents } from "@/features/group/application/hooks/useMyRea
 import { useStartGroupRecommendation } from "@/features/groupRecommendation/application/hooks/useStartGroupRecommendation";
 import { useGroupRealtimeEvents } from "@/features/group/application/hooks/useGroupRealtimeEvents";
 import type { GroupDeletedEvent } from "@/features/group/infrastructure/sse/dto/GroupDeletedEvent";
+import type { GroupRecommendationStartedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationStartedEvent";
 
 import {
     groupsAtom,
@@ -78,6 +79,8 @@ export default function GroupPage() {
     const [editingLocation, setEditingLocation] = useState<LocationSetting | null>(null);
     const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
     const [realtimeNoticeMessage, setRealtimeNoticeMessage] = useState<string | null>(null);
+
+    const handledRecommendationStartedEventIds = useRef<Set<string>>(new Set());
 
     const accessToken = useAtomValue(accessTokenAtom);
     const member = useAtomValue(memberAtom);
@@ -143,12 +146,46 @@ export default function GroupPage() {
         [member?.id, refetchGroups, selectedGroupId],
     );
 
+    const handleRecommendationStarted = useCallback(
+        async (event: GroupRecommendationStartedEvent) => {
+            if (handledRecommendationStartedEventIds.current.has(event.eventId)) {
+                return;
+            }
+
+            handledRecommendationStartedEventIds.current.add(event.eventId);
+
+            refetchGroups();
+
+            if (selectedGroupId !== event.groupId) {
+                return;
+            }
+
+            await refetchGroupDetail();
+
+            const isStartedByMe = member?.id === event.actorMemberId;
+
+            if (!isStartedByMe) {
+                router.push(
+                    `/group/${event.groupId}/recommendations/${event.sessionId}`,
+                );
+            }
+        },
+        [
+            member?.id,
+            refetchGroupDetail,
+            refetchGroups,
+            router,
+            selectedGroupId,
+        ],
+    );
+
     useGroupRealtimeEvents({
         accessToken,
         groupId: selectedGroupId,
         onMemberJoined: handleMemberJoined,
         onMemberLeft: handleMemberLeft,
         onGroupDeleted: handleGroupDeleted,
+        onRecommendationStarted: handleRecommendationStarted,
     });
 
     // 실시간 그룹 삭제 안내 메시지 3초 후 자동 제거

--- a/src/features/group/application/hooks/useGroupRealtimeEvents.ts
+++ b/src/features/group/application/hooks/useGroupRealtimeEvents.ts
@@ -7,6 +7,7 @@ import { GROUP_REALTIME_EVENT_TYPE } from "@/features/group/domain/model/GroupRe
 
 import type { GroupDeletedEvent } from "@/features/group/infrastructure/sse/dto/GroupDeletedEvent";
 import type { GroupRecommendationStartedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationStartedEvent";
+import type { GroupRecommendationReadinessUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationReadinessUpdatedEvent";
 
 type GroupRealtimeEventSource = {
     readonly readyState: number;
@@ -28,6 +29,7 @@ interface UseGroupRealtimeEventsProps {
     readonly onMemberLeft?: () => void;
     readonly onGroupDeleted?: (event: GroupDeletedEvent) => void;
     readonly onRecommendationStarted?: (event: GroupRecommendationStartedEvent) => void;
+    readonly onRecommendationReadinessUpdated?: (event: GroupRecommendationReadinessUpdatedEvent) => void;
 }
 
 export function useGroupRealtimeEvents({
@@ -37,6 +39,7 @@ export function useGroupRealtimeEvents({
     onMemberLeft,
     onGroupDeleted,
     onRecommendationStarted,
+    onRecommendationReadinessUpdated,
 }: UseGroupRealtimeEventsProps) {
     useEffect(() => {
         if (!accessToken || groupId === null) {
@@ -116,6 +119,24 @@ export function useGroupRealtimeEvents({
             },
         );
 
+        eventSource.addEventListener(
+            GROUP_REALTIME_EVENT_TYPE.GROUP_RECOMMENDATION_READINESS_UPDATED,
+            (event) => {
+                const readinessUpdatedEvent = JSON.parse(
+                    event.data,
+                ) as GroupRecommendationReadinessUpdatedEvent;
+
+                if (process.env.NODE_ENV === "development") {
+                    console.log(
+                        "[GROUP SSE] GROUP_RECOMMENDATION_READINESS_UPDATED",
+                        readinessUpdatedEvent,
+                    );
+                }
+
+                onRecommendationReadinessUpdated?.(readinessUpdatedEvent);
+            },
+        );
+
         eventSource.onerror = () => {
             if (process.env.NODE_ENV === "development") {
                 console.debug("그룹 실시간 이벤트 스트림 연결이 종료되었습니다.");
@@ -134,5 +155,6 @@ export function useGroupRealtimeEvents({
         onMemberLeft,
         onGroupDeleted,
         onRecommendationStarted,
+        onRecommendationReadinessUpdated,
     ]);
 }

--- a/src/features/group/application/hooks/useGroupRealtimeEvents.ts
+++ b/src/features/group/application/hooks/useGroupRealtimeEvents.ts
@@ -4,7 +4,9 @@ import { useEffect } from "react";
 
 import { createGroupRealtimeConnection } from "@/infrastructure/sse/groupRealtimeClient";
 import { GROUP_REALTIME_EVENT_TYPE } from "@/features/group/domain/model/GroupRealtimeEventType";
+
 import type { GroupDeletedEvent } from "@/features/group/infrastructure/sse/dto/GroupDeletedEvent";
+import type { GroupRecommendationStartedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationStartedEvent";
 
 type GroupRealtimeEventSource = {
     readonly readyState: number;
@@ -25,6 +27,7 @@ interface UseGroupRealtimeEventsProps {
     readonly onMemberJoined?: () => void;
     readonly onMemberLeft?: () => void;
     readonly onGroupDeleted?: (event: GroupDeletedEvent) => void;
+    readonly onRecommendationStarted?: (event: GroupRecommendationStartedEvent) => void;
 }
 
 export function useGroupRealtimeEvents({
@@ -33,6 +36,7 @@ export function useGroupRealtimeEvents({
     onMemberJoined,
     onMemberLeft,
     onGroupDeleted,
+    onRecommendationStarted,
 }: UseGroupRealtimeEventsProps) {
     useEffect(() => {
         if (!accessToken || groupId === null) {
@@ -94,6 +98,24 @@ export function useGroupRealtimeEvents({
             },
         );
 
+        eventSource.addEventListener(
+            GROUP_REALTIME_EVENT_TYPE.GROUP_RECOMMENDATION_STARTED,
+            (event) => {
+                const startedEvent = JSON.parse(
+                    event.data,
+                ) as GroupRecommendationStartedEvent;
+
+                if (process.env.NODE_ENV === "development") {
+                    console.log(
+                        "[GROUP SSE] GROUP_RECOMMENDATION_STARTED",
+                        startedEvent,
+                    );
+                }
+
+                onRecommendationStarted?.(startedEvent);
+            },
+        );
+
         eventSource.onerror = () => {
             if (process.env.NODE_ENV === "development") {
                 console.debug("그룹 실시간 이벤트 스트림 연결이 종료되었습니다.");
@@ -111,5 +133,6 @@ export function useGroupRealtimeEvents({
         onMemberJoined,
         onMemberLeft,
         onGroupDeleted,
+        onRecommendationStarted,
     ]);
 }

--- a/src/features/group/infrastructure/sse/dto/GroupRecommendationReadinessUpdatedEvent.ts
+++ b/src/features/group/infrastructure/sse/dto/GroupRecommendationReadinessUpdatedEvent.ts
@@ -1,0 +1,19 @@
+export interface GroupRecommendationReadinessUpdatedEvent {
+    readonly eventId: string;
+    readonly eventType: "GROUP_RECOMMENDATION_READINESS_UPDATED";
+    readonly occurredAt: string;
+    readonly groupId: number;
+    readonly sessionId: number;
+    readonly actorMemberId: number;
+    readonly payload: {
+        readonly sessionId: number;
+        readonly status: "PREPARING";
+        readonly readyMemberId: number;
+        readonly readyMemberNickname: string;
+        readonly readinessProgress: {
+            readonly totalMemberCount: number;
+            readonly readyMemberCount: number;
+            readonly allReady: boolean;
+        };
+    };
+}

--- a/src/features/group/infrastructure/sse/dto/GroupRecommendationStartedEvent.ts
+++ b/src/features/group/infrastructure/sse/dto/GroupRecommendationStartedEvent.ts
@@ -1,0 +1,17 @@
+export interface GroupRecommendationStartedEvent {
+    readonly eventId: string;
+    readonly eventType: "GROUP_RECOMMENDATION_STARTED";
+    readonly occurredAt: string;
+    readonly groupId: number;
+    readonly sessionId: number;
+    readonly actorMemberId: number;
+    readonly payload: {
+        readonly sessionId: number;
+        readonly status: "PREPARING";
+        readonly readinessProgress: {
+            readonly totalMemberCount: number;
+            readonly readyMemberCount: number;
+            readonly allReady: boolean;
+        };
+    };
+}


### PR DESCRIPTION
## 관련 이슈
Closes #191 
Closes #192 

## 요약
- 무엇을 변경했나요?
  - `GROUP_RECOMMENDATION_STARTED` SSE 이벤트를 수신하여 그룹 추천 시작 상태 실시간으로 반영
  - 추천 시작 시 그룹 목록 및 그룹 상세 정보 갱신 및 진행 중인 추천 세션 정보 반영
  - `GROUP_RECOMMENDATION_READINESS_UPDATED` SSE 이벤트를 수신하여 준비 진행률과 멤버 준비 상태를 실시간으로 갱신
  - 중복 이벤트 수신 시 동일한 상태가 반복 반영되지 않도록 중복 처리 방지 로직 추가

- 왜 이 변경이 필요한가요?
  - 그룹 추천 시작 및 준비 완료 상태를 그룹원 모두에게 실시간으로 동기화하여 최신 추천 진행 상태를 제공
  - 준비 진행률과 멤버 준비 상태를 새로고침 없이 최신 상태로 유지

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
