### PR TITLE
[Fix] 로그인 화면 이탈 후 reCAPTCHA 배지 노출 문제 수정 (MC-75)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,3 +23,7 @@ body {
     color: var(--foreground);
     font-family: var(--font-noto-sans), Arial, Helvetica, sans-serif;
 }
+
+.grecaptcha-badge {
+    visibility: hidden;
+}

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -2,10 +2,12 @@ import type { ReactNode } from "react";
 import { ReCaptchaProvider } from "next-recaptcha-v3";
 
 import { clientEnv } from "@/infrastructure/config/env";
+import LoginReCaptchaBadge from "@/features/auth/ui/components/LoginReCaptchaBadge";
 
-export default function LoginLayout({ children }: { children: ReactNode }) {
+export default function LoginLayout({children}: {children: ReactNode}) {
     return (
         <ReCaptchaProvider reCaptchaKey={clientEnv.captchaSiteKey}>
+            <LoginReCaptchaBadge />
             {children}
         </ReCaptchaProvider>
     );

--- a/src/features/auth/ui/components/LoginReCaptchaBadge.tsx
+++ b/src/features/auth/ui/components/LoginReCaptchaBadge.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+
+function setBadgeVisibility(visibility: "visible" | "hidden") {
+    document
+        .querySelectorAll<HTMLElement>(".grecaptcha-badge")
+        .forEach((badge) => {
+            badge.style.visibility = visibility;
+        });
+}
+
+export default function LoginReCaptchaBadge() {
+    useEffect(() => {
+        const showBadge = () => {
+            setBadgeVisibility("visible");
+        };
+
+        showBadge();
+
+        const observer = new MutationObserver(showBadge);
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+        });
+
+        return () => {
+            observer.disconnect();
+            setBadgeVisibility("hidden");
+        };
+    }, []);
+
+    return null;
+}


### PR DESCRIPTION
## 노션 백로그
MC-75

## 요약
- 무엇을 변경했나요?
  - 로그인 화면에서만 reCAPTCHA 배지가 표시되고, 다른 페이지로 이동하면 배지가 숨겨지도록 수정

- 왜 이 변경이 필요한가요?
  - 로그인 화면에서 로드된 reCAPTCHA 배지가 클라이언트 페이지 이동 후에도 다른 화면에 계속 노출되는 문제를 해결

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
