### PR TITLE
[Feat] 그룹 추천 후보 생성 실시간 반영 기능 구현 (#194)

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
@@ -4,9 +4,8 @@ import { useCallback, useRef, useState } from "react";
 import { useSetAtom, useAtomValue } from "jotai";
 import { useParams, useRouter } from "next/navigation";
 
-import PreferenceModal from "@/features/preference/ui/components/PreferenceModal";
-
 import type { GroupRecommendationReadinessUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationReadinessUpdatedEvent";
+import type { GroupRecommendationOpenedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationOpenedEvent";
 
 import { usePreferenceList } from "@/features/preference/application/hooks/usePreferenceList";
 import { hasRequiredPreference } from "@/features/preference/domain/validator/hasRequiredPreference";
@@ -15,6 +14,7 @@ import {
     memberAtom,
 } from "@/features/auth/application/selectors/authSelectors";
 import { groupRecommendationReadinessAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationReadinessAtom";
+import { groupRecommendationSessionDetailAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationSessionDetailAtom";
 
 import { useGroupRecommendationReadiness } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationReadiness";
 import { useCompleteGroupRecommendationPreparation } from "@/features/groupRecommendation/application/hooks/useCompleteGroupRecommendationPreparation";
@@ -26,6 +26,7 @@ import {
     groupRecommendationReadinessErrorMessageAtom,
 } from "@/features/groupRecommendation/application/selectors/groupRecommendationReadinessSelectors";
 
+import PreferenceModal from "@/features/preference/ui/components/PreferenceModal";
 import GroupRecommendationPreparationStatusCard from "@/features/groupRecommendation/ui/components/GroupRecommendationPreparationStatusCard";
 import GroupRecommendationPreparationInfoCard from "@/features/groupRecommendation/ui/components/GroupRecommendationPreparationInfoCard";
 import GroupRecommendationPreparationMemberCard from "@/features/groupRecommendation/ui/components/GroupRecommendationPreparationMemberCard";
@@ -49,11 +50,17 @@ export default function GroupRecommendationPreparationPage() {
         useState(false);
 
     const handledReadinessUpdatedEventIds = useRef<Set<string>>(new Set());
+    const handledRecommendationOpenedEventIds = useRef<Set<string>>(new Set());
+
+    // 방장이 준비 완료 API 응답으로 이미 결과 화면 이동을 예약한 경우,
+    // GROUP_RECOMMENDATION_OPENED SSE에서 중복 router.push가 실행되지 않도록 막는 ref
+    const isMovingToResultPageByAction = useRef(false);
 
     const accessToken = useAtomValue(accessTokenAtom);
     const member = useAtomValue(memberAtom);
 
     const setReadinessState = useSetAtom(groupRecommendationReadinessAtom);
+    const setSessionDetailState = useSetAtom(groupRecommendationSessionDetailAtom);
 
     const { refetchReadiness } = useGroupRecommendationReadiness(
         groupId,
@@ -89,7 +96,7 @@ export default function GroupRecommendationPreparationPage() {
 
             handledReadinessUpdatedEventIds.current.add(event.eventId);
 
-            if (event.groupId !== groupId ||event.sessionId !== sessionId) {
+            if (event.groupId !== groupId || event.sessionId !== sessionId) {
                 return;
             }
 
@@ -127,11 +134,86 @@ export default function GroupRecommendationPreparationPage() {
         [groupId, sessionId, setReadinessState],
     );
 
+    const handleRecommendationOpened = useCallback(
+        (event: GroupRecommendationOpenedEvent) => {
+            if (handledRecommendationOpenedEventIds.current.has(event.eventId)) {
+                return;
+            }
+
+            handledRecommendationOpenedEventIds.current.add(event.eventId);
+
+            if (event.groupId !== groupId || event.sessionId !== sessionId) {
+                return;
+            }
+
+            setReadinessState((prev) => {
+                if (prev.status !== "SUCCESS") {
+                    return prev;
+                }
+
+                return {
+                    status: "SUCCESS",
+                    data: {
+                        ...prev.data,
+                        status: event.payload.status,
+                    },
+                };
+            });
+
+            setSessionDetailState({
+                status: "SUCCESS",
+                data: {
+                    sessionId: event.payload.sessionId,
+                    status: event.payload.status,
+                    readiness: null,
+                    candidates: event.payload.candidates.map(
+                        (candidate, index) => ({
+                            candidateId: candidate.candidateId,
+                            menuId: candidate.menuItemId,
+                            menuName: candidate.menuName,
+                            rankNo: index + 1,
+                            score: 0,
+                            voteCount: 0,
+                        }),
+                    ),
+                    voteProgress: {
+                        totalMemberCount:
+                            event.payload.voteProgress.totalMemberCount,
+                        votedMemberCount:
+                            event.payload.voteProgress.votedMemberCount,
+                        allReady: undefined,
+                    },
+                    memberVotes: [],
+                    finalCandidate: null,
+                    createdAt: event.occurredAt,
+                },
+            });
+
+            // 방장이 completePreparation 응답으로 이미 이동을 예약한 경우에는
+            // SSE 이벤트에서 다시 router.push를 실행하지 않음
+            if (isMovingToResultPageByAction.current) {
+                return;
+            }
+
+            router.push(
+                `/group/${event.groupId}/recommendations/${event.sessionId}/result`,
+            );
+        },
+        [
+            groupId,
+            router,
+            sessionId,
+            setReadinessState,
+            setSessionDetailState,
+        ],
+    );
+
     useGroupRealtimeEvents({
         accessToken,
         groupId,
         onRecommendationReadinessUpdated:
             handleRecommendationReadinessUpdated,
+        onRecommendationOpened: handleRecommendationOpened,
     });
 
     const handleClickEditPreference = () => {
@@ -164,6 +246,10 @@ export default function GroupRecommendationPreparationPage() {
             );
 
             if (result.status === "OPEN") {
+                // 방장은 API 응답 기준으로 결과 화면 이동을 예약하므로,
+                // 이후 도착하는 GROUP_RECOMMENDATION_OPENED SSE에서는 중복 이동하지 않도록 표시
+                isMovingToResultPageByAction.current = true;
+
                 window.setTimeout(() => {
                     moveToResultPage();
                 }, 2500);

--- a/src/features/group/application/hooks/useGroupRealtimeEvents.ts
+++ b/src/features/group/application/hooks/useGroupRealtimeEvents.ts
@@ -8,6 +8,7 @@ import { GROUP_REALTIME_EVENT_TYPE } from "@/features/group/domain/model/GroupRe
 import type { GroupDeletedEvent } from "@/features/group/infrastructure/sse/dto/GroupDeletedEvent";
 import type { GroupRecommendationStartedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationStartedEvent";
 import type { GroupRecommendationReadinessUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationReadinessUpdatedEvent";
+import type { GroupRecommendationOpenedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationOpenedEvent";
 
 type GroupRealtimeEventSource = {
     readonly readyState: number;
@@ -30,6 +31,7 @@ interface UseGroupRealtimeEventsProps {
     readonly onGroupDeleted?: (event: GroupDeletedEvent) => void;
     readonly onRecommendationStarted?: (event: GroupRecommendationStartedEvent) => void;
     readonly onRecommendationReadinessUpdated?: (event: GroupRecommendationReadinessUpdatedEvent) => void;
+    readonly onRecommendationOpened?: (event: GroupRecommendationOpenedEvent) => void;
 }
 
 export function useGroupRealtimeEvents({
@@ -40,6 +42,7 @@ export function useGroupRealtimeEvents({
     onGroupDeleted,
     onRecommendationStarted,
     onRecommendationReadinessUpdated,
+    onRecommendationOpened,
 }: UseGroupRealtimeEventsProps) {
     useEffect(() => {
         if (!accessToken || groupId === null) {
@@ -137,6 +140,24 @@ export function useGroupRealtimeEvents({
             },
         );
 
+        eventSource.addEventListener(
+            GROUP_REALTIME_EVENT_TYPE.GROUP_RECOMMENDATION_OPENED,
+            (event) => {
+                const openedEvent = JSON.parse(
+                    event.data,
+                ) as GroupRecommendationOpenedEvent;
+
+                if (process.env.NODE_ENV === "development") {
+                    console.log(
+                        "[GROUP SSE] GROUP_RECOMMENDATION_OPENED",
+                        openedEvent,
+                    );
+                }
+
+                onRecommendationOpened?.(openedEvent);
+            },
+        );
+
         eventSource.onerror = () => {
             if (process.env.NODE_ENV === "development") {
                 console.debug("그룹 실시간 이벤트 스트림 연결이 종료되었습니다.");
@@ -156,5 +177,6 @@ export function useGroupRealtimeEvents({
         onGroupDeleted,
         onRecommendationStarted,
         onRecommendationReadinessUpdated,
+        onRecommendationOpened,
     ]);
 }

--- a/src/features/group/infrastructure/sse/dto/GroupRecommendationOpenedEvent.ts
+++ b/src/features/group/infrastructure/sse/dto/GroupRecommendationOpenedEvent.ts
@@ -1,0 +1,23 @@
+export interface GroupRecommendationOpenedEvent {
+    readonly eventId: string;
+    readonly eventType: "GROUP_RECOMMENDATION_OPENED";
+    readonly occurredAt: string;
+    readonly groupId: number;
+    readonly sessionId: number;
+    readonly actorMemberId: number | null;
+    readonly payload: {
+        readonly sessionId: number;
+        readonly status: "OPEN";
+        readonly candidates: readonly {
+            readonly candidateId: number;
+            readonly menuItemId: number;
+            readonly menuName: string;
+            readonly reason: string;
+        }[];
+        readonly voteProgress: {
+            readonly totalMemberCount: number;
+            readonly votedMemberCount: number;
+            readonly allVoted: boolean;
+        };
+    };
+}


### PR DESCRIPTION
## 관련 이슈
Closes #194 

## 요약
- 무엇을 변경했나요?
  - `GROUP_RECOMMENDATION_OPENED` SSE 이벤트를 수신하여 후보 메뉴와 투표 진행률을 실시간으로 반영하도록 구현
  - 후보 생성 시 그룹 추천 결과 화면으로 자동 이동하도록 구현
  - 방장의 중복 화면 이동을 방지하도록 처리
  
- 왜 이 변경이 필요한가요?
  - 후보 메뉴 생성 이후 그룹원 모두가 새로고침 없이 동일한 투표 화면을 확인할 수 있도록 하기 위해

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
