### PR TITLE
[Fix] 인증이 필요한 페이지의 비로그인 접근 제한 (MC-44)

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
@@ -30,12 +30,21 @@ import PreferenceModal from "@/features/preference/ui/components/PreferenceModal
 import GroupRecommendationPreparationStatusCard from "@/features/groupRecommendation/ui/components/GroupRecommendationPreparationStatusCard";
 import GroupRecommendationPreparationInfoCard from "@/features/groupRecommendation/ui/components/GroupRecommendationPreparationInfoCard";
 import GroupRecommendationPreparationMemberCard from "@/features/groupRecommendation/ui/components/GroupRecommendationPreparationMemberCard";
+import AuthRequiredGuard from "@/features/routeGuard/ui/components/AuthRequiredGuard";
 
 import { mockGroupRecommendationPreparation } from "@/features/groupRecommendation/ui/mock/mockGroupRecommendationPreparation";
 
 import { groupRecommendationPreparationPageStyles } from "@/ui/styles/groupRecommendationPreparationPageStyles";
 
 export default function GroupRecommendationPreparationPage() {
+    return (
+        <AuthRequiredGuard>
+            <GroupRecommendationPreparationPageContent />
+        </AuthRequiredGuard>
+    );
+}
+
+function GroupRecommendationPreparationPageContent() {
     const params = useParams<{
         groupId: string;
         sessionId: string;

--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -32,10 +32,19 @@ import {
 import GroupRecommendationResultVoteStatusCard from "@/features/groupRecommendation/ui/components/GroupRecommendationResultVoteStatusCard";
 import GroupRecommendationResultMemberList from "@/features/groupRecommendation/ui/components/GroupRecommendationResultMemberList";
 import GroupRecommendationResultCandidateCard from "@/features/groupRecommendation/ui/components/GroupRecommendationResultCandidateCard";
+import AuthRequiredGuard from "@/features/routeGuard/ui/components/AuthRequiredGuard";
 
 import { groupRecommendationResultPageStyles } from "@/ui/styles/groupRecommendationResultPageStyles";
 
 export default function GroupRecommendationResultPage() {
+    return (
+        <AuthRequiredGuard>
+            <GroupRecommendationResultPageContent />
+        </AuthRequiredGuard>
+    );
+}
+
+function GroupRecommendationResultPageContent() {
     const params = useParams<{ groupId: string; sessionId: string }>();
     const router = useRouter();
 

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -58,10 +58,19 @@ import GroupNameEditModal from "@/features/group/ui/components/GroupNameEditModa
 import GroupLocationEditModal from "@/features/group/ui/components/GroupLocationEditModal";
 import GroupDeleteModal from "@/features/group/ui/components/GroupDeleteModal";
 import GroupLeaveModal from "@/features/group/ui/components/GroupLeaveModal";
+import AuthRequiredGuard from "@/features/routeGuard/ui/components/AuthRequiredGuard";
 
 import { groupManagementPageStyles } from "@/ui/styles/groupManagementPageStyles";
 
 export default function GroupPage() {
+    return (
+        <AuthRequiredGuard>
+            <GroupPageContent />
+        </AuthRequiredGuard>
+    );
+}
+
+function GroupPageContent() {
     const router = useRouter();
 
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);

--- a/src/app/personal-recommendation/page.tsx
+++ b/src/app/personal-recommendation/page.tsx
@@ -11,6 +11,7 @@ import PersonalRecommendationPreferenceCard from "@/features/personalRecommendat
 import PersonalRecommendationHistoryPanel from "@/features/personalRecommendation/ui/components/PersonalRecommendationHistoryPanel";
 import PersonalRecommendationStartAlertModal from "@/features/personalRecommendation/ui/components/PersonalRecommendationStartAlertModal";
 import PersonalRecommendationLoadingView from "@/features/personalRecommendation/ui/components/PersonalRecommendationLoadingView";
+import AuthRequiredGuard from "@/features/routeGuard/ui/components/AuthRequiredGuard";
 
 import LocationModal from "@/features/locationSetting/ui/components/LocationModal";
 import PreferenceModal from "@/features/preference/ui/components/PreferenceModal";
@@ -30,6 +31,14 @@ import { personalRecommendationHistoryToPanelItemsMapper } from "@/features/pers
 const PERSONAL_RECOMMENDATION_LOCATION_KEY = "personal-recommendation-location";
 
 export default function PersonalRecommendationPage() {
+    return (
+        <AuthRequiredGuard>
+            <PersonalRecommendationPageContent />
+        </AuthRequiredGuard>
+    );
+}
+
+function PersonalRecommendationPageContent() {
     const [isPreferenceModalOpen, setIsPreferenceModalOpen] = useState(false);
     const [isLocationModalOpen, setIsLocationModalOpen] = useState(false);
 

--- a/src/app/personal-recommendation/result/page.tsx
+++ b/src/app/personal-recommendation/result/page.tsx
@@ -17,6 +17,7 @@ import { createLocationStorageKey } from "@/features/locationSetting/application
 
 import PersonalRecommendationResultCard from "@/features/personalRecommendation/ui/components/PersonalRecommendationResultCard";
 import PersonalRecommendationResultActionButtons from "@/features/personalRecommendation/ui/components/PersonalRecommendationResultActionButtons";
+import AuthRequiredGuard from "@/features/routeGuard/ui/components/AuthRequiredGuard";
 
 import { personalRecommendationResultPageStyles } from "@/ui/styles/personalRecommendationResultPageStyles";
 
@@ -24,6 +25,14 @@ const PERSONAL_RECOMMENDATION_LOCATION_KEY =
     "personal-recommendation-location";
 
 export default function PersonalRecommendationResultPage() {
+    return (
+        <AuthRequiredGuard>
+            <PersonalRecommendationResultPageContent />
+        </AuthRequiredGuard>
+    );
+}
+
+function PersonalRecommendationResultPageContent() {
     const router = useRouter();
 
     const member = useAtomValue(memberAtom);

--- a/src/app/preference/page.tsx
+++ b/src/app/preference/page.tsx
@@ -2,7 +2,6 @@
 
 import { preferencePageStyles } from "@/ui/styles/preferencePageStyles";
 
-import { useAuthGuard } from "@/features/routeGuard/application/hooks/useAuthGuard";
 import { usePreferenceList } from "@/features/preference/application/hooks/usePreferenceList";
 import { usePreferenceOptionList } from "@/features/preference/application/hooks/usePreferenceOptionList";
 import { usePreferenceSelection } from "@/features/preference/application/hooks/usePreferenceSelection";
@@ -17,8 +16,17 @@ import {
     requiredPreferenceGroupMeta,
 } from "@/features/preference/ui/config/preferenceOptions";
 
+import AuthRequiredGuard from "@/features/routeGuard/ui/components/AuthRequiredGuard";
+
 export default function PreferencePage() {
-    const { isAuthLoading, canAccess } = useAuthGuard();
+    return (
+        <AuthRequiredGuard>
+            <PreferencePageContent />
+        </AuthRequiredGuard>
+    );
+}
+
+function PreferencePageContent() {
     const { preferenceState } = usePreferenceList();
     const { preferenceOptionState } = usePreferenceOptionList();
     const { togglePreference } = usePreferenceSelection();
@@ -32,14 +40,6 @@ export default function PreferencePage() {
         removeFood,
     } = useDislikedFoodSearch();
     const { isSaving, savePreference } = useSavePreference();
-
-    if (isAuthLoading || !canAccess) {
-        return (
-            <div className={preferencePageStyles.loadingBox}>
-                <p>인증 상태 확인 중...</p>
-            </div>
-        );
-    }
 
     if (
         preferenceState.status === "LOADING" ||

--- a/src/app/recommendation-restaurants/page.tsx
+++ b/src/app/recommendation-restaurants/page.tsx
@@ -1,11 +1,14 @@
 import { Suspense } from "react";
 
+import AuthRequiredGuard from "@/features/routeGuard/ui/components/AuthRequiredGuard";
 import RecommendationRestaurantPageContent from "@/features/recommendationRestaurant/ui/components/RecommendationRestaurantPageContent";
 
 export default function RecommendationRestaurantPage() {
     return (
-        <Suspense fallback={<main className="min-h-screen bg-[#EEF7FC] px-16 py-12">맛집 정보를 불러오는 중입니다.</main>}>
-            <RecommendationRestaurantPageContent />
-        </Suspense>
+        <AuthRequiredGuard>
+            <Suspense fallback={<main className="min-h-screen bg-[#EEF7FC] px-16 py-12">맛집 정보를 불러오는 중입니다.</main>}>
+                <RecommendationRestaurantPageContent />
+            </Suspense>
+        </AuthRequiredGuard>
     );
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
 import { useAtomValue } from "jotai";
 
 import { getTerms } from "@/features/terms/domain/model/getTerms";
@@ -11,115 +11,113 @@ import { termsStorage } from "@/features/terms/infrastructure/storage/termsStora
 
 import { onboardingAtom } from "@/features/auth/application/selectors/authSelectors";
 import { useSubmitRequiredAgreements } from "@/features/auth/application/hooks/useSubmitRequiredAgreements";
-import { getOnboardingRoute } from "@/features/auth/application/onboarding/getOnboardingRoute";
+import { useTermsGuard } from "@/features/routeGuard/application/hooks/useTermsGuard";
 
 export default function TermsPage() {
-  const router = useRouter();
-  const terms = getTerms();
+    const router = useRouter();
+    const terms = getTerms();
 
-  const onboarding = useAtomValue(onboardingAtom);
-  const { submit, isSubmitting } = useSubmitRequiredAgreements();
+    const { canAccess } = useTermsGuard();
 
-  const shouldSubmitAgreementsToServer = onboarding?.nextStep === "REQUIRED_AGREEMENTS";
+    const onboarding = useAtomValue(onboardingAtom);
+    const { submit, isSubmitting } = useSubmitRequiredAgreements();
 
-  const [checkedMap, setCheckedMap] = useState<Record<string, boolean>>(() =>
-    Object.fromEntries(terms.map((t) => [t.name, false])),
-  );
+    const shouldSubmitAgreementsToServer =
+        onboarding?.nextStep === "REQUIRED_AGREEMENTS";
 
-  // 소셜 온보딩인데 이미 약관 단계가 아니면 맞는 페이지로 이동
-  useEffect(() => {
-    if (!onboarding) return;
-
-    if (onboarding.nextStep !== "REQUIRED_AGREEMENTS") {
-      router.replace(getOnboardingRoute(onboarding.nextStep));
-    }
-  }, [onboarding, router]);
-
-  const allChecked = terms.every((t) => checkedMap[t.name]);
-
-  const requiredAllChecked = useMemo(
-    () => terms.filter((t) => t.required).every((t) => checkedMap[t.name]),
-    [terms, checkedMap],
-  );
-
-  const handleToggle = (name: string) => {
-    setCheckedMap((prev) => ({ ...prev, [name]: !prev[name] }));
-  };
-
-  const handleToggleAll = () => {
-    const next = !allChecked;
-    setCheckedMap(Object.fromEntries(terms.map((t) => [t.name, next])));
-  };
-
-  const handleSubmit = async () => {
-    const agreements = terms.map((term) => ({
-      agreementType: term.type,
-      agreementVersion: term.version,
-      agreed: checkedMap[term.name],
-    }));
-
-    // 일반 회원가입: 서버 호출 없이 로컬에 저장
-    if (!shouldSubmitAgreementsToServer) {
-      termsStorage.save(agreements);
-      router.push("/signup/nickname");
-      return;
-    }
-
-    // 소셜 온보딩: 약관 동의 정보를 서버로 제출
-    await submit(
-      agreements
-        .filter((agreement) => agreement.agreed)
-        .map((agreement) => ({
-          agreementType: agreement.agreementType,
-          agreementVersion: agreement.agreementVersion,
-        })),
+    const [checkedMap, setCheckedMap] = useState<Record<string, boolean>>(() =>
+        Object.fromEntries(terms.map((t) => [t.name, false])),
     );
-  };
 
-  return (
-    <div className={termsPageStyles.container}>
-      <div className={termsPageStyles.card}>
-        <div className="flex flex-col items-center gap-2">
-          <h1 className={termsPageStyles.title}>약관 동의</h1>
-          <p className={termsPageStyles.description}>
-            서비스 이용을 위해 약관에 동의해주세요
-          </p>
+    const allChecked = terms.every((t) => checkedMap[t.name]);
+
+    const requiredAllChecked = useMemo(
+        () => terms.filter((t) => t.required).every((t) => checkedMap[t.name]),
+        [terms, checkedMap],
+    );
+
+    const handleToggle = (name: string) => {
+        setCheckedMap((prev) => ({ ...prev, [name]: !prev[name] }));
+    };
+
+    const handleToggleAll = () => {
+        const next = !allChecked;
+        setCheckedMap(Object.fromEntries(terms.map((t) => [t.name, next])));
+    };
+
+    const handleSubmit = async () => {
+        const agreements = terms.map((term) => ({
+            agreementType: term.type,
+            agreementVersion: term.version,
+            agreed: checkedMap[term.name],
+        }));
+
+        if (!shouldSubmitAgreementsToServer) {
+            termsStorage.save(agreements);
+            router.push("/signup/nickname");
+            return;
+        }
+
+        await submit(
+            agreements
+                .filter((agreement) => agreement.agreed)
+                .map((agreement) => ({
+                    agreementType: agreement.agreementType,
+                    agreementVersion: agreement.agreementVersion,
+                })),
+        );
+    };
+
+    if (!canAccess) {
+        return null;
+    }
+
+    return (
+        <div className={termsPageStyles.container}>
+            <div className={termsPageStyles.card}>
+                <div className="flex flex-col items-center gap-2">
+                    <h1 className={termsPageStyles.title}>약관 동의</h1>
+                    <p className={termsPageStyles.description}>
+                        서비스 이용을 위해 약관에 동의해주세요
+                    </p>
+                </div>
+
+                <div className={termsPageStyles.termList}>
+                    <label className={termsPageStyles.allAgreeRow}>
+                        <input
+                            type="checkbox"
+                            checked={allChecked}
+                            onChange={handleToggleAll}
+                            className={termsPageStyles.allAgreeCheckbox}
+                        />
+                        <span className={termsPageStyles.allAgreeLabel}>
+                            전체 동의
+                        </span>
+                    </label>
+
+                    {terms.map((termGroup) => (
+                        <TermGroupItem
+                            key={termGroup.name}
+                            termGroup={termGroup}
+                            checked={checkedMap[termGroup.name]}
+                            onToggle={() => handleToggle(termGroup.name)}
+                        />
+                    ))}
+                </div>
+
+                <button
+                    type="button"
+                    disabled={!requiredAllChecked || isSubmitting}
+                    onClick={handleSubmit}
+                    className={
+                        requiredAllChecked && !isSubmitting
+                            ? termsPageStyles.submitButton
+                            : termsPageStyles.submitButtonDisabled
+                    }
+                >
+                    {isSubmitting ? "처리 중..." : "동의하고 계속하기"}
+                </button>
+            </div>
         </div>
-
-        <div className={termsPageStyles.termList}>
-          <label className={termsPageStyles.allAgreeRow}>
-            <input
-              type="checkbox"
-              checked={allChecked}
-              onChange={handleToggleAll}
-              className={termsPageStyles.allAgreeCheckbox}
-            />
-            <span className={termsPageStyles.allAgreeLabel}>전체 동의</span>
-          </label>
-
-          {terms.map((termGroup) => (
-            <TermGroupItem
-              key={termGroup.name}
-              termGroup={termGroup}
-              checked={checkedMap[termGroup.name]}
-              onToggle={() => handleToggle(termGroup.name)}
-            />
-          ))}
-        </div>
-
-        <button
-          type="button"
-          disabled={!requiredAllChecked || isSubmitting}
-          onClick={handleSubmit}
-          className={
-            requiredAllChecked && !isSubmitting
-              ? termsPageStyles.submitButton
-              : termsPageStyles.submitButtonDisabled
-          }
-        >
-          {isSubmitting ? "처리 중..." : "동의하고 계속하기"}
-        </button>
-      </div>
-    </div>
-  );
+    );
 }

--- a/src/features/routeGuard/application/hooks/useTermsGuard.ts
+++ b/src/features/routeGuard/application/hooks/useTermsGuard.ts
@@ -1,32 +1,33 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useAtomValue } from "jotai";
 
 import { onboardingAtom } from "@/features/auth/application/selectors/authSelectors";
-import { accountStorage } from "@/features/signup/infrastructure/storage/accountStorage";
-import { termsStorage } from "@/features/terms/infrastructure/storage/termsStorage";
 import { getOnboardingRoute } from "@/features/auth/application/onboarding/getOnboardingRoute";
+import { accountStorage } from "@/features/signup/infrastructure/storage/accountStorage";
 
-export function useSignupNicknameGuard() {
+export function useTermsGuard() {
     const router = useRouter();
     const onboarding = useAtomValue(onboardingAtom);
 
-    useEffect(() => {
+    const canAccess = useMemo(() => {
         const account = accountStorage.load();
-        const savedAgreements = termsStorage.load();
 
         const isGeneralSignup =
             !!account &&
             !!account.email &&
-            !!account.emailVerificationToken &&
-            !!savedAgreements &&
-            savedAgreements.length > 0;
+            !!account.emailVerificationToken;
 
-        if (isGeneralSignup) return;
+        return (
+            isGeneralSignup ||
+            onboarding?.nextStep === "REQUIRED_AGREEMENTS"
+        );
+    }, [onboarding]);
 
-        if (onboarding?.nextStep === "REQUIRED_NICKNAME") return;
+    useEffect(() => {
+        if (canAccess) return;
 
         if (onboarding?.nextStep) {
             router.replace(getOnboardingRoute(onboarding.nextStep));
@@ -34,5 +35,9 @@ export function useSignupNicknameGuard() {
         }
 
         router.replace("/signup");
-    }, [router, onboarding]);
+    }, [canAccess, onboarding, router]);
+
+    return {
+        canAccess,
+    };
 }

--- a/src/features/routeGuard/ui/components/AuthRequiredGuard.tsx
+++ b/src/features/routeGuard/ui/components/AuthRequiredGuard.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { useAtomValue } from "jotai";
+
+import {
+    isAuthenticatedAtom,
+    isAuthLoadingAtom,
+    onboardingAtom,
+} from "@/features/auth/application/selectors/authSelectors";
+import { getOnboardingRoute } from "@/features/auth/application/onboarding/getOnboardingRoute";
+
+interface AuthRequiredGuardProps {
+    children: ReactNode;
+}
+
+export default function AuthRequiredGuard({ children }: AuthRequiredGuardProps) {
+    const router = useRouter();
+
+    const isAuthLoading = useAtomValue(isAuthLoadingAtom);
+    const isAuthenticated = useAtomValue(isAuthenticatedAtom);
+    const onboarding = useAtomValue(onboardingAtom);
+
+    useEffect(() => {
+        if (isAuthLoading) return;
+
+        if (!isAuthenticated) {
+            alert("로그인이 필요한 페이지입니다.");
+            router.replace("/");
+            return;
+        }
+
+        if (!onboarding) return;
+
+        if (onboarding.nextStep !== "READY") {
+            router.replace(getOnboardingRoute(onboarding.nextStep));
+        }
+    }, [isAuthLoading, isAuthenticated, onboarding, router]);
+
+    if (isAuthLoading || !isAuthenticated || onboarding?.nextStep !== "READY") {
+        return null;
+    }
+
+    return <>{children}</>;
+}


### PR DESCRIPTION
## 관련 이슈
노션 백로그 MC-44 참고

## 요약
- 무엇을 변경했나요?
  - 인증이 필요한 페이지에 공통 인증 가드 적용 
  - 회원가입 온보딩 단계에 맞는 접근 제어 추가

- 왜 이 변경이 필요한가요?
  - 비로그인 사용자의 보호 페이지 접근을 차단
  - 회원가입 과정을 거치지 않은 사용자가 약관 동의 및 닉네임 설정 페이지에 직접 접근하는 문제를 방지

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
