### PR TITLE
[Feat] 추천 메뉴 맛집 목록 및 지도 화면 UI 렌더링 (#121)

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft } from "lucide-react";
 
 import { isGroupOwnerAtom } from "@/features/group/application/selectors/groupDetailSelectors";
 import { accessTokenAtom } from "@/features/auth/application/selectors/authSelectors";
+import { groupDetailAtomValue } from "@/features/group/application/selectors/groupDetailSelectors";
 
 import { useMyRealtimeEvents } from "@/features/group/application/hooks/useMyRealtimeEvents";
 import { useGroupRealtimeEvents } from "@/features/group/application/hooks/useGroupRealtimeEvents";
@@ -41,6 +42,7 @@ export default function GroupRecommendationResultPage() {
     const groupId = Number(params.groupId);
     const sessionId = Number(params.sessionId);
     const accessToken = useAtomValue(accessTokenAtom);
+    const groupDetail = useAtomValue(groupDetailAtomValue);
 
     // 중복 VOTE_UPDATED 이벤트 처리 방지용 ref
     const handledVoteUpdatedEventIds = useRef<Set<string>>(new Set());
@@ -232,7 +234,22 @@ export default function GroupRecommendationResultPage() {
     };
 
     const handleClickMoveVoteResult = () => {
-        alert("투표 결과 상세 화면 구현 예정");
+        const finalCandidate = sessionDetail?.finalCandidate;
+
+        if (!finalCandidate || !groupDetail) {
+            alert("최종 추천 메뉴 정보를 불러오는 중입니다.");
+            return;
+        }
+
+        const searchParams = new URLSearchParams({
+            menuName: finalCandidate.menuName,
+            latitude: String(groupDetail.location.latitude),
+            longitude: String(groupDetail.location.longitude),
+            level: "4",
+            source: "group",
+        });
+
+        router.push(`/recommendation-restaurants?${searchParams.toString()}`);
     };
 
     if (isSessionDetailLoading) {

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -395,6 +395,23 @@ export default function GroupPage() {
         });
     };
 
+    const handleOpenRestaurantMap = () => {
+        if (!groupDetail?.recentlyRecommendation?.finalCandidate) {
+            alert("최종 추천 메뉴 정보를 불러오는 중입니다.");
+            return;
+        }
+
+        const searchParams = new URLSearchParams({
+            menuName: groupDetail.recentlyRecommendation.finalCandidate.menuName,
+            latitude: String(groupDetail.location.latitude),
+            longitude: String(groupDetail.location.longitude),
+            level: "4",
+            source: "group",
+        });
+
+        router.push(`/recommendation-restaurants?${searchParams.toString()}`);
+    };
+
     const openDeleteModal = () => {
         setIsDeleteModalOpen(true);
     };
@@ -540,7 +557,7 @@ export default function GroupPage() {
                             onClickLeaveGroup={() => setIsLeaveModalOpen(true)}
                             onClickStartRecommendation={handleStartRecommendation}
                             onClickMoveActiveRecommendation={handleMoveActiveRecommendation}
-                            onClickOpenRestaurantMap={() => alert("기능 준비중입니다.")}
+                            onClickOpenRestaurantMap={handleOpenRestaurantMap}
                         />
                     )}
                 </div>

--- a/src/app/personal-recommendation/result/page.tsx
+++ b/src/app/personal-recommendation/result/page.tsx
@@ -50,6 +50,23 @@ export default function PersonalRecommendationResultPage() {
         await completeSelection(recommendation.requestId, selectedCandidateId);
     };
 
+    // 맛집 보기 버튼 클릭
+    const handleClickRestaurant = (candidateId: number) => {
+        const candidate = recommendation.candidates.find(
+            (item) => item.id === candidateId,
+        );
+
+        if (!candidate) {
+            return;
+        }
+
+        router.push(
+            `/recommendation-restaurants?menuName=${encodeURIComponent(
+                candidate.menuName,
+            )}&source=personal`,
+        );
+    };
+
     return (
         <main className={personalRecommendationResultPageStyles.container}>
             <button
@@ -88,7 +105,11 @@ export default function PersonalRecommendationResultPage() {
                             </span>
                         ))
                     ) : (
-                        <span className={personalRecommendationResultPageStyles.emptyText}>
+                        <span
+                            className={
+                                personalRecommendationResultPageStyles.emptyText
+                            }
+                        >
                             표시할 취향 정보가 없습니다.
                         </span>
                     )}
@@ -105,6 +126,7 @@ export default function PersonalRecommendationResultPage() {
                         selected={selectedCandidateId === candidate.id}
                         disabled={isClosed}
                         onSelect={setSelectedCandidateId}
+                        onClickRestaurant={handleClickRestaurant}
                     />
                 ))}
             </section>

--- a/src/app/recommendation-restaurants/page.tsx
+++ b/src/app/recommendation-restaurants/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from "react";
+
+import RecommendationRestaurantPageContent from "@/features/recommendationRestaurant/ui/components/RecommendationRestaurantPageContent";
+
+export default function RecommendationRestaurantPage() {
+    return (
+        <Suspense>
+            <RecommendationRestaurantPageContent />
+        </Suspense>
+    );
+}

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationResultCard.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationResultCard.tsx
@@ -7,6 +7,7 @@ interface PersonalRecommendationResultCardProps {
     readonly selected: boolean;
     readonly disabled?: boolean;
     readonly onSelect: (candidateId: number) => void;
+    readonly onClickRestaurant: (candidateId: number) => void;
 }
 
 export default function PersonalRecommendationResultCard({
@@ -16,6 +17,7 @@ export default function PersonalRecommendationResultCard({
     selected,
     disabled = false,
     onSelect,
+    onClickRestaurant,
 }: PersonalRecommendationResultCardProps) {
     const handleSelect = () => {
         if (disabled) return;
@@ -51,10 +53,14 @@ export default function PersonalRecommendationResultCard({
 
                 <button
                     type="button"
-                    disabled={disabled}
-                    className={personalRecommendationResultCardStyles.restaurantButton}
+                    className={
+                        personalRecommendationResultCardStyles.restaurantButton
+                    }
                     onClick={(event) => {
+                        // 카드 선택 이벤트가 실행되지 않도록 막음
                         event.stopPropagation();
+
+                        onClickRestaurant(candidateId);
                     }}
                 >
                     맛집 보기

--- a/src/features/recommendationRestaurant/domain/model/RecommendationRestaurant.ts
+++ b/src/features/recommendationRestaurant/domain/model/RecommendationRestaurant.ts
@@ -1,0 +1,8 @@
+export interface RecommendationRestaurant {
+    readonly id: number;
+    readonly name: string;
+    readonly distanceText: string;
+    readonly rating: number | null;
+    readonly latitude: number;
+    readonly longitude: number;
+}

--- a/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantCard.tsx
+++ b/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantCard.tsx
@@ -1,0 +1,35 @@
+import { Star } from "lucide-react";
+
+import type { RecommendationRestaurant } from "@/features/recommendationRestaurant/domain/model/RecommendationRestaurant";
+import { recommendationRestaurantPageStyles } from "@/ui/styles/recommendationRestaurantPageStyles";
+
+interface RecommendationRestaurantCardProps {
+    readonly restaurant: RecommendationRestaurant;
+}
+
+export default function RecommendationRestaurantCard({
+    restaurant,
+}: RecommendationRestaurantCardProps) {
+    return (
+        <article className={recommendationRestaurantPageStyles.restaurantCard}>
+            <div className={recommendationRestaurantPageStyles.restaurantThumbnail} />
+
+            <div className={recommendationRestaurantPageStyles.restaurantInfo}>
+                <h2 className={recommendationRestaurantPageStyles.restaurantName}>
+                    {restaurant.name}
+                </h2>
+
+                <p className={recommendationRestaurantPageStyles.restaurantDistance}>
+                    {restaurant.distanceText}
+                </p>
+            </div>
+
+            {restaurant.rating !== null && (
+                <span className={recommendationRestaurantPageStyles.ratingBadge}>
+                    {restaurant.rating.toFixed(1)}
+                    <Star size={13} fill="currentColor" />
+                </span>
+            )}
+        </article>
+    );
+}

--- a/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantMapPlaceholder.tsx
+++ b/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantMapPlaceholder.tsx
@@ -1,0 +1,43 @@
+import { MapPin } from "lucide-react";
+
+import type { RecommendationRestaurant } from "@/features/recommendationRestaurant/domain/model/RecommendationRestaurant";
+import { recommendationRestaurantPageStyles } from "@/ui/styles/recommendationRestaurantPageStyles";
+
+interface RecommendationRestaurantMapPlaceholderProps {
+    readonly latitude: number;
+    readonly longitude: number;
+    readonly level: number;
+    readonly restaurants: readonly RecommendationRestaurant[];
+}
+
+export default function RecommendationRestaurantMapPlaceholder({
+    latitude,
+    longitude,
+    level,
+    restaurants,
+}: RecommendationRestaurantMapPlaceholderProps) {
+    return (
+        <section className={recommendationRestaurantPageStyles.mapArea}>
+            <div className={recommendationRestaurantPageStyles.mapInfoBox}>
+                <strong>지도 영역</strong>
+                <span>
+                    기준 위치: {latitude}, {longitude}
+                </span>
+                <span>level: {level}</span>
+            </div>
+
+            {restaurants.map((restaurant, index) => (
+                <span
+                    key={restaurant.id}
+                    className={recommendationRestaurantPageStyles.mockMarker}
+                    style={{
+                        left: `${35 + index * 8}%`,
+                        top: `${35 + (index % 3) * 10}%`,
+                    }}
+                >
+                    <MapPin size={34} fill="currentColor" />
+                </span>
+            ))}
+        </section>
+    );
+}

--- a/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantPageContent.tsx
+++ b/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantPageContent.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import RecommendationRestaurantCard from "@/features/recommendationRestaurant/ui/components/RecommendationRestaurantCard";
+import RecommendationRestaurantMapPlaceholder from "@/features/recommendationRestaurant/ui/components/RecommendationRestaurantMapPlaceholder";
+import { mockRecommendationRestaurants } from "@/features/recommendationRestaurant/ui/mock/mockRecommendationRestaurants";
+
+import { recommendationRestaurantPageStyles } from "@/ui/styles/recommendationRestaurantPageStyles";
+
+export default function RecommendationRestaurantPageContent() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+
+    const menuName = searchParams.get("menuName") ?? "추천 메뉴";
+    const latitude = Number(searchParams.get("latitude") ?? 37.4979);
+    const longitude = Number(searchParams.get("longitude") ?? 127.0276);
+    const level = Number(searchParams.get("level") ?? 4);
+
+    const source = searchParams.get("source") ?? "personal";
+    const isGroupRecommendation = source === "group";
+
+    return (
+        <main className={recommendationRestaurantPageStyles.container}>
+            <section className={recommendationRestaurantPageStyles.listSection}>
+                <button
+                    type="button"
+                    onClick={() => router.back()}
+                    className={recommendationRestaurantPageStyles.backButton}
+                >
+                    <ArrowLeft size={26} />
+                </button>
+
+                <div className={recommendationRestaurantPageStyles.titleSection}>
+                    <h1 className={recommendationRestaurantPageStyles.title}>
+                        {isGroupRecommendation
+                            ? "투표 결과"
+                            : `${menuName} 맛집`}
+                    </h1>
+
+                    {isGroupRecommendation && (
+                        <p className={recommendationRestaurantPageStyles.selectedMenuText}>
+                            선정 메뉴: {menuName}
+                        </p>
+                    )}
+                </div>
+
+                <div className={recommendationRestaurantPageStyles.restaurantList}>
+                    {mockRecommendationRestaurants.map((restaurant) => (
+                        <RecommendationRestaurantCard
+                            key={restaurant.id}
+                            restaurant={restaurant}
+                        />
+                    ))}
+                </div>
+            </section>
+
+            <RecommendationRestaurantMapPlaceholder
+                latitude={latitude}
+                longitude={longitude}
+                level={level}
+                restaurants={mockRecommendationRestaurants}
+            />
+        </main>
+    );
+}

--- a/src/features/recommendationRestaurant/ui/mock/mockRecommendationRestaurants.ts
+++ b/src/features/recommendationRestaurant/ui/mock/mockRecommendationRestaurants.ts
@@ -1,0 +1,36 @@
+import type { RecommendationRestaurant } from "@/features/recommendationRestaurant/domain/model/RecommendationRestaurant";
+
+export const mockRecommendationRestaurants: readonly RecommendationRestaurant[] = [
+    {
+        id: 1,
+        name: "BBQ 강남역점",
+        distanceText: "800m",
+        rating: 4.3,
+        latitude: 37.4979,
+        longitude: 127.0276,
+    },
+    {
+        id: 2,
+        name: "교촌 치킨 강남역점",
+        distanceText: "90m",
+        rating: 4.1,
+        latitude: 37.4984,
+        longitude: 127.0282,
+    },
+    {
+        id: 3,
+        name: "BHC 강남 n 타워점",
+        distanceText: "650m",
+        rating: 4.0,
+        latitude: 37.4968,
+        longitude: 127.0292,
+    },
+    {
+        id: 4,
+        name: "도른계 강남역점",
+        distanceText: "300m",
+        rating: null,
+        latitude: 37.4958,
+        longitude: 127.0279,
+    },
+];

--- a/src/ui/styles/recommendationRestaurantPageStyles.ts
+++ b/src/ui/styles/recommendationRestaurantPageStyles.ts
@@ -1,0 +1,28 @@
+export const recommendationRestaurantPageStyles = {
+    container: "flex h-screen overflow-hidden bg-white",
+
+    listSection: "flex w-[520px] shrink-0 flex-col overflow-y-auto bg-[#FAF9F9] px-14 py-10",
+
+    backButton:
+        "mb-10 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full text-zinc-800 transition-colors hover:bg-zinc-100 active:bg-zinc-200",
+
+    titleSection: "mb-12",
+    title: "text-4xl font-bold text-zinc-900",
+
+    selectedMenuText: "mt-3 text-lg font-semibold text-orange-500",
+
+    restaurantList: "flex flex-col gap-5 pb-10",
+    restaurantCard: "flex items-center gap-5 rounded-[28px] bg-white px-6 py-5 shadow-sm",
+    restaurantThumbnail: "h-14 w-14 shrink-0 rounded-xl bg-zinc-200",
+    restaurantInfo: "min-w-0 flex-1",
+    restaurantName: "truncate text-base font-bold text-zinc-900",
+    restaurantDistance: "mt-1 text-sm font-medium text-zinc-500",
+
+    ratingBadge:
+        "flex shrink-0 items-center gap-1 rounded-full bg-amber-200 px-3 py-1 text-sm font-bold text-zinc-900",
+
+    mapArea: "relative min-w-0 flex-1 overflow-hidden bg-[#E9E7E2]",
+    mapInfoBox:
+        "absolute left-8 top-8 z-10 flex flex-col gap-1 rounded-2xl bg-white/90 px-5 py-4 text-sm font-semibold text-zinc-700 shadow-md",
+    mockMarker: "absolute z-10 -translate-x-1/2 -translate-y-1/2 text-red-500",
+} as const;


### PR DESCRIPTION
## 관련 이슈
Closes #121 

## 요약
- 무엇을 변경했나요?
  - 추천 메뉴 맛집 목록 및 지도 화면 UI 렌더링
  - 개인 추천 결과와 그룹 추천 결과에서 맛집 화면으로 이동할 수 있도록 연결
  - 그룹 상세 패널의 '맛집 지도 보러가기' 버튼을 맛집 화면으로 이동하도록 수정

- 왜 이 변경이 필요한가요?
  - 추천된 메뉴를 판매하는 주변 맛집을 확인할 수 있는 화면과 이동 경로를 제공하기 위함
 
## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
