### PR TITLE
[Feat] 그룹 추천 최종 결과 실시간 반영 기능 구현(#199)

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -13,6 +13,7 @@ import { useGroupRealtimeEvents } from "@/features/group/application/hooks/useGr
 
 import type { GroupRecommendationVoteUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationVoteUpdatedEvent";
 import type { GroupRecommendationVoteCompletedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationVoteCompletedEvent";
+import type { GroupRecommendationFinalizedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationFinalizedEvent";
 
 import { groupRecommendationSessionDetailAtom } from "@/features/groupRecommendation/application/atoms/groupRecommendationSessionDetailAtom";
 
@@ -45,6 +46,7 @@ export default function GroupRecommendationResultPage() {
     const handledVoteUpdatedEventIds = useRef<Set<string>>(new Set());
     // 전원 투표 완료 이벤트 중복 처리 방지
     const handledVoteCompletedEventIds = useRef<Set<string>>(new Set());
+    const handledFinalizedEventIds = useRef<Set<string>>(new Set());
 
     const setSessionDetailState = useSetAtom(groupRecommendationSessionDetailAtom);
 
@@ -139,10 +141,66 @@ export default function GroupRecommendationResultPage() {
         [groupId, refetchSessionDetail, sessionId],
     );
 
+    const handleRecommendationFinalized = useCallback(
+        async (event: GroupRecommendationFinalizedEvent) => {
+            if (handledFinalizedEventIds.current.has(event.eventId)) {
+                return;
+            }
+
+            handledFinalizedEventIds.current.add(event.eventId);
+
+            if (event.groupId !== groupId || event.sessionId !== sessionId) {
+                return;
+            }
+
+            setSessionDetailState((prev) => {
+                if (prev.status !== "SUCCESS") {
+                    return prev;
+                }
+
+                const finalCandidate = prev.data.candidates.find(
+                    (candidate) =>
+                        candidate.candidateId ===
+                        event.payload.finalCandidate.candidateId,
+                );
+
+                return {
+                    status: "SUCCESS",
+                    data: {
+                        ...prev.data,
+                        status: event.payload.status,
+                        finalCandidate:
+                            finalCandidate ??
+                            {
+                                candidateId:
+                                    event.payload.finalCandidate.candidateId,
+                                menuId:
+                                    event.payload.finalCandidate.menuItemId,
+                                menuName:
+                                    event.payload.finalCandidate.menuName,
+                                rankNo: 1,
+                                score: 0,
+                                voteCount: 0,
+                            },
+                    },
+                };
+            });
+
+            await refetchGroupDetail();
+        },
+        [
+            groupId,
+            refetchGroupDetail,
+            sessionId,
+            setSessionDetailState,
+        ],
+    );
+
     useGroupRealtimeEvents({
         accessToken,
         groupId,
         onRecommendationVoteUpdated: handleRecommendationVoteUpdated,
+        onRecommendationFinalized: handleRecommendationFinalized,
     });
 
     useMyRealtimeEvents({

--- a/src/features/group/application/hooks/useGroupRealtimeEvents.ts
+++ b/src/features/group/application/hooks/useGroupRealtimeEvents.ts
@@ -10,6 +10,7 @@ import type { GroupRecommendationStartedEvent } from "@/features/group/infrastru
 import type { GroupRecommendationReadinessUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationReadinessUpdatedEvent";
 import type { GroupRecommendationOpenedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationOpenedEvent";
 import type { GroupRecommendationVoteUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationVoteUpdatedEvent";
+import type { GroupRecommendationFinalizedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationFinalizedEvent";
 
 type GroupRealtimeEventSource = {
     readonly readyState: number;
@@ -34,6 +35,7 @@ interface UseGroupRealtimeEventsProps {
     readonly onRecommendationReadinessUpdated?: (event: GroupRecommendationReadinessUpdatedEvent) => void;
     readonly onRecommendationOpened?: (event: GroupRecommendationOpenedEvent) => void;
     readonly onRecommendationVoteUpdated?: (event: GroupRecommendationVoteUpdatedEvent) => void;
+    readonly onRecommendationFinalized?: (event: GroupRecommendationFinalizedEvent) => void;
 }
 
 export function useGroupRealtimeEvents({
@@ -46,6 +48,7 @@ export function useGroupRealtimeEvents({
     onRecommendationReadinessUpdated,
     onRecommendationOpened,
     onRecommendationVoteUpdated,
+    onRecommendationFinalized,
 }: UseGroupRealtimeEventsProps) {
     useEffect(() => {
         if (!accessToken || groupId === null) {
@@ -179,6 +182,24 @@ export function useGroupRealtimeEvents({
             },
         );
 
+        eventSource.addEventListener(
+            GROUP_REALTIME_EVENT_TYPE.GROUP_RECOMMENDATION_FINALIZED,
+            (event) => {
+                const finalizedEvent = JSON.parse(
+                    event.data,
+                ) as GroupRecommendationFinalizedEvent;
+
+                if (process.env.NODE_ENV === "development") {
+                    console.log(
+                        "[GROUP SSE] GROUP_RECOMMENDATION_FINALIZED",
+                        finalizedEvent,
+                    );
+                }
+
+                onRecommendationFinalized?.(finalizedEvent);
+            },
+        );
+
         eventSource.onerror = () => {
             if (process.env.NODE_ENV === "development") {
                 console.debug("그룹 실시간 이벤트 스트림 연결이 종료되었습니다.");
@@ -200,5 +221,6 @@ export function useGroupRealtimeEvents({
         onRecommendationReadinessUpdated,
         onRecommendationOpened,
         onRecommendationVoteUpdated,
+        onRecommendationFinalized,
     ]);
 }

--- a/src/features/group/infrastructure/sse/dto/GroupRecommendationFinalizedEvent.ts
+++ b/src/features/group/infrastructure/sse/dto/GroupRecommendationFinalizedEvent.ts
@@ -1,0 +1,19 @@
+export interface GroupRecommendationFinalizedEvent {
+    readonly eventId: string;
+    readonly eventType: "GROUP_RECOMMENDATION_FINALIZED";
+    readonly occurredAt: string;
+    readonly groupId: number;
+    readonly sessionId: number;
+    readonly actorMemberId: number;
+    readonly payload: {
+        readonly sessionId: number;
+        readonly status: "FINALIZED";
+        readonly finalizedAt: string;
+        readonly finalCandidate: {
+            readonly candidateId: number;
+            readonly menuItemId: number;
+            readonly menuName: string;
+            readonly reason: string;
+        };
+    };
+}


### PR DESCRIPTION
## 관련 이슈
Closes #199 

## 요약
- 무엇을 변경했나요?
  - GROUP_RECOMMENDATION_FINALIZED 이벤트를 수신하여 그룹 추천 결과 화면과 그룹 상세 패널이 최종 추천 결과를 실시간으로 반영
  - 최종 선정 메뉴 정보를 상태에 반영하고 투표 종료 이후 UI가 '투표 결과 보러가기' 버튼과 최종 추천 결과 상태로 변경
 
- 왜 이 변경이 필요한가요?
  - 방장이 최종 메뉴를 확정하면 모든 그룹원이 새로고침 없이 동일한 최종 추천 결과를 확인할 수 있도록 하기 위함
  - 그룹 추천 결과 화면과 그룹 상세 패널의 상태를 실시간으로 동기화하여 사용자 경험을 개선

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
