### PR TITLE
[Feat] 인증/온보딩 페이지 상단 이동 요소 변경 (MC-46)

### DIFF
--- a/src/app/auth/find-id/page.tsx
+++ b/src/app/auth/find-id/page.tsx
@@ -2,10 +2,13 @@
 
 import FindIdForm from "@/features/findId/ui/components/FindIdForm";
 import { findIdPageStyles } from "@/ui/styles/findIdPageStyles";
+import HomeNavigationButton from "@/ui/components/HomeNavigationButton";
 
 export default function FindIdPage() {
     return (
         <main className={findIdPageStyles.page}>
+            <HomeNavigationButton />
+
             <section className={findIdPageStyles.card}>
                 <h1 className={findIdPageStyles.title}>아이디 찾기</h1>
                 <FindIdForm />

--- a/src/app/auth/find-password/page.tsx
+++ b/src/app/auth/find-password/page.tsx
@@ -8,6 +8,7 @@ import {
     resetPasswordAtom,
 } from "@/features/resetPassword/application/atoms/resetPasswordAtom";
 import { resetPasswordPageStyles } from "@/ui/styles/resetPasswordPageStyles";
+import HomeNavigationButton from "@/ui/components/HomeNavigationButton";
 
 export default function FindPasswordPage() {
     const setResetPasswordState = useSetAtom(resetPasswordAtom);
@@ -18,6 +19,8 @@ export default function FindPasswordPage() {
 
     return (
         <main className={resetPasswordPageStyles.page}>
+            <HomeNavigationButton />
+
             <section className={resetPasswordPageStyles.card}>
                 <h1 className={resetPasswordPageStyles.title}>비밀번호 찾기</h1>
                 <ResetPasswordForm />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -13,6 +13,7 @@ import {
     isAuthenticatedAtom,
     isAuthLoadingAtom,
 } from "@/features/auth/application/selectors/authSelectors";
+import HomeNavigationButton from "@/ui/components/HomeNavigationButton";
 
 const providers: AuthProvider[] = ["GOOGLE", "KAKAO", "NAVER"];
 
@@ -52,6 +53,8 @@ export default function LoginPage() {
 
     return (
         <div className={loginPageStyles.container}>
+            <HomeNavigationButton />
+
             <div className={loginPageStyles.card}>
                 <div className="flex w-full flex-col gap-1">
                     <h1 className={loginPageStyles.title}>로그인</h1>

--- a/src/app/signup/nickname/page.tsx
+++ b/src/app/signup/nickname/page.tsx
@@ -11,7 +11,9 @@ import { signupApi } from "@/features/signup/infrastructure/api/signupApi"
 import { onboardingAtom } from "@/features/auth/application/selectors/authSelectors";
 import { useSubmitMyNickname } from "@/features/auth/application/hooks/useSubmitMyNickname";
 import { useNicknameValidation } from "@/features/nickname/application/hooks/useNicknameValidation";
-import { useSignupNicknameGuard } from "@/features/signup/application/hooks/useSignupNicknameGuard"; // ✅ 추가
+import { useSignupNicknameGuard } from "@/features/signup/application/hooks/useSignupNicknameGuard";
+
+import HomeNavigationButton from "@/ui/components/HomeNavigationButton";
 
 export default function NicknamePage() {
     const router = useRouter();
@@ -98,6 +100,8 @@ export default function NicknamePage() {
 
     return (
         <div className={nicknamePageStyles.container}>
+            <HomeNavigationButton />
+
             <div className={nicknamePageStyles.card}>
                 <div className="flex flex-col gap-1 w-full">
                     <h1 className={nicknamePageStyles.title}>닉네임 설정</h1>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -4,7 +4,9 @@ import { useRouter } from "next/navigation";
 
 import { signupPageStyles } from "@/ui/styles/signupPageStyles";
 import type { AuthProvider } from "@/features/auth/domain/model/AuthProvider";
+
 import SocialLoginButton from "@/features/auth/ui/components/SocialLoginButton";
+import HomeNavigationButton from "@/ui/components/HomeNavigationButton";
 
 import { accountStorage } from "@/features/signup/infrastructure/storage/accountStorage";
 import { useLoginIdValidation } from "@/features/signup/application/hooks/useLoginIdValidation";
@@ -130,10 +132,7 @@ export default function SignupPage() {
 
     return (
         <div className={signupPageStyles.container}>
-            {/* 로고 */}
-            <div className="absolute top-20 flex items-center gap-2 text-2xl font-semibold text-black">
-                <span>Matchuri</span>
-            </div>
+            <HomeNavigationButton />
 
             <div className={signupPageStyles.card}>
                 {/* 제목 */}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -13,6 +13,8 @@ import { onboardingAtom } from "@/features/auth/application/selectors/authSelect
 import { useSubmitRequiredAgreements } from "@/features/auth/application/hooks/useSubmitRequiredAgreements";
 import { useTermsGuard } from "@/features/routeGuard/application/hooks/useTermsGuard";
 
+import HomeNavigationButton from "@/ui/components/HomeNavigationButton";
+
 export default function TermsPage() {
     const router = useRouter();
     const terms = getTerms();
@@ -74,6 +76,8 @@ export default function TermsPage() {
 
     return (
         <div className={termsPageStyles.container}>
+            <HomeNavigationButton />
+
             <div className={termsPageStyles.card}>
                 <div className="flex flex-col items-center gap-2">
                     <h1 className={termsPageStyles.title}>약관 동의</h1>

--- a/src/ui/components/HomeNavigationButton.tsx
+++ b/src/ui/components/HomeNavigationButton.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import Link from "next/link";
+import { House } from "lucide-react";
+
+export default function HomeNavigationButton() {
+    return (
+        <Link
+            href="/"
+            className="absolute left-10 top-10 flex items-center gap-2 text-sm font-semibold text-slate-700 transition hover:text-slate-900"
+        >
+            <House className="h-4 w-4" />
+            홈으로 가기
+        </Link>
+    );
+}

--- a/src/ui/layout/AppLayout.tsx
+++ b/src/ui/layout/AppLayout.tsx
@@ -2,6 +2,7 @@
 
 import { Provider, useAtomValue } from "jotai";
 import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
 
 import { jotaiStore } from "@/shared/lib/jotaiStore";
 import AuthInitializer from "@/features/auth/ui/components/AuthInitializer";
@@ -14,13 +15,26 @@ import {
 import Navbar from "@/ui/components/Navbar";
 import Sidebar from "@/ui/components/Sidebar";
 
+const authNavigationHiddenPaths = [
+    "/login",
+    "/signup",
+    "/terms",
+    "/signup/nickname",
+    "/auth/find-id",
+    "/auth/find-password",
+];
+
 function AppContent({ children }: { children: ReactNode }) {
+    const pathname = usePathname();
+
     const isAuthenticated = useAtomValue(isAuthenticatedAtom);
     const isAuthLoading = useAtomValue(isAuthLoadingAtom);
     const isOnboardingReady = useAtomValue(isOnboardingReadyAtom);
 
     const showMemberLayout =
-      !isAuthLoading && isAuthenticated && isOnboardingReady;
+        !isAuthLoading && isAuthenticated && isOnboardingReady;
+
+    const hideNavbar = authNavigationHiddenPaths.includes(pathname);
 
     if (isAuthLoading) {
         return null;
@@ -28,7 +42,7 @@ function AppContent({ children }: { children: ReactNode }) {
 
     return (
         <>
-            <Navbar />
+            {!hideNavbar && <Navbar />}
             {showMemberLayout && <Sidebar />}
 
             <main
@@ -37,7 +51,7 @@ function AppContent({ children }: { children: ReactNode }) {
                     showMemberLayout ? "ml-[280px]" : "",
                 ].join(" ")}
             >
-            {children}
+                {children}
             </main>
         </>
     );


### PR DESCRIPTION
## 관련 이슈
노션 백로그 MC-46 참고

## 요약
- 무엇을 변경했나요?
  - 인증 관련 페이지(로그인, 회원가입, 약관 동의, 닉네임 설정, 아이디 찾기, 비밀번호 찾기)의 상단 로고 및 로그인 버튼을 제거
  - 메인 화면으로 이동하는 홈으로 가기 버튼을 추가
- 왜 이 변경이 필요한가요?
  - 인증 관련 페이지의 상단 UI를 일관성 있게 구성하고, 사용자가 언제든 비로그인 메인 화면으로 쉽게 이동

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
