### PR TITLE
[Feat] 메뉴 추천 결과 화면의 메뉴 카드 썸네일 이미지 표시 기능 구현 (#207)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+    images: {
+        remotePatterns: [
+            {
+                protocol: "https",
+                hostname: "asset.matchuri.com",
+            },
+        ],
+    },
 };
 
 export default nextConfig;

--- a/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
@@ -174,6 +174,7 @@ export default function GroupRecommendationPreparationPage() {
                             rankNo: index + 1,
                             score: 0,
                             voteCount: 0,
+                            thumbnailUrl: candidate.thumbnailUrl ?? null,
                         }),
                     ),
                     voteProgress: {

--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -183,6 +183,8 @@ export default function GroupRecommendationResultPage() {
                                 rankNo: 1,
                                 score: 0,
                                 voteCount: 0,
+                                thumbnailUrl:
+                                    event.payload.finalCandidate.thumbnailUrl ?? null,
                             },
                     },
                 };
@@ -346,6 +348,7 @@ export default function GroupRecommendationResultPage() {
                             key={candidate.candidateId}
                             menuName={candidate.menuName}
                             matchPercent={Math.round(candidate.score)}
+                            thumbnailUrl={candidate.thumbnailUrl}
                             selected={candidate.selected}
                             isVoteClosed={isFinalized}
                             isVoting={isVoting}

--- a/src/app/personal-recommendation/result/page.tsx
+++ b/src/app/personal-recommendation/result/page.tsx
@@ -145,6 +145,7 @@ export default function PersonalRecommendationResultPage() {
                         candidateId={candidate.id}
                         menuName={candidate.menuName}
                         score={candidate.score}
+                        thumbnailUrl={candidate.thumbnailUrl}
                         selected={selectedCandidateId === candidate.id}
                         disabled={isClosed}
                         onSelect={setSelectedCandidateId}

--- a/src/features/group/infrastructure/sse/dto/GroupRecommendationFinalizedEvent.ts
+++ b/src/features/group/infrastructure/sse/dto/GroupRecommendationFinalizedEvent.ts
@@ -13,6 +13,7 @@ export interface GroupRecommendationFinalizedEvent {
             readonly candidateId: number;
             readonly menuItemId: number;
             readonly menuName: string;
+            readonly thumbnailUrl: string | null;
             readonly reason: string;
         };
     };

--- a/src/features/group/infrastructure/sse/dto/GroupRecommendationOpenedEvent.ts
+++ b/src/features/group/infrastructure/sse/dto/GroupRecommendationOpenedEvent.ts
@@ -12,6 +12,7 @@ export interface GroupRecommendationOpenedEvent {
             readonly candidateId: number;
             readonly menuItemId: number;
             readonly menuName: string;
+            readonly thumbnailUrl: string | null;
             readonly reason: string;
         }[];
         readonly voteProgress: {

--- a/src/features/groupRecommendation/domain/model/GroupRecommendationSessionDetail.ts
+++ b/src/features/groupRecommendation/domain/model/GroupRecommendationSessionDetail.ts
@@ -10,6 +10,7 @@ export interface GroupRecommendationSessionCandidate {
     readonly rankNo: number;
     readonly score: number;
     readonly voteCount: number;
+    readonly thumbnailUrl: string | null;
 }
 
 export interface GroupRecommendationSessionProgress {

--- a/src/features/groupRecommendation/infrastructure/api/dto/CompleteGroupRecommendationPreparationResponse.ts
+++ b/src/features/groupRecommendation/infrastructure/api/dto/CompleteGroupRecommendationPreparationResponse.ts
@@ -16,6 +16,7 @@ export interface CompleteGroupRecommendationPreparationResponse {
             readonly rankNo: number;
             readonly score: number;
             readonly voteCount: number;
+            readonly thumbnailUrl: string | null;
         }[];
     };
 

--- a/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationSessionDetailResponse.ts
+++ b/src/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationSessionDetailResponse.ts
@@ -16,6 +16,7 @@ export interface GroupRecommendationSessionDetailResponse {
             readonly rankNo: number;
             readonly score: number;
             readonly voteCount: number;
+            readonly thumbnailUrl: string | null;
         }[];
         readonly voteProgress: {
             readonly totalMemberCount: number;
@@ -28,6 +29,7 @@ export interface GroupRecommendationSessionDetailResponse {
             readonly rankNo: number;
             readonly score: number;
             readonly voteCount: number;
+            readonly thumbnailUrl: string | null;
         } | null;
         readonly memberVotes: readonly {
             readonly memberId: number;

--- a/src/features/groupRecommendation/ui/components/GroupRecommendationResultCandidateCard.tsx
+++ b/src/features/groupRecommendation/ui/components/GroupRecommendationResultCandidateCard.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 import { groupRecommendationResultPageStyles } from "@/ui/styles/groupRecommendationResultPageStyles";
 
 interface GroupRecommendationResultCandidateCardProps {
@@ -5,9 +7,9 @@ interface GroupRecommendationResultCandidateCardProps {
     readonly matchPercent: number;
     readonly selected: boolean;
     readonly isVoteClosed: boolean;
-
     // 투표 API 요청 중인지 여부
     readonly isVoting: boolean;
+    readonly thumbnailUrl: string | null;
 
     readonly onClickVote: () => void;
 }
@@ -18,6 +20,7 @@ export default function GroupRecommendationResultCandidateCard({
     selected,
     isVoteClosed,
     isVoting,
+    thumbnailUrl,
     onClickVote,
 }: GroupRecommendationResultCandidateCardProps) {
     const isVoteButtonDisabled = isVoteClosed || isVoting;
@@ -31,6 +34,20 @@ export default function GroupRecommendationResultCandidateCard({
             }
         >
             <div className={groupRecommendationResultPageStyles.candidateImagePlaceholder}>
+                {thumbnailUrl ? (
+                    <Image
+                        src={thumbnailUrl}
+                        alt={`${menuName} 이미지`}
+                        fill
+                        sizes="(max-width: 768px) 100vw, 33vw"
+                        className={groupRecommendationResultPageStyles.candidateImage}
+                    />
+                ) : (
+                    <span className={groupRecommendationResultPageStyles.candidateImageFallbackText}>
+                        이미지 준비중입니다
+                    </span>
+                )}
+
                 <span className={groupRecommendationResultPageStyles.matchBadge}>
                     {matchPercent}% Match
                 </span>

--- a/src/features/personalRecommendation/domain/model/PersonalRecommendation.ts
+++ b/src/features/personalRecommendation/domain/model/PersonalRecommendation.ts
@@ -4,6 +4,7 @@ export interface RecommendedMenu {
     readonly menuName: string;
     readonly rankNo: number;
     readonly score: number;
+    readonly thumbnailUrl: string | null;
 }
 
 export interface PersonalRecommendation {

--- a/src/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse.ts
+++ b/src/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse.ts
@@ -4,6 +4,7 @@ export interface PersonalRecommendationCandidateResponse {
     readonly menuName: string;
     readonly rankNo: number;
     readonly score: number;
+    readonly thumbnailUrl: string | null;
 }
 
 export interface CreatePersonalRecommendationData {

--- a/src/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse.ts
+++ b/src/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse.ts
@@ -4,6 +4,7 @@ export interface PersonalRecommendationDetailCandidateResponse {
     readonly menuName: string;
     readonly rankNo: number;
     readonly score: number;
+    readonly thumbnailUrl: string | null;
 }
 
 export interface PersonalRecommendationDetailData {

--- a/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationDetailMapper.ts
+++ b/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationDetailMapper.ts
@@ -16,6 +16,7 @@ export function mapPersonalRecommendationDetail(
             menuName: candidate.menuName,
             rankNo: candidate.rankNo,
             score: candidate.score,
+            thumbnailUrl: candidate.thumbnailUrl,
         })),
     };
 }

--- a/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationMapper.ts
+++ b/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationMapper.ts
@@ -19,6 +19,7 @@ export function mapPersonalRecommendation(
             menuName: candidate.menuName,
             rankNo: candidate.rankNo,
             score: candidate.score,
+            thumbnailUrl: candidate.thumbnailUrl,
         })),
     };
 }

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationResultCard.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationResultCard.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 import { personalRecommendationResultCardStyles } from "@/ui/styles/personalRecommendationResultCardStyles";
 
 interface PersonalRecommendationResultCardProps {
@@ -6,6 +8,7 @@ interface PersonalRecommendationResultCardProps {
     readonly score: number;
     readonly selected: boolean;
     readonly disabled?: boolean;
+    readonly thumbnailUrl: string | null;
     readonly onSelect: (candidateId: number) => void;
     readonly onClickRestaurant: (candidateId: number) => void;
 }
@@ -16,6 +19,7 @@ export default function PersonalRecommendationResultCard({
     score,
     selected,
     disabled = false,
+    thumbnailUrl,
     onSelect,
     onClickRestaurant,
 }: PersonalRecommendationResultCardProps) {
@@ -35,6 +39,20 @@ export default function PersonalRecommendationResultCard({
             }
         >
             <div className={personalRecommendationResultCardStyles.imagePlaceholder}>
+                {thumbnailUrl ? (
+                    <Image
+                        src={thumbnailUrl}
+                        alt={`${menuName} 이미지`}
+                        fill
+                        sizes="(max-width: 768px) 100vw, 33vw"
+                        className={personalRecommendationResultCardStyles.menuImage}
+                    />
+                ) : (
+                    <span className={personalRecommendationResultCardStyles.imageFallbackText}>
+                        이미지 준비중입니다
+                    </span>
+                )}
+
                 <span className={personalRecommendationResultCardStyles.matchBadge}>
                     {Math.round(score)}% Match
                 </span>
@@ -53,13 +71,9 @@ export default function PersonalRecommendationResultCard({
 
                 <button
                     type="button"
-                    className={
-                        personalRecommendationResultCardStyles.restaurantButton
-                    }
+                    className={personalRecommendationResultCardStyles.restaurantButton}
                     onClick={(event) => {
-                        // 카드 선택 이벤트가 실행되지 않도록 막음
                         event.stopPropagation();
-
                         onClickRestaurant(candidateId);
                     }}
                 >

--- a/src/ui/styles/groupRecommendationResultPageStyles.ts
+++ b/src/ui/styles/groupRecommendationResultPageStyles.ts
@@ -45,4 +45,6 @@ export const groupRecommendationResultPageStyles = {
         "mt-5 h-14 w-full rounded-full bg-slate-100 text-lg font-semibold text-zinc-900 transition-colors hover:bg-blue-200 hover:text-blue-700 active:bg-blue-200",
     disabledVoteButton:
         "mt-5 h-14 w-full cursor-not-allowed rounded-full bg-zinc-300 text-lg font-semibold text-zinc-500",
+    candidateImage: "h-full w-full object-cover",
+    candidateImageFallbackText: "text-sm font-semibold text-zinc-400",
 } as const;

--- a/src/ui/styles/personalRecommendationResultCardStyles.ts
+++ b/src/ui/styles/personalRecommendationResultCardStyles.ts
@@ -1,18 +1,20 @@
 export const personalRecommendationResultCardStyles = {
-    card:
-        "overflow-hidden rounded-3xl bg-white shadow-md transition hover:-translate-y-1 hover:shadow-lg",
+    card: "overflow-hidden rounded-3xl cursor-pointer bg-white shadow-md transition hover:-translate-y-1 hover:shadow-lg",
     selectedCard:
         "overflow-hidden rounded-3xl bg-white shadow-md ring-4 ring-blue-400 transition hover:-translate-y-1 hover:shadow-lg",
     imagePlaceholder:
-        "relative flex h-[260px] items-center justify-center bg-zinc-200",
+        "relative flex h-56 items-center justify-center overflow-hidden bg-zinc-100",
+
     matchBadge:
-        "absolute left-5 top-5 rounded-full bg-orange-700 px-5 py-2 text-sm font-semibold text-white",
+        "absolute left-4 top-4 rounded-full bg-white/90 px-4 py-2 text-sm font-bold text-blue-600",
     selectedBadge:
-        "absolute right-5 top-5 rounded-full bg-blue-500 px-5 py-2 text-sm font-semibold text-white",
-    content:
-        "flex flex-col gap-5 px-7 py-7",
-    menuName:
-        "text-lg font-semibold text-zinc-900",
+        "absolute right-4 top-4 rounded-full bg-blue-500 px-4 py-2 text-sm font-bold text-white",
+
+    menuImage: "object-cover",
+    imageFallbackText: "text-sm font-semibold text-zinc-400",
+
+    content: "px-7 py-6",
+    menuName: "text-2xl font-bold text-zinc-950",
     restaurantButton:
-        "h-14 rounded-full bg-green-200 text-base font-semibold text-zinc-900 transition hover:bg-green-300",
+        "mt-6 h-14 rounded-full cursor-pointer bg-zinc-950 px-8 text-base font-bold text-white transition hover:bg-zinc-800",
 } as const;

--- a/src/ui/styles/personalRecommendationResultPageStyles.ts
+++ b/src/ui/styles/personalRecommendationResultPageStyles.ts
@@ -2,7 +2,7 @@ export const personalRecommendationResultPageStyles = {
     container:
         "min-h-screen bg-[#fbf9f9] px-12 py-10",
     backButton:
-        "flex h-10 w-10 items-center justify-center rounded-full text-zinc-800 transition hover:bg-zinc-100",
+        "flex h-10 w-10 items-center cursor-pointer justify-center rounded-full text-zinc-800 transition hover:bg-zinc-100",
     title:
         "mt-8 text-4xl font-semibold text-zinc-950",
     closedMessage:


### PR DESCRIPTION
## 관련 이슈
Closes #207 

## 요약
- 무엇을 변경했나요?
  - 개인/그룹 메뉴 추천 결과 카드에 메뉴 썸네일 이미지 표시 기능 추가
  - 추천 후보 DTO 및 도메인 모델에 `thumbnailUrl` 필드를 반영 
  - 이미지가 없는 경우 대체 문구를 표시하도록 구현

- 왜 이 변경이 필요한가요?
  - 추천 메뉴를 이미지와 함께 제공하여 결과 화면의 가독성과 사용자 경험을 개선하기 위해 변경
 
## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
