### PR TITLE
[Feat] 그룹 메뉴 추천 화면 내 페이지 이동 기능 추가 (MC-45)

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from "react";
 import { useSetAtom, useAtomValue } from "jotai";
 import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
 
 import type { GroupRecommendationReadinessUpdatedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationReadinessUpdatedEvent";
 import type { GroupRecommendationOpenedEvent } from "@/features/group/infrastructure/sse/dto/GroupRecommendationOpenedEvent";
@@ -236,6 +237,10 @@ function GroupRecommendationPreparationPageContent() {
         );
     };
 
+    const handleClickBack = () => {
+        router.push(`/group?selectedGroupId=${groupId}`);
+    };
+
     const handleClickCompletePreparation = async () => {
         if (!member) {
             alert("회원 정보를 불러오는 중입니다.");
@@ -317,6 +322,14 @@ function GroupRecommendationPreparationPageContent() {
         <>
             <main className={groupRecommendationPreparationPageStyles.container}>
                 <div className={groupRecommendationPreparationPageStyles.content}>
+                    <button
+                        type="button"
+                        onClick={handleClickBack}
+                        className={groupRecommendationPreparationPageStyles.backButton}
+                    >
+                        <ArrowLeft size={30} strokeWidth={2.5} />
+                    </button>
+
                     <h1 className={groupRecommendationPreparationPageStyles.title}>
                         그룹 메뉴 추천
                     </h1>

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -23,11 +23,6 @@ const MENUS = [
 export default function Sidebar() {
     const pathname = usePathname();
 
-    const isGroupRecommendationPage =
-        pathname.startsWith("/group/") &&
-        pathname.includes("/recommendations/") &&
-        !pathname.endsWith("/result");
-
     const isRecommendationLoading = useAtomValue(
         isPersonalRecommendationLoadingAtom,
     );
@@ -40,12 +35,6 @@ export default function Sidebar() {
         event: React.MouseEvent<HTMLAnchorElement>,
         href: string,
     ) => {
-        // 그룹 메뉴 추천 진행중에는 페이지 이동 차단
-        if (isGroupRecommendationPage) {
-            event.preventDefault();
-            alert("그룹 메뉴 추천이 진행 중에는 다른 페이지로 이동할 수 없습니다.");
-            return;
-        }
         if (!isRecommendationLoading) return;
 
         if (href === "/personal-recommendation") {

--- a/src/ui/styles/groupRecommendationPreparationPageStyles.ts
+++ b/src/ui/styles/groupRecommendationPreparationPageStyles.ts
@@ -2,6 +2,8 @@ export const groupRecommendationPreparationPageStyles = {
     container: "min-h-screen bg-white",
     content: "mx-auto w-full max-w-[1280px] px-16 py-20",
 
+    backButton:
+        "mb-8 flex h-12 w-12 items-center justify-center rounded-full bg-white text-zinc-900 shadow-sm transition hover:bg-zinc-100 cursor-pointer",
     title: "text-4xl font-bold text-zinc-900",
 
     layout: "mt-20 grid grid-cols-[minmax(0,1fr)_380px] gap-14",


### PR DESCRIPTION
## 관련 이슈
노션 백로그 MC-45 참고

## 요약
- 무엇을 변경했나요?
  - 그룹 메뉴 추천 화면에서 뒤로 가기 버튼과 사이드 메뉴를 통해 다른 페이지로 이동할 수 있도록 개선

- 왜 이 변경이 필요한가요?
  - 그룹 메뉴 추천 화면에서도 다른 화면과 동일한 내비게이션 경험을 제공
  - 사용자가 원하는 페이지로 자유롭게 이동할 수 있도록 하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
