### PR TITLE
[Chore] 미사용 Geist 폰트 preload 제거 및 Noto Sans 적용 (MC-24)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,25 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+    --background: #ffffff;
+    --foreground: #171717;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+    --color-background: var(--background);
+    --color-foreground: var(--foreground);
+    --font-sans: var(--font-noto-sans);
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+    :root {
+        --background: #0a0a0a;
+        --foreground: #ededed;
+    }
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+    background: var(--background);
+    color: var(--foreground);
+    font-family: var(--font-noto-sans), Arial, Helvetica, sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,36 +1,31 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Noto_Sans } from "next/font/google";
+
 import "./globals.css";
 import AppLayout from "@/ui/layout/AppLayout";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+const notoSans = Noto_Sans({
+    variable: "--font-noto-sans",
+    subsets: ["latin"],
+    weight: ["400", "500", "600", "700"],
+    display: "swap",
 });
 
 export const metadata: Metadata = {
-  title: "matchuri-frontend",
-  description: "matchuri-frontend",
+    title: "matchuri-frontend",
+    description: "matchuri-frontend",
 };
 
 export default function RootLayout({
-  children,
+    children,
 }: Readonly<{
-  children: React.ReactNode;
+    children: React.ReactNode;
 }>) {
-  return (
-    <html
-      lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
-    >
-      <body className="min-h-full flex flex-col">
-        <AppLayout>{children}</AppLayout>
-      </body>
-    </html>
-  );
+    return (
+        <html lang="ko" className={`${notoSans.variable} h-full antialiased`}>
+            <body className="min-h-full flex flex-col">
+                <AppLayout>{children}</AppLayout>
+            </body>
+        </html>
+    );
 }


### PR DESCRIPTION
## 관련 이슈
노션 백로그 FE-13 참고

## 요약
- 무엇을 변경했나요?
  - 미사용 Geist 폰트 설정을 제거하고 프로젝트 전역 폰트를 Noto Sans로 적용
 
- 왜 이 변경이 필요한가요?
  - 사용하지 않는 폰트 preload로 발생하는 브라우저 성능 경고를 제거하고, 프로젝트의 전역 폰트 설정을 일관되게 관리

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
