### PR TITLE
[Feat] 개인 메뉴 추천 재요청 기능 추가 (MC-32)

### DIFF
--- a/src/app/personal-recommendation/page.tsx
+++ b/src/app/personal-recommendation/page.tsx
@@ -33,26 +33,34 @@ export default function PersonalRecommendationPage() {
     const [isPreferenceModalOpen, setIsPreferenceModalOpen] = useState(false);
     const [isLocationModalOpen, setIsLocationModalOpen] = useState(false);
 
+    // 로그인한 회원 정보 조회
     const member = useAtomValue(memberAtom);
 
+    // 회원별로 위치 저장 key를 분리하기 위한 storage key 생성
     const locationStorageKey = createLocationStorageKey(
         PERSONAL_RECOMMENDATION_LOCATION_KEY,
         member?.id ?? "unknown",
     );
 
+    // 개인 추천에 사용할 위치 정보
     const { location, saveLocation } = useLocationSetting(locationStorageKey);
+
+    // 취향 프로필 조회
     const { preferenceState } = usePreferenceList();
 
+    // 개인 추천 생성/재요청 중 로딩 화면 표시 여부
     const isRecommendationLoading = useAtomValue(
         isPersonalRecommendationLoadingAtom,
     );
 
+    // 개인 추천 이력 조회
     const { histories } = usePersonalRecommendationHistories();
 
+    // 이력 데이터를 화면 표시용 데이터로 변환
     const historyPanelItems =
         personalRecommendationHistoryToPanelItemsMapper(histories);
 
-    // 추천 결과 화면 이동
+    // 추천 결과 상세 조회 후 결과 페이지로 이동
     const { moveToRecommendationResult } =
         usePersonalRecommendationResultNavigation();
 
@@ -61,6 +69,7 @@ export default function PersonalRecommendationPage() {
         (history) => history.status === "OPEN",
     );
 
+    // 필수 취향 정보가 모두 등록되어 있는지 확인
     const hasPreference =
         preferenceState.status === "SUCCESS" &&
         hasRequiredPreference(preferenceState.data);
@@ -75,7 +84,7 @@ export default function PersonalRecommendationPage() {
         hasPreference,
     });
 
-    // 진행 중 추천이 있으면 새 추천 대신 기존 결과 이동
+    // 진행 중 추천이 있으면 새 추천 생성 대신 기존 추천 결과 화면으로 이동
     const handleClickHeroButton = openRecommendation
         ? () => moveToRecommendationResult(openRecommendation.id)
         : startRecommendation;

--- a/src/app/personal-recommendation/result/page.tsx
+++ b/src/app/personal-recommendation/result/page.tsx
@@ -11,6 +11,8 @@ import { userPreferenceAtom } from "@/features/preference/application/selectors/
 import { getPreferenceSummaryKeywords } from "@/features/preference/application/mapper/getPreferenceSummaryKeywords";
 import { useCompletePersonalRecommendationSelection } from "@/features/personalRecommendation/application/hooks/useCompletePersonalRecommendationSelection";
 import { useLocationSetting } from "@/features/locationSetting/application/hooks/useLocationSetting";
+import { useRerollPersonalRecommendation } from "@/features/personalRecommendation/application/hooks/useRerollPersonalRecommendation";
+
 import { createLocationStorageKey } from "@/features/locationSetting/application/utils/createLocationStorageKey";
 
 import PersonalRecommendationResultCard from "@/features/personalRecommendation/ui/components/PersonalRecommendationResultCard";
@@ -37,6 +39,9 @@ export default function PersonalRecommendationResultPage() {
 
     const { isCompleting, completeSelection } =
         useCompletePersonalRecommendationSelection();
+
+    const { isRerolling, rerollRecommendation } =
+        useRerollPersonalRecommendation();
 
     const [selectedCandidateId, setSelectedCandidateId] = useState<number | null>(
         recommendation?.selectedCandidateId ?? null,
@@ -87,6 +92,17 @@ export default function PersonalRecommendationResultPage() {
         });
 
         router.push(`/recommendation-restaurants?${searchParams.toString()}`);
+    };
+
+    const handleRetryRecommendation = async () => {
+        const nextRecommendation = await rerollRecommendation(
+            recommendation.requestId,
+            "NOT_SATISFIED",
+        );
+
+        if (nextRecommendation) {
+            setSelectedCandidateId(null);
+        }
     };
 
     return (
@@ -155,11 +171,10 @@ export default function PersonalRecommendationResultPage() {
             </section>
 
             <PersonalRecommendationResultActionButtons
-                onRetryRecommendation={() => {
-                    console.log("재요청");
-                }}
+                onRetryRecommendation={handleRetryRecommendation}
                 onCompleteSelection={handleCompleteSelection}
                 canCompleteSelection={selectedCandidateId !== null}
+                isRetryRecommendationLoading={isRerolling}
                 isCompleteSelectionLoading={isCompleting}
                 isClosed={isClosed}
             />

--- a/src/features/personalRecommendation/application/hooks/useRerollPersonalRecommendation.ts
+++ b/src/features/personalRecommendation/application/hooks/useRerollPersonalRecommendation.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { useSetAtom } from "jotai";
+
+import { personalRecommendationAtom } from "@/features/personalRecommendation/application/atoms/personalRecommendationAtom";
+import { personalRecommendationApi } from "@/features/personalRecommendation/infrastructure/api/personalRecommendationApi";
+import type { PersonalRecommendationRerollType } from "@/features/personalRecommendation/domain/model/PersonalRecommendationRerollType";
+
+export function useRerollPersonalRecommendation() {
+    const setRecommendationState = useSetAtom(personalRecommendationAtom);
+    const [isRerolling, setIsRerolling] = useState(false);
+
+    const rerollRecommendation = async (
+        requestId: number,
+        rerollType: PersonalRecommendationRerollType,
+    ) => {
+        if (isRerolling) return null;
+
+        setIsRerolling(true);
+
+        try {
+            const recommendation =
+                await personalRecommendationApi.rerollRecommendation(
+                    requestId,
+                    rerollType,
+                );
+
+            setRecommendationState({
+                status: "SUCCESS",
+                data: recommendation,
+            });
+
+            return recommendation;
+        } catch (error) {
+            alert(
+                error instanceof Error
+                    ? error.message
+                    : "개인 메뉴 추천 재요청에 실패했습니다.",
+            );
+
+            return null;
+        } finally {
+            setIsRerolling(false);
+        }
+    };
+
+    return {
+        isRerolling,
+        rerollRecommendation,
+    };
+}

--- a/src/features/personalRecommendation/domain/model/PersonalRecommendationRerollType.ts
+++ b/src/features/personalRecommendation/domain/model/PersonalRecommendationRerollType.ts
@@ -1,0 +1,3 @@
+export type PersonalRecommendationRerollType =
+    | "NOT_SATISFIED"
+    | "INPUT_CHANGED";

--- a/src/features/personalRecommendation/infrastructure/api/dto/RerollPersonalRecommendationResponse.ts
+++ b/src/features/personalRecommendation/infrastructure/api/dto/RerollPersonalRecommendationResponse.ts
@@ -1,0 +1,12 @@
+import type { CreatePersonalRecommendationData } from "@/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse";
+
+export interface RerollPersonalRecommendationResponse {
+    readonly success: boolean;
+    readonly data: CreatePersonalRecommendationData | null;
+    readonly error: {
+        readonly status: number;
+        readonly code: string;
+        readonly message: string;
+        readonly details: readonly unknown[];
+    } | null;
+}

--- a/src/features/personalRecommendation/infrastructure/api/personalRecommendationApi.ts
+++ b/src/features/personalRecommendation/infrastructure/api/personalRecommendationApi.ts
@@ -1,15 +1,23 @@
 import { httpClient } from "@/infrastructure/http/httpClient";
 
 import type { PersonalRecommendationHistory } from "@/features/personalRecommendation/domain/model/PersonalRecommendationHistory";
+import type { PersonalRecommendationRerollType } from "@/features/personalRecommendation/domain/model/PersonalRecommendationRerollType";
+
 import type { CreatePersonalRecommendationResponse } from "@/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse";
 import type { SelectPersonalRecommendationCandidateResponse } from "@/features/personalRecommendation/infrastructure/api/dto/SelectPersonalRecommendationCandidateResponse";
 import type { PersonalRecommendationHistoryResponse } from "@/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationHistoryResponse";
 import type { PersonalRecommendationDetailResponse } from "@/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse";
+import type { RerollPersonalRecommendationResponse } from "@/features/personalRecommendation/infrastructure/api/dto/RerollPersonalRecommendationResponse";
 
 import { mapPersonalRecommendationDetail } from "@/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationDetailMapper";
 import { mapPersonalRecommendation } from "@/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationMapper";
 
 interface CreatePersonalRecommendationRequest {
+    readonly contextJson: Record<string, unknown>;
+}
+
+interface RerollPersonalRecommendationRequest {
+    readonly rerollType: PersonalRecommendationRerollType;
     readonly contextJson: Record<string, unknown>;
 }
 
@@ -85,5 +93,29 @@ export const personalRecommendationApi = {
         }
 
         return mapPersonalRecommendationDetail(response.data);
+    },
+
+    async rerollRecommendation(
+        requestId: number,
+        rerollType: PersonalRecommendationRerollType,
+    ) {
+        const request: RerollPersonalRecommendationRequest = {
+            rerollType,
+            contextJson: {},
+        };
+
+        const response =
+            await httpClient.post<RerollPersonalRecommendationResponse>(
+                `/api/v1/personal/recommendations/${requestId}/reroll`,
+                request,
+            );
+
+        if (!response.success || !response.data) {
+            throw new Error(
+                response.error?.message ?? "개인 메뉴 추천 재요청에 실패했습니다.",
+            );
+        }
+
+        return mapPersonalRecommendation(response.data);
     },
 };

--- a/src/features/preference/ui/components/PreferenceModal.tsx
+++ b/src/features/preference/ui/components/PreferenceModal.tsx
@@ -181,7 +181,7 @@ export default function PreferenceModal({
                     </section>
                 </div>
 
-                <footer className={preferenceModalStyles.footer}>
+                <div className={preferenceModalStyles.footer}>
                     <button
                         type="button"
                         onClick={savePreference}
@@ -190,7 +190,7 @@ export default function PreferenceModal({
                     >
                         {isSaving ? "저장 중..." : "저장하기"}
                     </button>
-                </footer>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## 관련 이슈
노션 백로그 MC-32 참고

## 요약
- 무엇을 변경했나요?
  - 개인 메뉴 추천 재요청 기능을 추가하고 추천 결과 페이지와 API를 연동
- 왜 이 변경이 필요한가요?
  - 추천 결과가 만족스럽지 않은 경우 사용자가 기존 추천을 종료하고 새로운 개인 메뉴 추천을 받을 수 있도록 하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
