### PR TITLE
[Fix] 설정 페이지 닉네임 변경 시 중복 확인 동작 개선 (MC-43)

### DIFF
--- a/src/features/settings/ui/components/ProfileManagementSection.tsx
+++ b/src/features/settings/ui/components/ProfileManagementSection.tsx
@@ -5,6 +5,9 @@ import { User, Camera, Check } from "lucide-react";
 import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
 import { useNicknameValidation } from "@/features/nickname/application/hooks/useNicknameValidation";
 import { updateNickname } from "@/features/settings/infrastructure/api/settingsApi";
+import { updateMemberNickname } from "@/features/auth/application/store/authStore";
+import { useSetAtom } from "jotai";
+import { settingsAtom } from "@/features/settings/application/atoms/settingsAtom";
 
 interface ProfileManagementSectionProps {
     nickname: string;
@@ -26,6 +29,7 @@ export default function ProfileManagementSection({
         initialNickname,
     });
 
+    const setSettings = useSetAtom(settingsAtom);
     const [currentNickname, setCurrentNickname] = useState(initialNickname);
     const [isSaving, setIsSaving] = useState(false);
 
@@ -42,6 +46,20 @@ export default function ProfileManagementSection({
             await updateNickname(trimmedNickname);
 
             setCurrentNickname(trimmedNickname);
+            updateMemberNickname(trimmedNickname);
+
+            setSettings((prev) => {
+                if (!("data" in prev) || !prev.data) return prev;
+
+                return {
+                    ...prev,
+                    data: {
+                        ...prev.data,
+                        nickname: trimmedNickname,
+                    },
+                };
+            });
+
             alert("닉네임이 변경되었습니다.");
         } catch (error) {
             alert(
@@ -85,10 +103,11 @@ export default function ProfileManagementSection({
                         type="text"
                         value={nickname}
                         className={settingsPageStyles.input}
-                        onChange={(event) =>
-                            handleNicknameChange(event.target.value)
-                        }
-                        onBlur={() => validateNickname(nickname)}
+                        onChange={(e) => {
+                            const nextNickname = e.target.value;
+                            handleNicknameChange(nextNickname);
+                            validateNickname(nextNickname);
+                        }}
                         maxLength={100}
                     />
                 )}


### PR DESCRIPTION
## 관련 이슈
노션 백로그 MC-43 참고

## 요약
- 무엇을 변경했나요?
  - 설정 페이지에서 닉네임 변경 시 중복 확인이 자동으로 진행되도록 개선
  - 변경된 닉네임이 메인 페이지와 설정 페이지에 즉시 반영되도록 상태 동기화 적용
- 왜 이 변경이 필요한가요?
  - 사용자가 중복 확인 버튼을 별도로 클릭하지 않아도 닉네임을 검증할 수 있도록 UX를 개선
  - 닉네임 변경 후 화면 간 표시 정보가 일치하지 않는 문제 해결

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
