### PR TITLE
[Feat] 소셜 로그인 사용자의 설정 페이지에 이메일 표시 기능 추가 (MC-52)

### DIFF
--- a/src/features/settings/ui/components/AccountManagementSection.tsx
+++ b/src/features/settings/ui/components/AccountManagementSection.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from "react";
 import { Shield, Save, Eye, EyeOff } from "lucide-react";
-import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
+
 import { useChangePassword } from "@/features/settings/application/hooks/useChangePassword";
+import { settingsPageStyles } from "@/ui/styles/settingsPageStyles";
 
 interface AccountManagementSectionProps {
     userId?: number;
@@ -38,6 +39,8 @@ export default function AccountManagementSection({
     const [showNewPassword, setShowNewPassword] = useState(false);
     const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
+    const displayEmail = email?.trim() || "이메일 정보 없음";
+
     return (
         <section className={settingsPageStyles.section}>
             <h2 className={settingsPageStyles.sectionTitle}>
@@ -49,7 +52,11 @@ export default function AccountManagementSection({
                 <>
                     <div className={settingsPageStyles.formGroup}>
                         <div className={settingsPageStyles.skeletonDisabledInput} />
-                        <div className={settingsPageStyles.skeletonDisabledInputWithMargin} />
+                        <div
+                            className={
+                                settingsPageStyles.skeletonDisabledInputWithMargin
+                            }
+                        />
                         <div className={settingsPageStyles.skeletonInput} />
                         <div className={settingsPageStyles.skeletonInput} />
                     </div>
@@ -61,136 +68,158 @@ export default function AccountManagementSection({
                     <div className={settingsPageStyles.divider} />
                 </>
             ) : (
-                showPasswordFields && (
-                    <>
+                <>
+                    {showPasswordFields ? (
+                        <>
+                            <div className={settingsPageStyles.formGroup}>
+                                <div className={settingsPageStyles.disabledInput}>
+                                    <p className="mb-2 text-xs font-semibold uppercase">
+                                        USER ID
+                                    </p>
+                                    <p>{userId ?? "사용자 정보 없음"}</p>
+                                </div>
+
+                                <div
+                                    className={`${settingsPageStyles.disabledInput} mb-4`}
+                                >
+                                    <p className="mb-2 text-xs font-semibold uppercase">
+                                        EMAIL
+                                    </p>
+                                    <p>{displayEmail}</p>
+                                </div>
+
+                                <label className={settingsPageStyles.label}>
+                                    현재 비밀번호
+                                </label>
+
+                                <div className={settingsPageStyles.passwordInputWrapper}>
+                                    <input
+                                        type={showCurrentPassword ? "text" : "password"}
+                                        value={currentPassword}
+                                        onChange={(event) => setCurrentPassword(event.target.value)}
+                                        placeholder="••••••••••••"
+                                        className={`${settingsPageStyles.input} ${settingsPageStyles.passwordInput}`}
+                                    />
+
+                                    <button
+                                        type="button"
+                                        onClick={() =>setShowCurrentPassword((prev) => !prev)}
+                                        className={settingsPageStyles.passwordToggleButton}
+                                        aria-label={
+                                            showCurrentPassword
+                                                ? "현재 비밀번호 숨기기"
+                                                : "현재 비밀번호 보기"
+                                        }
+                                    >
+                                        {showCurrentPassword ? (<Eye size={22} />) : (<EyeOff size={22} />)}
+                                    </button>
+                                </div>
+
+                                <label className={settingsPageStyles.label}>
+                                    새로운 비밀번호
+                                </label>
+
+                                <div className={settingsPageStyles.passwordInputWrapper}>
+                                    <input
+                                        type={showNewPassword ? "text" : "password"}
+                                        value={newPassword}
+                                        onChange={(event) =>setNewPassword(event.target.value)}
+                                        placeholder="••••••••••••"
+                                        className={`${settingsPageStyles.input} ${settingsPageStyles.passwordInput}`}
+                                    />
+
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowNewPassword((prev) => !prev)}
+                                        className={settingsPageStyles.passwordToggleButton}
+                                        aria-label={
+                                            showNewPassword
+                                                ? "새 비밀번호 숨기기"
+                                                : "새 비밀번호 보기"
+                                        }
+                                    >
+                                        {showNewPassword ? (<Eye size={22} />) : (<EyeOff size={22} />)}
+                                    </button>
+                                </div>
+
+                                {passwordMessage && (
+                                    <p className="text-sm text-red-500">
+                                        {passwordMessage}
+                                    </p>
+                                )}
+
+                                <label className={settingsPageStyles.label}>
+                                    비밀번호 확인
+                                </label>
+
+                                <div className={settingsPageStyles.passwordInputWrapper}>
+                                    <input
+                                        type={showConfirmPassword? "text": "password"}
+                                        value={newPasswordConfirm}
+                                        onChange={(event) => setNewPasswordConfirm(event.target.value)}
+                                        placeholder="••••••••••••"
+                                        className={`${settingsPageStyles.input} ${settingsPageStyles.passwordInput}`}
+                                    />
+
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowConfirmPassword((prev) => !prev)}
+                                        className={settingsPageStyles.passwordToggleButton}
+                                        aria-label={
+                                            showConfirmPassword
+                                                ? "비밀번호 확인 숨기기"
+                                                : "비밀번호 확인 보기"
+                                        }
+                                    >
+                                        {showConfirmPassword ? (<Eye size={22} />) : (<EyeOff size={22} />)}
+                                    </button>
+                                </div>
+
+                                {confirmMessage && (
+                                    <p className="text-sm text-red-500">
+                                        {confirmMessage}
+                                    </p>
+                                )}
+                            </div>
+
+                            <div
+                                className={
+                                    settingsPageStyles.saveButtonWrapper
+                                }
+                            >
+                                <button
+                                    type="button"
+                                    onClick={submit}
+                                    disabled={!canChangePassword}
+                                    className={`${settingsPageStyles.saveButton} disabled:cursor-not-allowed disabled:opacity-50`}
+                                >
+                                    {isSaving ? "저장 중..." : "저장"}
+                                    <Save size={18} />
+                                </button>
+                            </div>
+                        </>
+                    ) : (
                         <div className={settingsPageStyles.formGroup}>
                             <div className={settingsPageStyles.disabledInput}>
                                 <p className="mb-2 text-xs font-semibold uppercase">
-                                    USER ID
-                                </p>
-                                <p>{userId}</p>
-                            </div>
-
-                            <div className={`${settingsPageStyles.disabledInput} mb-4`}>
-                                <p className="mb-2 text-xs font-semibold uppercase">
                                     EMAIL
                                 </p>
-                                <p>{email}</p>
+                                <p>{displayEmail}</p>
                             </div>
-
-                            <label className={settingsPageStyles.label}>
-                                현재 비밀번호
-                            </label>
-                            <div className={settingsPageStyles.passwordInputWrapper}>
-                                <input
-                                    type={showCurrentPassword ? "text" : "password"}
-                                    value={currentPassword}
-                                    onChange={(event) => setCurrentPassword(event.target.value)}
-                                    placeholder="••••••••••••"
-                                    className={`${settingsPageStyles.input} ${settingsPageStyles.passwordInput}`}
-                                />
-
-                                <button
-                                    type="button"
-                                    onClick={() => setShowCurrentPassword((prev) => !prev)}
-                                    className={settingsPageStyles.passwordToggleButton}
-                                    aria-label={
-                                        showCurrentPassword
-                                            ? "현재 비밀번호 숨기기"
-                                            : "현재 비밀번호 보기"
-                                    }
-                                >
-                                    {showCurrentPassword ? <Eye size={22} /> : <EyeOff size={22} />}
-                                </button>
-                            </div>
-
-                            <label className={settingsPageStyles.label}>
-                                새로운 비밀번호
-                            </label>
-                            <div className={settingsPageStyles.passwordInputWrapper}>
-                                <input
-                                    type={showNewPassword ? "text" : "password"}
-                                    value={newPassword}
-                                    onChange={(event) => setNewPassword(event.target.value)}
-                                    placeholder="••••••••••••"
-                                    className={`${settingsPageStyles.input} ${settingsPageStyles.passwordInput}`}
-                                />
-
-                                <button
-                                    type="button"
-                                    onClick={() => setShowNewPassword((prev) => !prev)}
-                                    className={settingsPageStyles.passwordToggleButton}
-                                    aria-label={
-                                        showNewPassword
-                                            ? "새 비밀번호 숨기기"
-                                            : "새 비밀번호 보기"
-                                    }
-                                >
-                                    {showNewPassword ? <Eye size={22} /> : <EyeOff size={22} />}
-                                </button>
-                            </div>
-
-                            {passwordMessage && (
-                                <p className="text-sm text-red-500">
-                                    {passwordMessage}
-                                </p>
-                            )}
-
-                            <label className={settingsPageStyles.label}>
-                                비밀번호 확인
-                            </label>
-                            <div className={settingsPageStyles.passwordInputWrapper}>
-                                <input
-                                    type={showConfirmPassword ? "text" : "password"}
-                                    value={newPasswordConfirm}
-                                    onChange={(event) => setNewPasswordConfirm(event.target.value)}
-                                    placeholder="••••••••••••"
-                                    className={`${settingsPageStyles.input} ${settingsPageStyles.passwordInput}`}
-                                />
-
-                                <button
-                                    type="button"
-                                    onClick={() => setShowConfirmPassword((prev) => !prev)}
-                                    className={settingsPageStyles.passwordToggleButton}
-                                    aria-label={
-                                        showConfirmPassword
-                                            ? "비밀번호 확인 숨기기"
-                                            : "비밀번호 확인 보기"
-                                    }
-                                >
-                                    {showConfirmPassword ? <Eye size={22} /> : <EyeOff size={22} />}
-                                </button>
-                            </div>
-
-                            {confirmMessage && (
-                                <p className="text-sm text-red-500">
-                                    {confirmMessage}
-                                </p>
-                            )}
                         </div>
+                    )}
 
-                        <div className={settingsPageStyles.saveButtonWrapper}>
-                            <button
-                                type="button"
-                                onClick={submit}
-                                disabled={!canChangePassword}
-                                className={`${settingsPageStyles.saveButton} disabled:cursor-not-allowed disabled:opacity-50`}
-                            >
-                                {isSaving ? "저장 중..." : "저장"}
-                                <Save size={18} />
-                            </button>
-                        </div>
-
-                        <div className={settingsPageStyles.divider} />
-                    </>
-                )
+                    <div className={settingsPageStyles.divider} />
+                </>
             )}
 
             <div className={settingsPageStyles.accountRow}>
                 <div>
-                    <p className={settingsPageStyles.dangerTitle}>회원 탈퇴</p>
+                    <p className={settingsPageStyles.dangerTitle}>
+                        회원 탈퇴
+                    </p>
                     <p className={settingsPageStyles.dangerDescription}>
-                        계정과 및 데이터를 영구적으로 삭제합니다.
+                        계정 및 데이터를 영구적으로 삭제합니다.
                     </p>
                 </div>
 


### PR DESCRIPTION
## 노션 백로그
MC-52

## 요약
- 무엇을 변경했나요?
  - 소셜 로그인 사용자가 설정 페이지의 계정 관리 영역에서 계정에 연결된 이메일을 확인할 수 있도록 이메일 표시 기능을 추가

- 왜 이 변경이 필요한가요?
  - 현재 로그인한 계정의 이메일을 확인할 수 있도록 사용자 편의성을 개선

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
