### PR TITLE
[Feat] 자체 로그인에 Google reCAPTCHA v3 연동 (MC-55)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_MATCHURI_BACKEND_ORIGIN=https://api.example.test
 NEXT_PUBLIC_KAKAO_MAP_APP_KEY=dummy-kakao-map-app-key
+NEXT_PUBLIC_RECAPTCHA_SITE_KEY=dummy-recaptcha-site-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,22 @@
-<!-- BEGIN:nextjs-agent-rules -->
-# This is NOT the Next.js you know
+# Frontend Agent Router
 
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
-<!-- END:nextjs-agent-rules -->
+프론트엔드 작업 전에는 루트 `AGENTS.md`를 확인한 뒤 아래 기준 문서만 필요한 만큼 엽니다.
+
+- 프론트엔드 기준: `../docs/frontend/index.md`
+- 구현 가이드: `../docs/frontend/guide.md`
+- API 기준: `../docs/api/index.md`
+- API 상태표: `../docs/api/api-status.md`
+- FE/BE API 계약 동기화 스킬: `../.agents/skills/matchuri-api-contract-sync/SKILL.md`
+
+## Source Of Truth
+
+- API 소비 계약은 `src/features/**/infrastructure/api/`와 `dto/`를 우선합니다.
+- 도메인 타입은 `src/features/**/domain/`을 우선합니다.
+
+## Layer Invariant
+
+- 의존성 흐름: `domain/types -> config -> infrastructure/api -> application -> ui`.
+- 하위 레이어는 상위 레이어를 import하지 않습니다.
+- `domain`과 `infrastructure`는 `ui`를 참조하지 않습니다.
+
+Next.js는 현재 버전의 변경 사항이 클 수 있으므로, 코드 작성 전에 로컬 패키지 문서나 설치된 타입을 우선 확인합니다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "jotai": "^2.19.1",
         "lucide-react": "^1.8.0",
         "next": "^16.2.9",
+        "next-recaptcha-v3": "^1.5.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "tailwind-merge": "^3.5.0",
@@ -5112,6 +5113,19 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-recaptcha-v3": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/next-recaptcha-v3/-/next-recaptcha-v3-1.5.3.tgz",
+      "integrity": "sha512-Osnt1gj0+Mor8rc42NCzpteQrrSbcxskGLOeWLU/T0xdXtJE90y/gFyp87/yN1goIMI+gXs5f0PMymMa29nuLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": "^13 || ^14 || ^15 || ^16",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/node-exports-info": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "jotai": "^2.19.1",
     "lucide-react": "^1.8.0",
     "next": "^16.2.9",
+    "next-recaptcha-v3": "^1.5.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "tailwind-merge": "^3.5.0",

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { ReCaptchaProvider } from "next-recaptcha-v3";
+
+import { clientEnv } from "@/infrastructure/config/env";
+
+export default function LoginLayout({ children }: { children: ReactNode }) {
+    return (
+        <ReCaptchaProvider reCaptchaKey={clientEnv.captchaSiteKey}>
+            {children}
+        </ReCaptchaProvider>
+    );
+}

--- a/src/features/auth/application/hooks/useLogin.ts
+++ b/src/features/auth/application/hooks/useLogin.ts
@@ -5,9 +5,11 @@ import { useRouter } from "next/navigation";
 import { HttpError } from "@/infrastructure/http/httpClient";
 import { login } from "@/features/auth/application/usecase/login";
 import { getOnboardingRoute } from "@/features/auth/application/onboarding/getOnboardingRoute";
+import { useLoginCaptcha } from "@/features/auth/infrastructure/recaptcha/useLoginCaptcha";
 
 export function useLogin() {
     const router = useRouter();
+    const { execute: executeCaptcha, errorMessage: captchaErrorMessage, isReady: isCaptchaReady, } = useLoginCaptcha();
 
     const [loginId, setLoginId] = useState("");
     const [password, setPassword] = useState("");
@@ -15,8 +17,10 @@ export function useLogin() {
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const isValid = useMemo(() => {
-        return loginId.trim().length > 0 && password.trim().length > 0;
-    }, [loginId, password]);
+        return loginId.trim().length > 0
+            && password.trim().length > 0
+            && isCaptchaReady;
+    }, [isCaptchaReady, loginId, password]);
 
     const submit = useCallback(async () => {
         if (!isValid || isSubmitting) return;
@@ -24,15 +28,32 @@ export function useLogin() {
         setIsSubmitting(true);
         setErrorMessage(null);
 
+        const recaptchaToken = await executeCaptcha();
+        if (!recaptchaToken) {
+            setIsSubmitting(false);
+            return;
+        }
+
         try {
             const response = await login({
                 loginId: loginId.trim(),
                 password,
+                recaptchaToken,
             });
 
             router.replace(getOnboardingRoute(response.data.onboarding.nextStep));
         } catch (error) {
-            if (error instanceof HttpError && error.status === 401) {
+            const errorCode = error instanceof HttpError
+                ? error.body?.error?.code
+                : undefined;
+
+            if (errorCode === "AUTH_CAPTCHA_VERIFICATION_FAILED") {
+                setErrorMessage("자동입력 방지 확인에 실패했습니다. 다시 시도해주세요.");
+            } else if (errorCode === "AUTH_CAPTCHA_SERVICE_UNAVAILABLE") {
+                setErrorMessage(
+                    "자동입력 방지 서비스를 사용할 수 없습니다. 잠시 후 다시 시도해주세요.",
+                );
+            } else if (error instanceof HttpError && error.status === 401) {
                 setErrorMessage("아이디 또는 비밀번호가 올바르지 않습니다.");
             } else {
                 setErrorMessage("로그인에 실패했습니다.");
@@ -40,14 +61,14 @@ export function useLogin() {
         } finally {
             setIsSubmitting(false);
         }
-    }, [isSubmitting, isValid, loginId, password, router]);
+    }, [executeCaptcha, isSubmitting, isValid, loginId, password, router]);
 
     return {
         loginId,
         setLoginId,
         password,
         setPassword,
-        errorMessage,
+        errorMessage: captchaErrorMessage ?? errorMessage,
         isSubmitting,
         isValid,
         submit,

--- a/src/features/auth/application/hooks/useLogin.ts
+++ b/src/features/auth/application/hooks/useLogin.ts
@@ -38,7 +38,7 @@ export function useLogin() {
             const response = await login({
                 loginId: loginId.trim(),
                 password,
-                recaptchaToken,
+                captchaToken: recaptchaToken,
             });
 
             router.replace(getOnboardingRoute(response.data.onboarding.nextStep));

--- a/src/features/auth/domain/model/LoginRequest.ts
+++ b/src/features/auth/domain/model/LoginRequest.ts
@@ -1,4 +1,5 @@
 export interface LoginRequest {
     readonly loginId: string;
     readonly password: string;
+    readonly recaptchaToken: string;
 }

--- a/src/features/auth/domain/model/LoginRequest.ts
+++ b/src/features/auth/domain/model/LoginRequest.ts
@@ -1,5 +1,5 @@
 export interface LoginRequest {
     readonly loginId: string;
     readonly password: string;
-    readonly recaptchaToken: string;
+    readonly captchaToken: string;
 }

--- a/src/features/auth/infrastructure/recaptcha/useLoginCaptcha.ts
+++ b/src/features/auth/infrastructure/recaptcha/useLoginCaptcha.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { useReCaptcha } from "next-recaptcha-v3";
+
+const LOGIN_RECAPTCHA_ACTION = "login";
+const RECAPTCHA_LOAD_ERROR_MESSAGE = "자동입력 방지 확인을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.";
+const RECAPTCHA_PREPARING_MESSAGE = "자동입력 방지 확인을 준비하고 있습니다. 잠시 후 다시 시도해주세요.";
+const RECAPTCHA_EXECUTION_ERROR_MESSAGE = "자동입력 방지 확인에 실패했습니다. 잠시 후 다시 시도해주세요.";
+
+export function useLoginCaptcha() {
+    const { executeRecaptcha, loaded: isLoaded, error: loadError, } = useReCaptcha();
+    const isExecutingRef = useRef(false);
+    const [executionErrorMessage, setExecutionErrorMessage] = useState<string | null>(null);
+
+    const execute = useCallback(async (): Promise<string | null> => {
+        if (!isLoaded || loadError || isExecutingRef.current) {
+            setExecutionErrorMessage(
+                loadError
+                    ? RECAPTCHA_LOAD_ERROR_MESSAGE
+                    : RECAPTCHA_PREPARING_MESSAGE,
+            );
+            return null;
+        }
+
+        isExecutingRef.current = true;
+        setExecutionErrorMessage(null);
+
+        try {
+            const token = await executeRecaptcha(LOGIN_RECAPTCHA_ACTION);
+            if (!token) {
+                throw new Error("reCAPTCHA token is empty");
+            }
+            return token;
+        } catch {
+            setExecutionErrorMessage(RECAPTCHA_EXECUTION_ERROR_MESSAGE);
+            return null;
+        } finally {
+            isExecutingRef.current = false;
+        }
+    }, [executeRecaptcha, isLoaded, loadError]);
+
+    return {
+        execute,
+        errorMessage: loadError
+            ? RECAPTCHA_LOAD_ERROR_MESSAGE
+            : executionErrorMessage,
+        isReady: isLoaded && !loadError,
+    };
+}

--- a/src/infrastructure/config/env.ts
+++ b/src/infrastructure/config/env.ts
@@ -1,6 +1,7 @@
 const clientValues = {
   apiBaseUrl: process.env.NEXT_PUBLIC_MATCHURI_BACKEND_ORIGIN,
   kakaoMapAppKey: process.env.NEXT_PUBLIC_KAKAO_MAP_APP_KEY,
+  captchaSiteKey: process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY,
 } as const;
 
 // 필수 값 체크 (fail-fast)
@@ -17,4 +18,5 @@ if (missing.length > 0) {
 export const clientEnv = {
   apiBaseUrl: clientValues.apiBaseUrl!,
   kakaoMapAppKey: clientValues.kakaoMapAppKey!,
+  captchaSiteKey: clientValues.captchaSiteKey!,
 } as const;


### PR DESCRIPTION
## 관련 이슈
MC-55

## 요약
- 로그인 경로에만 `ReCaptchaProvider`를 배치하고 `next-recaptcha-v3` 의존성을 추가했습니다.
- `useLoginCaptcha`가 reCAPTCHA 로드 상태, `login` action 토큰 발급, 실행 오류를 담당하도록 분리했습니다.
- `useLogin`이 CAPTCHA 실행과 로그인 요청을 조율하되 로그인 페이지가 사용하는 상태/함수 계약은 유지했습니다.
- 로그인 요청에 `recaptchaToken`을 포함하고 `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` 환경 설정을 추가했습니다.
- 기존 FE 구조와 로그인 UI 변경을 최소화하면서 자체 로그인에 자동화 요청 방어를 적용하기 위한 변경입니다.

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [x] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

`next-recaptcha-v3`만 기능 구현에 필요한 의존성으로 추가했으며, 환경 변수 예시와 FE 작업 지침을 함께 갱신했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

`npm run test`는 현재 `package.json`에 test 스크립트가 없어 실행 대상이 없습니다.

## UI 증빙
- [x] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

가시적인 UI 변경은 없으며 기존 `page.tsx`는 변경하지 않아 증빙 대상이 아닙니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분: `page.tsx → useLogin → useLoginCaptcha` 책임 분리, CAPTCHA 준비 상태와 로그인 제출 상태의 결합, BE 오류 코드별 사용자 메시지
- 알려진 제한 사항: 자체 로그인에만 적용하며 OAuth 로그인은 범위에서 제외합니다. 실행 환경에 `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` 설정이 필요합니다.