### PR TITLE
[Feat] 그룹 추천 투표 진행 상태 실시간 반영 및 방장 전용 투표 완료 알림 구현

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -5,15 +5,18 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 
-import { useGroupDetail } from "@/features/group/application/hooks/useGroupDetail";
-import { useGroupRealtimeEvents } from "@/features/group/application/hooks/useGroupRealtimeEvents";
 import { isGroupOwnerAtom } from "@/features/group/application/selectors/groupDetailSelectors";
-
 import { accessTokenAtom } from "@/features/auth/application/selectors/authSelectors";
 
+import { useMyRealtimeEvents } from "@/features/group/application/hooks/useMyRealtimeEvents";
+import { useGroupRealtimeEvents } from "@/features/group/application/hooks/useGroupRealtimeEvents";
+
 import type { GroupRecommendationVoteUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationVoteUpdatedEvent";
+import type { GroupRecommendationVoteCompletedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationVoteCompletedEvent";
 
 import { groupRecommendationSessionDetailAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationSessionDetailAtom";
+
+import { useGroupDetail } from "@/features/group/application/hooks/useGroupDetail";
 import { useGroupRecommendationSessionDetail } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationSessionDetail";
 import { useVoteGroupRecommendationCandidate } from "@/features/groupRecommendation/application/hooks/useVoteGroupRecommendationCandidate";
 import { useFinalizeGroupRecommendation } from "@/features/groupRecommendation/application/hooks/useFinalizeGroupRecommendation";
@@ -40,6 +43,8 @@ export default function GroupRecommendationResultPage() {
 
     // 중복 VOTE_UPDATED 이벤트 처리 방지용 ref
     const handledVoteUpdatedEventIds = useRef<Set<string>>(new Set());
+    // 전원 투표 완료 이벤트 중복 처리 방지
+    const handledVoteCompletedEventIds = useRef<Set<string>>(new Set());
 
     const setSessionDetailState = useSetAtom(groupRecommendationSessionDetailAtom);
 
@@ -115,10 +120,35 @@ export default function GroupRecommendationResultPage() {
         ],
     );
 
+    const handleRecommendationVoteCompleted = useCallback(
+        async (event: GroupRecommendationVoteCompletedEvent) => {
+            if (handledVoteCompletedEventIds.current.has(event.eventId)) {
+                return;
+            }
+
+            handledVoteCompletedEventIds.current.add(event.eventId);
+
+            if (event.groupId !== groupId || event.sessionId !== sessionId) {
+                return;
+            }
+
+            await refetchSessionDetail({
+                showLoading: false,
+            });
+        },
+        [groupId, refetchSessionDetail, sessionId],
+    );
+
     useGroupRealtimeEvents({
         accessToken,
         groupId,
         onRecommendationVoteUpdated: handleRecommendationVoteUpdated,
+    });
+
+    useMyRealtimeEvents({
+        accessToken,
+        onRecommendationVoteCompleted:
+            handleRecommendationVoteCompleted,
     });
 
     const handleClickBack = () => {

--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { useAtomValue } from "jotai";
+import { useCallback, useRef } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 
 import { useGroupDetail } from "@/features/group/application/hooks/useGroupDetail";
+import { useGroupRealtimeEvents } from "@/features/group/application/hooks/useGroupRealtimeEvents";
 import { isGroupOwnerAtom } from "@/features/group/application/selectors/groupDetailSelectors";
 
+import { accessTokenAtom } from "@/features/auth/application/selectors/authSelectors";
+
+import type { GroupRecommendationVoteUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationVoteUpdatedEvent";
+
+import { groupRecommendationSessionDetailAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationSessionDetailAtom";
 import { useGroupRecommendationSessionDetail } from "@/features/groupRecommendation/application/hooks/useGroupRecommendationSessionDetail";
 import { useVoteGroupRecommendationCandidate } from "@/features/groupRecommendation/application/hooks/useVoteGroupRecommendationCandidate";
 import { useFinalizeGroupRecommendation } from "@/features/groupRecommendation/application/hooks/useFinalizeGroupRecommendation";
@@ -29,8 +36,15 @@ export default function GroupRecommendationResultPage() {
 
     const groupId = Number(params.groupId);
     const sessionId = Number(params.sessionId);
+    const accessToken = useAtomValue(accessTokenAtom);
 
-    useGroupDetail(groupId);
+    // 중복 VOTE_UPDATED 이벤트 처리 방지용 ref
+    const handledVoteUpdatedEventIds = useRef<Set<string>>(new Set());
+
+    const setSessionDetailState = useSetAtom(groupRecommendationSessionDetailAtom);
+
+    const { refetchGroupDetail } = useGroupDetail(groupId);
+
     const isOwner = useAtomValue(isGroupOwnerAtom);
 
     const { refetchSessionDetail } = useGroupRecommendationSessionDetail(groupId, sessionId);
@@ -50,6 +64,62 @@ export default function GroupRecommendationResultPage() {
     const sessionDetail = useAtomValue(groupRecommendationSessionDetailAtomValue);
     const isSessionDetailLoading = useAtomValue(isGroupRecommendationSessionDetailLoadingAtom);
     const sessionDetailErrorMessage = useAtomValue(groupRecommendationSessionDetailErrorMessageAtom);
+
+    // OUP_RECOMMENDATION_VOTE_UPDATED 이벤트 수신 시 투표 진행률 갱신
+    const handleRecommendationVoteUpdated = useCallback(
+        async (event: GroupRecommendationVoteUpdatedEvent) => {
+            if (handledVoteUpdatedEventIds.current.has(event.eventId)) {
+                return;
+            }
+
+            handledVoteUpdatedEventIds.current.add(event.eventId);
+
+            if (event.groupId !== groupId || event.sessionId !== sessionId) {
+                return;
+            }
+
+            setSessionDetailState((prev) => {
+                if (prev.status !== "SUCCESS") {
+                    return prev;
+                }
+
+                return {
+                    status: "SUCCESS",
+                    data: {
+                        ...prev.data,
+                        voteProgress: {
+                            totalMemberCount:
+                                event.payload.voteProgress.totalMemberCount,
+                            votedMemberCount:
+                                event.payload.voteProgress.votedMemberCount,
+                            allReady: undefined,
+                        },
+                    },
+                };
+            });
+
+            //  VOTE_UPDATED 이벤트에는 누가 투표했는지 정보가 없기 때문에
+            // 멤버별 투표 완료 표시를 갱신하려면 세션 상세를 다시 조회해야 함
+            await refetchSessionDetail({
+                showLoading: false,
+            });
+
+            await refetchGroupDetail();
+        },
+        [
+            groupId,
+            refetchGroupDetail,
+            refetchSessionDetail,
+            sessionId,
+            setSessionDetailState,
+        ],
+    );
+
+    useGroupRealtimeEvents({
+        accessToken,
+        groupId,
+        onRecommendationVoteUpdated: handleRecommendationVoteUpdated,
+    });
 
     const handleClickBack = () => {
         router.push(`/group?selectedGroupId=${groupId}`);

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -94,7 +94,7 @@ export default function GroupPage() {
     const isGroupDetailLoading = useAtomValue(isGroupDetailLoadingAtom);
     const groupDetailErrorMessage = useAtomValue(groupDetailErrorMessageAtom);
 
-    useMyRealtimeEvents(accessToken);
+    useMyRealtimeEvents({accessToken});
 
     const { refetchGroups } = useGroupList();
     const { refetchInvites } = useGroupInvites();

--- a/src/features/group/application/hooks/useGroupRealtimeEvents.ts
+++ b/src/features/group/application/hooks/useGroupRealtimeEvents.ts
@@ -9,6 +9,7 @@ import type { GroupDeletedEvent } from "@/features/group/infrastructure/sse/dto/
 import type { GroupRecommendationStartedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationStartedEvent";
 import type { GroupRecommendationReadinessUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationReadinessUpdatedEvent";
 import type { GroupRecommendationOpenedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationOpenedEvent";
+import type { GroupRecommendationVoteUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationVoteUpdatedEvent";
 
 type GroupRealtimeEventSource = {
     readonly readyState: number;
@@ -32,6 +33,7 @@ interface UseGroupRealtimeEventsProps {
     readonly onRecommendationStarted?: (event: GroupRecommendationStartedEvent) => void;
     readonly onRecommendationReadinessUpdated?: (event: GroupRecommendationReadinessUpdatedEvent) => void;
     readonly onRecommendationOpened?: (event: GroupRecommendationOpenedEvent) => void;
+    readonly onRecommendationVoteUpdated?: (event: GroupRecommendationVoteUpdatedEvent) => void;
 }
 
 export function useGroupRealtimeEvents({
@@ -43,6 +45,7 @@ export function useGroupRealtimeEvents({
     onRecommendationStarted,
     onRecommendationReadinessUpdated,
     onRecommendationOpened,
+    onRecommendationVoteUpdated,
 }: UseGroupRealtimeEventsProps) {
     useEffect(() => {
         if (!accessToken || groupId === null) {
@@ -158,6 +161,24 @@ export function useGroupRealtimeEvents({
             },
         );
 
+        eventSource.addEventListener(
+            GROUP_REALTIME_EVENT_TYPE.GROUP_RECOMMENDATION_VOTE_UPDATED,
+            (event) => {
+                const voteUpdatedEvent = JSON.parse(
+                    event.data,
+                ) as GroupRecommendationVoteUpdatedEvent;
+
+                if (process.env.NODE_ENV === "development") {
+                    console.log(
+                        "[GROUP SSE] GROUP_RECOMMENDATION_VOTE_UPDATED",
+                        voteUpdatedEvent,
+                    );
+                }
+
+                onRecommendationVoteUpdated?.(voteUpdatedEvent);
+            },
+        );
+
         eventSource.onerror = () => {
             if (process.env.NODE_ENV === "development") {
                 console.debug("그룹 실시간 이벤트 스트림 연결이 종료되었습니다.");
@@ -178,5 +199,6 @@ export function useGroupRealtimeEvents({
         onRecommendationStarted,
         onRecommendationReadinessUpdated,
         onRecommendationOpened,
+        onRecommendationVoteUpdated,
     ]);
 }

--- a/src/features/group/application/hooks/useMyRealtimeEvents.ts
+++ b/src/features/group/application/hooks/useMyRealtimeEvents.ts
@@ -8,6 +8,7 @@ import { MY_REALTIME_EVENT_TYPE } from "@/features/group/domain/model/MyRealtime
 import { createMyRealtimeConnection } from "@/infrastructure/sse/myRealtimeClient";
 import { mapInviteCreatedEventToModel } from "@/features/group/infrastructure/sse/mapper/myRealtimeEventMapper";
 import type { GroupInviteCreatedEvent } from "@/features/group/infrastructure/sse/dto/GroupInviteCreatedEvent";
+import type { GroupRecommendationVoteCompletedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationVoteCompletedEvent";
 
 type MyRealtimeEventSource = {
     addEventListener: (
@@ -18,7 +19,17 @@ type MyRealtimeEventSource = {
     onerror: ((event: unknown) => void) | null;
 };
 
-export function useMyRealtimeEvents(accessToken: string | null) {
+interface UseMyRealtimeEventsProps {
+    readonly accessToken: string | null;
+    readonly onRecommendationVoteCompleted?: (
+        event: GroupRecommendationVoteCompletedEvent,
+    ) => void;
+}
+
+export function useMyRealtimeEvents({
+    accessToken,
+    onRecommendationVoteCompleted,
+}: UseMyRealtimeEventsProps) {
     const setInviteState = useSetAtom(inviteAtom);
 
     useEffect(() => {
@@ -27,7 +38,9 @@ export function useMyRealtimeEvents(accessToken: string | null) {
         const eventSource = createMyRealtimeConnection(accessToken) as unknown as MyRealtimeEventSource;
 
         eventSource.addEventListener(MY_REALTIME_EVENT_TYPE.CONNECTED, () => {
-            console.log("나의 실시간 이벤트 스트림 연결 완료");
+            if (process.env.NODE_ENV === "development") {
+                console.log("나의 실시간 이벤트 스트림 연결 완료");
+            }
         });
 
         eventSource.addEventListener(MY_REALTIME_EVENT_TYPE.GROUP_INVITE_CREATED, (event) => {
@@ -57,12 +70,36 @@ export function useMyRealtimeEvents(accessToken: string | null) {
             });
         });
 
+        eventSource.addEventListener(
+            MY_REALTIME_EVENT_TYPE.GROUP_RECOMMENDATION_VOTE_COMPLETED,
+            (event) => {
+                const voteCompletedEvent = JSON.parse(
+                    event.data,
+                ) as GroupRecommendationVoteCompletedEvent;
+
+                if (process.env.NODE_ENV === "development") {
+                    console.log(
+                        "[MY SSE] GROUP_RECOMMENDATION_VOTE_COMPLETED",
+                        voteCompletedEvent,
+                    );
+                }
+
+                onRecommendationVoteCompleted?.(voteCompletedEvent);
+            },
+        );
+
         eventSource.onerror = (error) => {
-            console.error("나의 실시간 이벤트 스트림 에러", error);
+            if (process.env.NODE_ENV === "development") {
+                console.error("나의 실시간 이벤트 스트림 에러", error);
+            }
         };
 
         return () => {
             eventSource.close();
         };
-    }, [accessToken, setInviteState]);
+    }, [
+        accessToken,
+        setInviteState,
+        onRecommendationVoteCompleted,
+    ]);
 }

--- a/src/features/group/infrastructure/sse/dto/GroupRecommendationVoteCompletedEvent.ts
+++ b/src/features/group/infrastructure/sse/dto/GroupRecommendationVoteCompletedEvent.ts
@@ -1,0 +1,17 @@
+export interface GroupRecommendationVoteCompletedEvent {
+    readonly eventId: string;
+    readonly eventType: "GROUP_RECOMMENDATION_VOTE_COMPLETED";
+    readonly occurredAt: string;
+    readonly groupId: number;
+    readonly sessionId: number;
+    readonly actorMemberId: null;
+    readonly payload: {
+        readonly sessionId: number;
+        readonly voteProgress: {
+            readonly totalMemberCount: number;
+            readonly votedMemberCount: number;
+            readonly allVoted: boolean;
+        };
+        readonly finalizeRequired: boolean;
+    };
+}

--- a/src/features/group/infrastructure/sse/dto/GroupRecommendationVoteUpdatedEvent.ts
+++ b/src/features/group/infrastructure/sse/dto/GroupRecommendationVoteUpdatedEvent.ts
@@ -1,0 +1,18 @@
+export interface GroupRecommendationVoteUpdatedEvent {
+    readonly eventId: string;
+    readonly eventType: "GROUP_RECOMMENDATION_VOTE_UPDATED";
+    readonly occurredAt: string;
+    readonly groupId: number;
+    readonly sessionId: number;
+    readonly actorMemberId: number | null;
+
+    readonly payload: {
+        readonly sessionId: number;
+
+        readonly voteProgress: {
+            readonly totalMemberCount: number;
+            readonly votedMemberCount: number;
+            readonly allVoted: boolean;
+        };
+    };
+}


### PR DESCRIPTION
## 관련 이슈
Closes #196 
Closes #197 

## 요약
- 무엇을 변경했나요?
  - GROUP_RECOMMENDATION_VOTE_UPDATED 이벤트를 수신하여 그룹 추천 결과 화면과 그룹 상세 패널의 투표 진행률 및 투표 완료 상태가 실시간으로 갱신되도록 구현
  - GROUP_RECOMMENDATION_VOTE_COMPLETED 이벤트를 수신하여 방장이 전원 투표 완료 상태를 실시간으로 확인하고 투표 종료 버튼을 활성화할 수 있도록 구현
 
- 왜 이 변경이 필요한가요?
  - 그룹원들의 투표 진행 상황을 실시간으로 공유하여 모든 참여자가 최신 투표 현황을 확인
  - 모든 그룹원의 투표가 완료되는 즉시 방장이 추가 새로고침 없이 투표를 종료

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
