### PR TITLE
[Fix] 개인 위치 미설정 상태의 조회 오류 처리 수정 (MC-64)

### DIFF
--- a/src/features/locationSetting/infrastructure/api/locationSettingApi.ts
+++ b/src/features/locationSetting/infrastructure/api/locationSettingApi.ts
@@ -1,4 +1,4 @@
-import { HttpError, httpClient } from "@/infrastructure/http/httpClient";
+import { httpClient } from "@/infrastructure/http/httpClient";
 
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
 import type { MemberLocationResponse } from "@/features/locationSetting/infrastructure/api/dto/MemberLocationResponse";
@@ -6,39 +6,30 @@ import type { SaveMemberLocationRequest } from "@/features/locationSetting/infra
 
 import { mapMemberLocation } from "@/features/locationSetting/infrastructure/api/mapper/memberLocationMapper";
 
-const MEMBER_LOCATION_NOT_FOUND = "MEMBER_LOCATION_NOT_FOUND";
 const DEFAULT_RADIUS_METERS = 1000;
 const DEFAULT_MAP_LEVEL = 4;
 
 export const locationSettingApi = {
     async fetchMyLocation(): Promise<LocationSetting | null> {
-        try {
-            const response = await httpClient.get<MemberLocationResponse>(
-                "/api/v1/members/me/location",
+        const response = await httpClient.get<MemberLocationResponse>(
+            "/api/v1/members/me/location",
+        );
+
+        if (!response.success) {
+            throw new Error(
+                response.error?.message ??
+                    "개인 위치 정보를 불러오지 못했습니다.",
             );
-
-            if (!response.success || !response.data) {
-                throw new Error(
-                    response.error?.message ??
-                        "개인 위치 정보를 불러오지 못했습니다.",
-                );
-            }
-
-            return mapMemberLocation(
-                response.data,
-                DEFAULT_MAP_LEVEL,
-            );
-        } catch (error) {
-            if (
-                error instanceof HttpError &&
-                error.body?.error?.code ===
-                    MEMBER_LOCATION_NOT_FOUND
-            ) {
-                return null;
-            }
-
-            throw error;
         }
+
+        if (response.data === null) {
+            return null;
+        }
+
+        return mapMemberLocation(
+            response.data,
+            DEFAULT_MAP_LEVEL,
+        );
     },
 
     async saveMyLocation(


### PR DESCRIPTION
## 노션 백로그
MC-64

## 요약
- 무엇을 변경했나요?
  - 개인 위치 조회 API가 data: null을 반환하는 경우, 이를 오류가 아닌 위치 미설정 상태로 처리하도록 수정
- 왜 이 변경이 필요한가요?
  - 저장된 위치가 없는 정상적인 사용자에게 조회 오류 메시지가 표시되는 것을 방지하고 화면에서 위치 미설정 상태를 올바르게 안내하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
