### PR TITLE
[Feat] 회원 탈퇴 기능 추가 (MC-34)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,12 +1,16 @@
 "use client";
 
+import { useState } from "react";
 import { useAtomValue } from "jotai";
+
 import { useAuthGuard } from "@/features/routeGuard/application/hooks/useAuthGuard";
 import { settingsAtom } from "@/features/settings/application/atoms/settingsAtom";
 import { isLocalLoginAtom } from "@/features/settings/application/selectors/settingsSelectors";
 import { useSettingsProfile } from "@/features/settings/application/hooks/useSettingsProfile";
+import { useDeleteMember } from "@/features/settings/application/hooks/useDeleteMember";
 import ProfileManagementSection from "@/features/settings/ui/components/ProfileManagementSection";
 import AccountManagementSection from "@/features/settings/ui/components/AccountManagementSection";
+import DeleteMemberConfirmModal from "@/features/settings/ui/components/DeleteMemberConfirmModal";
 import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
 
 export default function SettingsPage() {
@@ -17,9 +21,16 @@ export default function SettingsPage() {
     const settingsState = useAtomValue(settingsAtom);
     const isLocalLogin = useAtomValue(isLocalLoginAtom);
 
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const { isDeleting, deleteAccount } = useDeleteMember();
+
     const profile = "data" in settingsState ? settingsState.data : null;
     const isLoading = isAuthLoading || !canAccess || settingsState.status === "LOADING" || !profile;
     const isError = settingsState.status === "ERROR" && !profile;
+
+    const handleConfirmDeleteMember = async () => {
+        await deleteAccount();
+    };
 
     return (
         <main className={settingsPageStyles.page}>
@@ -45,9 +56,17 @@ export default function SettingsPage() {
                         email={profile?.email}
                         showPasswordFields={profile ? isLocalLogin : false}
                         isLoading={isLoading}
+                        onClickDeleteMember={() => setIsDeleteModalOpen(true)}
                     />
                 </>
             )}
+
+            <DeleteMemberConfirmModal
+                isOpen={isDeleteModalOpen}
+                isDeleting={isDeleting}
+                onClose={() => setIsDeleteModalOpen(false)}
+                onConfirm={handleConfirmDeleteMember}
+            />
         </main>
     );
 }

--- a/src/features/settings/application/hooks/useDeleteMember.ts
+++ b/src/features/settings/application/hooks/useDeleteMember.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { deleteMemberAccount } from "@/features/settings/application/usecase/deleteMemberAccount";
+
+export function useDeleteMember() {
+    const [isDeleting, setIsDeleting] = useState(false);
+
+    const deleteAccount = useCallback(async () => {
+        if (isDeleting) return;
+
+        setIsDeleting(true);
+
+        try {
+            await deleteMemberAccount();
+
+            window.location.replace("/");
+        } catch {
+            alert("회원 탈퇴를 진행할 수 없습니다. 다시 시도해보세요");
+            setIsDeleting(false);
+        }
+    }, [isDeleting]);
+
+    return {
+        isDeleting,
+        deleteAccount,
+    };
+}

--- a/src/features/settings/application/usecase/deleteMemberAccount.ts
+++ b/src/features/settings/application/usecase/deleteMemberAccount.ts
@@ -1,0 +1,10 @@
+import { clearAuth } from "@/features/auth/application/store/authStore";
+import { deleteMember } from "@/features/settings/infrastructure/api/settingsApi";
+
+export async function deleteMemberAccount() {
+    try {
+        await deleteMember();
+    } finally {
+        clearAuth();
+    }
+}

--- a/src/features/settings/infrastructure/api/settingsApi.ts
+++ b/src/features/settings/infrastructure/api/settingsApi.ts
@@ -33,6 +33,17 @@ interface UpdateNicknameResponse {
     readonly error: ApiError | null;
 }
 
+interface DeleteMemberData {
+    readonly id: number;
+    readonly status: "INACTIVE";
+}
+
+interface DeleteMemberResponse {
+    readonly success: boolean;
+    readonly data: DeleteMemberData;
+    readonly error: ApiError | null;
+}
+
 export async function fetchSettingsProfile(): Promise<SettingsProfile> {
     const response = await httpClient.get<MemberMeResponse>("/api/v1/members/me");
 
@@ -58,6 +69,21 @@ export async function updateNickname(
     if (!response.success) {
         throw new Error(
             response.error?.message || "닉네임 변경에 실패했습니다.",
+        );
+    }
+
+    return response.data;
+}
+
+export async function deleteMember(): Promise<DeleteMemberData> {
+    const response = await httpClient.delete<DeleteMemberResponse>(
+        "/api/v1/members/me",
+    );
+
+    if (!response.success) {
+        throw new Error(
+            response.error?.message ||
+                "회원 탈퇴를 진행할 수 없습니다. 다시 시도해보세요",
         );
     }
 

--- a/src/features/settings/ui/components/AccountManagementSection.tsx
+++ b/src/features/settings/ui/components/AccountManagementSection.tsx
@@ -8,6 +8,7 @@ interface AccountManagementSectionProps {
     email?: string;
     showPasswordFields: boolean;
     isLoading?: boolean;
+    onClickDeleteMember: () => void;
 }
 
 export default function AccountManagementSection({
@@ -15,6 +16,7 @@ export default function AccountManagementSection({
     email,
     showPasswordFields,
     isLoading = false,
+    onClickDeleteMember,
 }: AccountManagementSectionProps) {
     return (
         <section className={settingsPageStyles.section}>
@@ -98,7 +100,8 @@ export default function AccountManagementSection({
                 <button
                     type="button"
                     disabled={isLoading}
-                    className={`${settingsPageStyles.dangerButton} disabled:cursor-not-allowed disabled:opacity-50`}
+                    onClick={onClickDeleteMember}
+                    className={settingsPageStyles.deleteMemberButton}
                 >
                     회원 탈퇴
                 </button>

--- a/src/features/settings/ui/components/DeleteMemberConfirmModal.tsx
+++ b/src/features/settings/ui/components/DeleteMemberConfirmModal.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
+
+interface DeleteMemberConfirmModalProps {
+    isOpen: boolean;
+    isDeleting: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+}
+
+export default function DeleteMemberConfirmModal({
+    isOpen,
+    isDeleting,
+    onClose,
+    onConfirm,
+}: DeleteMemberConfirmModalProps) {
+    if (!isOpen) return null;
+
+    return (
+        <div className={settingsPageStyles.modalOverlay}>
+            <div className={settingsPageStyles.modalBox}>
+                <div className={settingsPageStyles.modalTitleWrapper}>
+                    <AlertTriangle size={22} />
+                    <h2 className={settingsPageStyles.modalTitle}>회원 탈퇴</h2>
+                </div>
+
+                <p className={settingsPageStyles.modalDescription}>
+                    회원 탈퇴 후에는 해당 계정으로 다시 로그인할 수 없습니다.
+                    <br />
+                    회원 탈퇴를 진행하시겠습니까?
+                </p>
+
+                <div className={settingsPageStyles.modalButtonWrapper}>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        disabled={isDeleting}
+                        className={settingsPageStyles.modalCancelButton}
+                    >
+                        취소
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={onConfirm}
+                        disabled={isDeleting}
+                        className={settingsPageStyles.modalDangerButton}
+                    >
+                        {isDeleting ? "탈퇴 중..." : "탈퇴하기"}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/ui/styles/settingsPageStyles.ts
+++ b/src/ui/styles/settingsPageStyles.ts
@@ -24,6 +24,25 @@ export const settingsPageStyles = {
     dangerDescription: "mt-1 text-sm text-gray-600",
     dangerButton:
         "h-12 w-40 rounded-full border border-red-500 text-red-500 font-semibold",
+    deleteMemberButton:
+        "h-12 w-40 rounded-full border border-red-500 text-red-500 font-semibold cursor-pointer transition hover:bg-red-50 hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50",
+
+    modalOverlay:
+        "fixed inset-0 z-50 flex items-center justify-center bg-black/40",
+    modalBox:
+        "w-[420px] rounded-[32px] bg-white p-8 shadow-xl",
+    modalTitleWrapper:
+        "mb-4 flex items-center gap-2 text-red-500",
+    modalTitle:
+        "text-lg font-bold",
+    modalDescription:
+        "text-sm leading-6 text-zinc-700",
+    modalButtonWrapper:
+        "mt-6 flex justify-end gap-3",
+    modalCancelButton:
+        "rounded-xl border border-zinc-300 px-4 py-2 text-sm font-semibold text-zinc-700 cursor-pointer transition hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50",
+    modalDangerButton:
+        "rounded-xl bg-red-500 px-4 py-2 text-sm font-semibold text-white cursor-pointer transition hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50",
 
     skeletonProfileIcon:
         "h-16 w-16 animate-pulse rounded-full bg-[#c7d2df]",


### PR DESCRIPTION
## 관련 이슈
노션 백로그 MC-34 참고

## 요약
- 무엇을 변경했나요?
  - 설정 페이지에 회원 탈퇴 기능 추가
  - 탈퇴 확인 모달 추가
  - 회원 탈퇴 API 연동
- 왜 이 변경이 필요한가요?
  - 사용자가 서비스에서 계정을 안전하게 탈퇴할 수 있도록 하고, 탈퇴 후 인증 상태를 초기화하여 비로그인 상태로 정상 전환되도록 하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
