### PR TITLE
[Fix] 비밀번호 변경 시 저장 버튼 비활성화 문제 수정(MC-38)

### DIFF
--- a/src/features/settings/application/hooks/useChangePassword.ts
+++ b/src/features/settings/application/hooks/useChangePassword.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { HttpError } from "@/infrastructure/http/httpClient";
+import { changePassword } from "@/features/settings/infrastructure/api/settingsApi";
+
+const PASSWORD_MIN = 8;
+const PASSWORD_MAX = 100;
+const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).+$/;
+const WHITESPACE_REGEX = /\s/;
+
+function getPasswordMessage(password: string) {
+    if (!password) return "";
+
+    if (WHITESPACE_REGEX.test(password)) {
+        return "비밀번호에는 공백을 사용할 수 없습니다.";
+    }
+
+    if (password.length < PASSWORD_MIN || password.length > PASSWORD_MAX) {
+        return "비밀번호는 8자 이상 100자 이하로 입력해주세요.";
+    }
+
+    if (!PASSWORD_REGEX.test(password)) {
+        return "비밀번호는 문자, 숫자, 특수문자를 각각 1개 이상 포함해야 합니다.";
+    }
+
+    return "";
+}
+
+function getChangePasswordErrorMessage(error: unknown) {
+    if (error instanceof HttpError) {
+        if (error.status === 401) {
+            return "현재 비밀번호가 일치하지 않습니다.";
+        }
+
+        return "비밀번호 변경에 실패했습니다.";
+    }
+
+    return "비밀번호 변경에 실패했습니다.";
+}
+
+export function useChangePassword() {
+    const [currentPassword, setCurrentPassword] = useState("");
+    const [newPassword, setNewPassword] = useState("");
+    const [newPasswordConfirm, setNewPasswordConfirm] = useState("");
+    const [isSaving, setIsSaving] = useState(false);
+
+    const passwordMessage = getPasswordMessage(newPassword);
+    const isNewPasswordValid = newPassword.length > 0 && !passwordMessage;
+    const isPasswordMatched =
+        newPasswordConfirm.length > 0 && newPassword === newPasswordConfirm;
+
+    const confirmMessage = useMemo(() => {
+        if (!newPasswordConfirm) return "";
+        if (!isPasswordMatched) return "새 비밀번호가 일치하지 않습니다.";
+        return "";
+    }, [isPasswordMatched, newPasswordConfirm]);
+
+    const canChangePassword =
+        currentPassword.length > 0 &&
+        isNewPasswordValid &&
+        isPasswordMatched &&
+        !isSaving;
+
+    const submit = async () => {
+        if (!canChangePassword) return;
+
+        setIsSaving(true);
+
+        try {
+            await changePassword({
+                currentPassword,
+                newPassword,
+            });
+
+            alert("비밀번호가 변경되었습니다.");
+
+            setCurrentPassword("");
+            setNewPassword("");
+            setNewPasswordConfirm("");
+        } catch (error) {
+            alert(getChangePasswordErrorMessage(error));
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    return {
+        currentPassword,
+        newPassword,
+        newPasswordConfirm,
+        passwordMessage,
+        confirmMessage,
+        isSaving,
+        canChangePassword,
+        setCurrentPassword,
+        setNewPassword,
+        setNewPasswordConfirm,
+        submit,
+    };
+}

--- a/src/features/settings/infrastructure/api/settingsApi.ts
+++ b/src/features/settings/infrastructure/api/settingsApi.ts
@@ -44,6 +44,21 @@ interface DeleteMemberResponse {
     readonly error: ApiError | null;
 }
 
+interface ChangePasswordRequest {
+    readonly currentPassword: string;
+    readonly newPassword: string;
+}
+
+interface ChangePasswordData {
+    readonly passwordChanged: boolean;
+}
+
+interface ChangePasswordResponse {
+    readonly success: boolean;
+    readonly data: ChangePasswordData;
+    readonly error: ApiError | null;
+}
+
 export async function fetchSettingsProfile(): Promise<SettingsProfile> {
     const response = await httpClient.get<MemberMeResponse>("/api/v1/members/me");
 
@@ -85,6 +100,21 @@ export async function deleteMember(): Promise<DeleteMemberData> {
             response.error?.message ||
                 "회원 탈퇴를 진행할 수 없습니다. 다시 시도해보세요",
         );
+    }
+
+    return response.data;
+}
+
+export async function changePassword(
+    request: ChangePasswordRequest,
+): Promise<ChangePasswordData> {
+    const response = await httpClient.patch<ChangePasswordResponse>(
+        "/api/v1/members/me/password",
+        request,
+    );
+
+    if (!response.success) {
+        throw new Error("비밀번호 변경에 실패했습니다.");
     }
 
     return response.data;

--- a/src/features/settings/ui/components/AccountManagementSection.tsx
+++ b/src/features/settings/ui/components/AccountManagementSection.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { Shield, Save } from "lucide-react";
+import { useState } from "react";
+import { Shield, Save, Eye, EyeOff } from "lucide-react";
 import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
+import { useChangePassword } from "@/features/settings/application/hooks/useChangePassword";
 
 interface AccountManagementSectionProps {
     userId?: number;
@@ -18,6 +20,24 @@ export default function AccountManagementSection({
     isLoading = false,
     onClickDeleteMember,
 }: AccountManagementSectionProps) {
+    const {
+        currentPassword,
+        newPassword,
+        newPasswordConfirm,
+        passwordMessage,
+        confirmMessage,
+        isSaving,
+        canChangePassword,
+        setCurrentPassword,
+        setNewPassword,
+        setNewPasswordConfirm,
+        submit,
+    } = useChangePassword();
+
+    const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+    const [showNewPassword, setShowNewPassword] = useState(false);
+    const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
     return (
         <section className={settingsPageStyles.section}>
             <h2 className={settingsPageStyles.sectionTitle}>
@@ -59,27 +79,104 @@ export default function AccountManagementSection({
                             </div>
 
                             <label className={settingsPageStyles.label}>
+                                현재 비밀번호
+                            </label>
+                            <div className={settingsPageStyles.passwordInputWrapper}>
+                                <input
+                                    type={showCurrentPassword ? "text" : "password"}
+                                    value={currentPassword}
+                                    onChange={(event) => setCurrentPassword(event.target.value)}
+                                    placeholder="••••••••••••"
+                                    className={`${settingsPageStyles.input} ${settingsPageStyles.passwordInput}`}
+                                />
+
+                                <button
+                                    type="button"
+                                    onClick={() => setShowCurrentPassword((prev) => !prev)}
+                                    className={settingsPageStyles.passwordToggleButton}
+                                    aria-label={
+                                        showCurrentPassword
+                                            ? "현재 비밀번호 숨기기"
+                                            : "현재 비밀번호 보기"
+                                    }
+                                >
+                                    {showCurrentPassword ? <Eye size={22} /> : <EyeOff size={22} />}
+                                </button>
+                            </div>
+
+                            <label className={settingsPageStyles.label}>
                                 새로운 비밀번호
                             </label>
-                            <input
-                                type="password"
-                                placeholder="••••••••••••"
-                                className={settingsPageStyles.input}
-                            />
+                            <div className={settingsPageStyles.passwordInputWrapper}>
+                                <input
+                                    type={showNewPassword ? "text" : "password"}
+                                    value={newPassword}
+                                    onChange={(event) => setNewPassword(event.target.value)}
+                                    placeholder="••••••••••••"
+                                    className={`${settingsPageStyles.input} ${settingsPageStyles.passwordInput}`}
+                                />
+
+                                <button
+                                    type="button"
+                                    onClick={() => setShowNewPassword((prev) => !prev)}
+                                    className={settingsPageStyles.passwordToggleButton}
+                                    aria-label={
+                                        showNewPassword
+                                            ? "새 비밀번호 숨기기"
+                                            : "새 비밀번호 보기"
+                                    }
+                                >
+                                    {showNewPassword ? <Eye size={22} /> : <EyeOff size={22} />}
+                                </button>
+                            </div>
+
+                            {passwordMessage && (
+                                <p className="text-sm text-red-500">
+                                    {passwordMessage}
+                                </p>
+                            )}
 
                             <label className={settingsPageStyles.label}>
                                 비밀번호 확인
                             </label>
-                            <input
-                                type="password"
-                                placeholder="••••••••••••"
-                                className={settingsPageStyles.input}
-                            />
+                            <div className={settingsPageStyles.passwordInputWrapper}>
+                                <input
+                                    type={showConfirmPassword ? "text" : "password"}
+                                    value={newPasswordConfirm}
+                                    onChange={(event) => setNewPasswordConfirm(event.target.value)}
+                                    placeholder="••••••••••••"
+                                    className={`${settingsPageStyles.input} ${settingsPageStyles.passwordInput}`}
+                                />
+
+                                <button
+                                    type="button"
+                                    onClick={() => setShowConfirmPassword((prev) => !prev)}
+                                    className={settingsPageStyles.passwordToggleButton}
+                                    aria-label={
+                                        showConfirmPassword
+                                            ? "비밀번호 확인 숨기기"
+                                            : "비밀번호 확인 보기"
+                                    }
+                                >
+                                    {showConfirmPassword ? <Eye size={22} /> : <EyeOff size={22} />}
+                                </button>
+                            </div>
+
+                            {confirmMessage && (
+                                <p className="text-sm text-red-500">
+                                    {confirmMessage}
+                                </p>
+                            )}
                         </div>
 
                         <div className={settingsPageStyles.saveButtonWrapper}>
-                            <button type="button" className={settingsPageStyles.saveButton}>
-                                저장
+                            <button
+                                type="button"
+                                onClick={submit}
+                                disabled={!canChangePassword}
+                                className={`${settingsPageStyles.saveButton} disabled:cursor-not-allowed disabled:opacity-50`}
+                            >
+                                {isSaving ? "저장 중..." : "저장"}
                                 <Save size={18} />
                             </button>
                         </div>

--- a/src/ui/styles/settingsPageStyles.ts
+++ b/src/ui/styles/settingsPageStyles.ts
@@ -8,7 +8,7 @@ export const settingsPageStyles = {
         "relative mb-10 flex h-32 w-32 items-center justify-center rounded-full bg-[#d9e2ec]",
     profileIcon: "text-[#6b7c93]",
     editButton:
-        "absolute bottom-2 right-2 flex h-8 w-8 items-center justify-center rounded-full bg-[#37639f] text-white shadow-md",
+        "absolute bottom-2 right-2 flex h-8 w-8 items-center justify-center rounded-full bg-[#37639f] text-white shadow-md cursor-pointer",
     formGroup: "flex flex-col gap-3",
     label: "text-sm font-semibold text-gray-800",
     input:
@@ -17,7 +17,7 @@ export const settingsPageStyles = {
         "h-20 rounded-2xl bg-[#d8d8d8] px-5 py-4 text-sm text-gray-500 outline-none",
     saveButtonWrapper: "mt-10 flex justify-end",
     saveButton:
-        "flex h-12 w-44 items-center justify-center gap-8 rounded-full bg-[#37639f] text-white",
+        "flex h-12 w-44 items-center justify-center gap-8 rounded-full bg-[#37639f] text-white cursor-pointer",
     accountRow: "flex items-center justify-between",
     divider: "my-10 border-t border-gray-300",
     dangerTitle: "font-bold text-red-500",
@@ -26,6 +26,10 @@ export const settingsPageStyles = {
         "h-12 w-40 rounded-full border border-red-500 text-red-500 font-semibold",
     deleteMemberButton:
         "h-12 w-40 rounded-full border border-red-500 text-red-500 font-semibold cursor-pointer transition hover:bg-red-50 hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50",
+
+    passwordInputWrapper: "relative w-full",
+    passwordToggleButton: "absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer text-zinc-500 transition-colors hover:text-zinc-700",
+    passwordInput: "w-full pr-12",
 
     modalOverlay:
         "fixed inset-0 z-50 flex items-center justify-center bg-black/40",


### PR DESCRIPTION
## 관련 이슈
노션 백로그 MC-38 참고

## 요약
- 무엇을 변경했나요?
- 왜 이 변경이 필요한가요?

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
