### PR TITLE
[Fix] 소셜 회원가입 후 최신 닉네임이 반영되도록 수정 (MC-29)

### DIFF
--- a/src/features/auth/application/hooks/useSubmitMyNickname.ts
+++ b/src/features/auth/application/hooks/useSubmitMyNickname.ts
@@ -6,7 +6,10 @@ import { useRouter } from "next/navigation";
 import { logger } from "@/shared/lib/logger";
 
 import { onboardingApi } from "@/features/auth/infrastructure/api/onboardingApi";
-import { updateOnboarding } from "@/features/auth/application/store/authStore";
+import {
+    updateMemberNickname,
+    updateOnboarding,
+} from "@/features/auth/application/store/authStore";
 import { getOnboardingRoute } from "@/features/auth/application/onboarding/getOnboardingRoute";
 
 export function useSubmitMyNickname() {
@@ -20,20 +23,21 @@ export function useSubmitMyNickname() {
             setIsSubmitting(true);
 
             try {
+                const trimmedNickname = nickname.trim();
+
                 const response = await onboardingApi.updateOnboardingNickname({
-                    nickname,
+                    nickname: trimmedNickname,
                 });
 
                 logger.log("닉네임 완료 응답:", response.data.onboarding);
                 logger.log(
                     "이동 경로:",
-                    getOnboardingRoute(response.data.onboarding.nextStep)
+                    getOnboardingRoute(response.data.onboarding.nextStep),
                 );
 
-                // onboarding 상태 업데이트
                 updateOnboarding(response.data.onboarding);
+                updateMemberNickname(trimmedNickname);
 
-                // 다음 단계 이동 (READY → /home)
                 router.replace(
                     getOnboardingRoute(response.data.onboarding.nextStep),
                 );

--- a/src/features/auth/application/store/authStore.ts
+++ b/src/features/auth/application/store/authStore.ts
@@ -35,6 +35,20 @@ export function updateOnboarding(onboarding: OnboardingState) {
     });
 }
 
+export function updateMemberNickname(nickname: string) {
+    const auth = jotaiStore.get(authAtom);
+
+    if (auth.status !== "AUTHENTICATED") return;
+
+    jotaiStore.set(authAtom, {
+        ...auth,
+        member: {
+            ...auth.member,
+            nickname,
+        },
+    });
+}
+
 export function clearAuth() {
     jotaiStore.set(authAtom, { status: "UNAUTHENTICATED" });
 }


### PR DESCRIPTION
## 관련 이슈
노션 백로그 MC-29 참고

## 요약
- 무엇을 변경했나요?
  - 소셜 회원가입 후 닉네임 설정 완료 시 전역 인증 상태(authAtom)의 member.nickname도 함께 갱신하도록 수정
  - 로그인 전용 메인 페이지에서 임시 닉네임 대신 사용자가 설정한 닉네임이 즉시 표시되도록 개선
- 왜 이 변경이 필요한가요?
  - 기존에는 닉네임 변경 API 호출 후 onboarding 상태만 갱신되어 인증 상태에 저장된 member 정보가 임시 닉네임으로 유지되었음
  - 이로 인해 회원가입 직후 메인 페이지에서 설정한 닉네임이 아닌 임시 닉네임이 표시되는 문제가 발생하여 이를 해결

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
