### PR TITLE
[Fix] 초기 페이지 렌더링 시 화면 깜빡임 개선(MC-11)

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -16,7 +16,13 @@ export default function HomePage() {
     const member = useAtomValue(memberAtom);
 
     if (!canAccess) {
-        return null;
+        return (
+            <main className={homeMemberPageStyles.container}>
+                <div className={homeMemberPageStyles.content}>
+                    <p>화면을 준비하는 중...</p>
+                </div>
+            </main>
+        );
     }
 
     const nickname = member?.nickname ?? "사용자";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ const notoSans = Noto_Sans({
     subsets: ["latin"],
     weight: ["400", "500", "600", "700"],
     display: "swap",
+    preload: false,
 });
 
 export const metadata: Metadata = {

--- a/src/app/recommendation-restaurants/page.tsx
+++ b/src/app/recommendation-restaurants/page.tsx
@@ -4,7 +4,7 @@ import RecommendationRestaurantPageContent from "@/features/recommendationRestau
 
 export default function RecommendationRestaurantPage() {
     return (
-        <Suspense>
+        <Suspense fallback={<main className="min-h-screen bg-[#EEF7FC] px-16 py-12">맛집 정보를 불러오는 중입니다.</main>}>
             <RecommendationRestaurantPageContent />
         </Suspense>
     );

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -17,31 +17,9 @@ export default function SettingsPage() {
     const settingsState = useAtomValue(settingsAtom);
     const isLocalLogin = useAtomValue(isLocalLoginAtom);
 
-    if (isAuthLoading || !canAccess) {
-        return (
-            <main className={settingsPageStyles.page}>
-                로그인 상태를 확인하는 중...
-            </main>
-        );
-    }
-
-    if (settingsState.status === "LOADING") {
-        return (
-            <main className={settingsPageStyles.page}>
-                설정 정보를 불러오는 중...
-            </main>
-        );
-    }
-
-    if (settingsState.status === "ERROR") {
-        return (
-            <main className={settingsPageStyles.page}>
-                {settingsState.message}
-            </main>
-        );
-    }
-
-    const profile = settingsState.data;
+    const profile = "data" in settingsState ? settingsState.data : null;
+    const isLoading = isAuthLoading || !canAccess || settingsState.status === "LOADING" || !profile;
+    const isError = settingsState.status === "ERROR" && !profile;
 
     return (
         <main className={settingsPageStyles.page}>
@@ -50,13 +28,26 @@ export default function SettingsPage() {
                 프로필 정보 및 계정 보안 설정을 관리하세요.
             </p>
 
-            <ProfileManagementSection nickname={profile.nickname} />
+            {isError ? (
+                <section className={settingsPageStyles.section}>
+                    <p className="text-sm text-red-500">{settingsState.message}</p>
+                </section>
+            ) : (
+                <>
+                    <ProfileManagementSection
+                        key={profile?.id ?? "profile-loading"}
+                        nickname={profile?.nickname ?? ""}
+                        isLoading={isLoading}
+                    />
 
-            <AccountManagementSection
-                userId={profile.id}
-                email={profile.email}
-                showPasswordFields={isLocalLogin}
-            />
+                    <AccountManagementSection
+                        userId={profile?.id}
+                        email={profile?.email}
+                        showPasswordFields={profile ? isLocalLogin : false}
+                        isLoading={isLoading}
+                    />
+                </>
+            )}
         </main>
     );
 }

--- a/src/features/auth/application/hooks/useAuthInit.ts
+++ b/src/features/auth/application/hooks/useAuthInit.ts
@@ -1,19 +1,26 @@
 "use client";
 
 import { useEffect } from "react";
+
+import { authAtom } from "@/features/auth/application/atom/authAtom";
 import { authApi } from "@/features/auth/infrastructure/api/authApi";
 import {
     clearAuth,
     setAuthenticated,
     setAuthLoading,
 } from "@/features/auth/application/store/authStore";
+import { jotaiStore } from "@/shared/lib/jotaiStore";
 
 export function useAuthInit() {
     useEffect(() => {
         let cancelled = false;
 
         const init = async () => {
-            setAuthLoading();
+            const currentAuth = jotaiStore.get(authAtom);
+
+            if (currentAuth.status !== "AUTHENTICATED") {
+                setAuthLoading();
+            }
 
             try {
                 const response = await authApi.refresh();

--- a/src/features/routeGuard/application/hooks/useAuthGuard.ts
+++ b/src/features/routeGuard/application/hooks/useAuthGuard.ts
@@ -18,29 +18,28 @@ export function useAuthGuard(redirectPath: string = "/login") {
     const isOnboardingReady = useAtomValue(isOnboardingReadyAtom);
 
     useEffect(() => {
-        // 아직 인증 상태 확인 중이면 아무것도 안 함
         if (isAuthLoading) return;
 
-        // 로그인 안 되어 있으면 리다이렉트
         if (!isAuthenticated) {
             router.replace(redirectPath);
+            return;
         }
 
         if (!isOnboardingReady) {
-          router.replace(redirectPath);
+            router.replace(redirectPath);
         }
     }, [
         isAuthLoading,
         isAuthenticated,
         isOnboardingReady,
         router,
-        redirectPath
+        redirectPath,
     ]);
 
     return {
         isAuthenticated,
         isAuthLoading,
         isOnboardingReady,
-        canAccess: isAuthenticated && isOnboardingReady,
+        canAccess: !isAuthLoading && isAuthenticated && isOnboardingReady,
     };
 }

--- a/src/features/settings/application/atoms/settingsAtom.ts
+++ b/src/features/settings/application/atoms/settingsAtom.ts
@@ -2,5 +2,5 @@ import { atom } from "jotai";
 import type { SettingsState } from "@/features/settings/domain/state/SettingsState";
 
 export const settingsAtom = atom<SettingsState>({
-    status: "LOADING",
+    status: "IDLE",
 });

--- a/src/features/settings/application/hooks/useSettingsProfile.ts
+++ b/src/features/settings/application/hooks/useSettingsProfile.ts
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { useSetAtom } from "jotai";
+
 import { settingsAtom } from "@/features/settings/application/atoms/settingsAtom";
 import { fetchSettingsProfile } from "@/features/settings/infrastructure/api/settingsApi";
 
@@ -11,27 +12,41 @@ export function useSettingsProfile(enabled: boolean) {
     useEffect(() => {
         if (!enabled) return;
 
+        let cancelled = false;
+
         async function loadSettingsProfile() {
-            setSettings({ status: "LOADING" });
+            setSettings((prev) => ({
+                status: "LOADING",
+                data: "data" in prev ? prev.data : undefined,
+            }));
 
             try {
                 const profile = await fetchSettingsProfile();
 
-                setSettings({
-                    status: "SUCCESS",
-                    data: profile,
-                });
+                if (!cancelled) {
+                    setSettings({
+                        status: "SUCCESS",
+                        data: profile,
+                    });
+                }
             } catch (error) {
-                setSettings({
-                    status: "ERROR",
-                    message:
-                        error instanceof Error
-                            ? error.message
-                            : "회원 정보를 불러오지 못했습니다.",
-                });
+                if (!cancelled) {
+                    setSettings((prev) => ({
+                        status: "ERROR",
+                        data: "data" in prev ? prev.data : undefined,
+                        message:
+                            error instanceof Error
+                                ? error.message
+                                : "회원 정보를 불러오지 못했습니다.",
+                    }));
+                }
             }
         }
 
         loadSettingsProfile();
+
+        return () => {
+            cancelled = true;
+        };
     }, [enabled, setSettings]);
 }

--- a/src/features/settings/domain/state/SettingsState.ts
+++ b/src/features/settings/domain/state/SettingsState.ts
@@ -1,6 +1,7 @@
 import type { SettingsProfile } from "@/features/settings/domain/model/SettingsProfile";
 
 export type SettingsState =
-    | { readonly status: "LOADING" }
+    | { readonly status: "IDLE" }
+    | { readonly status: "LOADING"; readonly data?: SettingsProfile }
     | { readonly status: "SUCCESS"; readonly data: SettingsProfile }
-    | { readonly status: "ERROR"; readonly message: string };
+    | { readonly status: "ERROR"; readonly message: string; readonly data?: SettingsProfile };

--- a/src/features/settings/ui/components/AccountManagementSection.tsx
+++ b/src/features/settings/ui/components/AccountManagementSection.tsx
@@ -4,15 +4,17 @@ import { Shield, Save } from "lucide-react";
 import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
 
 interface AccountManagementSectionProps {
-    userId?: number; // TODO: 서버에서 아이디를 받는 거 추가되면 string으로 수정 필요
+    userId?: number;
     email?: string;
     showPasswordFields: boolean;
+    isLoading?: boolean;
 }
 
 export default function AccountManagementSection({
     userId,
     email,
     showPasswordFields,
+    isLoading = false,
 }: AccountManagementSectionProps) {
     return (
         <section className={settingsPageStyles.section}>
@@ -21,51 +23,68 @@ export default function AccountManagementSection({
                 계정 관리
             </h2>
 
-            {showPasswordFields && (
+            {isLoading ? (
                 <>
                     <div className={settingsPageStyles.formGroup}>
-                        <div className={settingsPageStyles.disabledInput}>
-                            <p className="mb-2 text-xs font-semibold uppercase">
-                                USER ID
-                            </p>
-                            <p>{userId}</p>
-                        </div>
-
-                        <div className={`${settingsPageStyles.disabledInput} mb-4`}>
-                            <p className="mb-2 text-xs font-semibold uppercase">
-                                EMAIL
-                            </p>
-                            <p>{email}</p>
-                        </div>
-
-                        <label className={settingsPageStyles.label}>
-                            새로운 비밀번호
-                        </label>
-                        <input
-                            type="password"
-                            placeholder="••••••••••••"
-                            className={settingsPageStyles.input}
-                        />
-
-                        <label className={settingsPageStyles.label}>
-                            비밀번호 확인
-                        </label>
-                        <input
-                            type="password"
-                            placeholder="••••••••••••"
-                            className={settingsPageStyles.input}
-                        />
+                        <div className={settingsPageStyles.skeletonDisabledInput} />
+                        <div className={settingsPageStyles.skeletonDisabledInputWithMargin} />
+                        <div className={settingsPageStyles.skeletonInput} />
+                        <div className={settingsPageStyles.skeletonInput} />
                     </div>
 
                     <div className={settingsPageStyles.saveButtonWrapper}>
-                        <button type="button" className={settingsPageStyles.saveButton}>
-                            저장
-                            <Save size={18} />
-                        </button>
+                        <div className={settingsPageStyles.skeletonSaveButton} />
                     </div>
 
                     <div className={settingsPageStyles.divider} />
                 </>
+            ) : (
+                showPasswordFields && (
+                    <>
+                        <div className={settingsPageStyles.formGroup}>
+                            <div className={settingsPageStyles.disabledInput}>
+                                <p className="mb-2 text-xs font-semibold uppercase">
+                                    USER ID
+                                </p>
+                                <p>{userId}</p>
+                            </div>
+
+                            <div className={`${settingsPageStyles.disabledInput} mb-4`}>
+                                <p className="mb-2 text-xs font-semibold uppercase">
+                                    EMAIL
+                                </p>
+                                <p>{email}</p>
+                            </div>
+
+                            <label className={settingsPageStyles.label}>
+                                새로운 비밀번호
+                            </label>
+                            <input
+                                type="password"
+                                placeholder="••••••••••••"
+                                className={settingsPageStyles.input}
+                            />
+
+                            <label className={settingsPageStyles.label}>
+                                비밀번호 확인
+                            </label>
+                            <input
+                                type="password"
+                                placeholder="••••••••••••"
+                                className={settingsPageStyles.input}
+                            />
+                        </div>
+
+                        <div className={settingsPageStyles.saveButtonWrapper}>
+                            <button type="button" className={settingsPageStyles.saveButton}>
+                                저장
+                                <Save size={18} />
+                            </button>
+                        </div>
+
+                        <div className={settingsPageStyles.divider} />
+                    </>
+                )
             )}
 
             <div className={settingsPageStyles.accountRow}>
@@ -76,7 +95,11 @@ export default function AccountManagementSection({
                     </p>
                 </div>
 
-                <button type="button" className={settingsPageStyles.dangerButton}>
+                <button
+                    type="button"
+                    disabled={isLoading}
+                    className={`${settingsPageStyles.dangerButton} disabled:cursor-not-allowed disabled:opacity-50`}
+                >
                     회원 탈퇴
                 </button>
             </div>

--- a/src/features/settings/ui/components/ProfileManagementSection.tsx
+++ b/src/features/settings/ui/components/ProfileManagementSection.tsx
@@ -8,10 +8,12 @@ import { updateNickname } from "@/features/settings/infrastructure/api/settingsA
 
 interface ProfileManagementSectionProps {
     nickname: string;
+    isLoading?: boolean;
 }
 
 export default function ProfileManagementSection({
     nickname: initialNickname,
+    isLoading = false,
 }: ProfileManagementSectionProps) {
     const {
         nickname,
@@ -30,6 +32,7 @@ export default function ProfileManagementSection({
     const handleNicknameSave = async () => {
         const trimmedNickname = nickname.trim();
 
+        if (isLoading) return;
         if (trimmedNickname === currentNickname) return;
         if (!canSaveNickname) return;
 
@@ -58,31 +61,39 @@ export default function ProfileManagementSection({
                 프로필 관리
             </h2>
 
-            {/* 프로필 영역 */}
             <div className={settingsPageStyles.profileImageWrapper}>
-                <User size={64} className={settingsPageStyles.profileIcon} />
+                {isLoading ? (
+                    <div className={settingsPageStyles.skeletonProfileIcon} />
+                ) : (
+                    <>
+                        <User size={64} className={settingsPageStyles.profileIcon} />
 
-                <button type="button" className={settingsPageStyles.editButton}>
-                    <Camera size={16} />
-                </button>
+                        <button type="button" className={settingsPageStyles.editButton}>
+                            <Camera size={16} />
+                        </button>
+                    </>
+                )}
             </div>
 
-            {/* 닉네임 */}
             <div className={settingsPageStyles.formGroup}>
                 <label className={settingsPageStyles.label}>닉네임</label>
-                <input
-                    type="text"
-                    value={nickname}
-                    className={settingsPageStyles.input}
-                    onChange={(event) =>
-                        handleNicknameChange(event.target.value)
-//                         validateNickname(nextNickname);
-                    }
-                    onBlur={() => validateNickname(nickname)} // TODO: 나중에 onChange 안에 있는 걸로 수정 필요
-                    maxLength={100}
-                />
 
-                {message && (
+                {isLoading ? (
+                    <div className={settingsPageStyles.skeletonInput} />
+                ) : (
+                    <input
+                        type="text"
+                        value={nickname}
+                        className={settingsPageStyles.input}
+                        onChange={(event) =>
+                            handleNicknameChange(event.target.value)
+                        }
+                        onBlur={() => validateNickname(nickname)}
+                        maxLength={100}
+                    />
+                )}
+
+                {!isLoading && message && (
                     <p
                         className={
                             status === "AVAILABLE"
@@ -96,19 +107,23 @@ export default function ProfileManagementSection({
             </div>
 
             <div className={settingsPageStyles.saveButtonWrapper}>
-                <button
-                    type="button"
-                    onClick={handleNicknameSave}
-                    disabled={
-                        isSaving ||
-                        nickname.trim() === currentNickname ||
-                        !canSaveNickname
-                    }
-                    className={`${settingsPageStyles.saveButton} disabled:cursor-not-allowed disabled:opacity-50`}
-                >
-                    {isSaving ? "저장 중..." : "저장"}
-                    <Check size={18} />
-                </button>
+                {isLoading ? (
+                    <div className={settingsPageStyles.skeletonSaveButton} />
+                ) : (
+                    <button
+                        type="button"
+                        onClick={handleNicknameSave}
+                        disabled={
+                            isSaving ||
+                            nickname.trim() === currentNickname ||
+                            !canSaveNickname
+                        }
+                        className={`${settingsPageStyles.saveButton} disabled:cursor-not-allowed disabled:opacity-50`}
+                    >
+                        {isSaving ? "저장 중..." : "저장"}
+                        <Check size={18} />
+                    </button>
+                )}
             </div>
         </section>
     );

--- a/src/ui/styles/settingsPageStyles.ts
+++ b/src/ui/styles/settingsPageStyles.ts
@@ -24,4 +24,15 @@ export const settingsPageStyles = {
     dangerDescription: "mt-1 text-sm text-gray-600",
     dangerButton:
         "h-12 w-40 rounded-full border border-red-500 text-red-500 font-semibold",
+
+    skeletonProfileIcon:
+        "h-16 w-16 animate-pulse rounded-full bg-[#c7d2df]",
+    skeletonInput:
+        "h-14 animate-pulse rounded-2xl bg-white",
+    skeletonDisabledInput:
+        "h-20 animate-pulse rounded-2xl bg-[#d8d8d8]",
+    skeletonDisabledInputWithMargin:
+        "mb-4 h-20 animate-pulse rounded-2xl bg-[#d8d8d8]",
+    skeletonSaveButton:
+        "h-12 w-44 animate-pulse rounded-full bg-[#c7d2df]",
 };


### PR DESCRIPTION
## 관련 이슈
노션 백로그 MC-11 참고

## 요약
- 무엇을 변경했나요?
  - 초기 페이지 렌더링 시 발생하는 화면 깜빡임 현상 개선
  - 인증 상태 및 설정 정보 로딩 시 기존 화면 레이아웃을 유지하도록 렌더링 구조를 변경
  - Settings 상태에 이전 데이터를 유지하도록 개선하여 불필요한 화면 전환 제거
  - Profile / Account 설정 영역에 Skeleton UI를 적용하여 자연스러운 화면 전환을 제공하도록 수정
  - 인증 초기화 및 Route Guard 로직을 개선하여 초기 렌더링 과정에서 불필요한 상태 변경이 발생하지 않도록 수정

- 왜 이 변경이 필요한가요?
  - 기존에는 인증 확인과 초기 데이터 조회 과정에서 Loading 화면과 실제 화면이 반복적으로 교체되면서 화면이 깜빡이는 현상이 발생
  - 초기 렌더링 과정에서도 기존 레이아웃을 유지하도록 변경하여 사용자 경험을 개선하고 불필요한 재렌더링을 줄임

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
