### PR TITLE
[Feat] 위치 반경 기반 맛집 탐색 및 추천 결과 화면 개선

### DIFF
--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -265,6 +265,7 @@ function GroupRecommendationResultPageContent() {
             menuName: finalCandidate.menuName,
             latitude: String(groupDetail.location.latitude),
             longitude: String(groupDetail.location.longitude),
+            radiusMeters: String(groupDetail.location.radiusMeters),
             level: "4",
             source: "group",
         });

--- a/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
+++ b/src/app/group/[groupId]/recommendations/[sessionId]/result/page.tsx
@@ -237,8 +237,17 @@ function GroupRecommendationResultPageContent() {
     };
 
     const handleClickCloseVote = async () => {
+        if (!groupDetail) {
+            alert("그룹 위치 정보를 불러오는 중입니다.");
+            return;
+        }
+
         try {
-            await finalize(groupId, sessionId);
+            await finalize(
+                groupId,
+                sessionId,
+                groupDetail.location,
+            );
         } catch {
             alert("투표 종료에 실패했습니다.");
         }

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -5,6 +5,7 @@ import { useAtomValue } from "jotai";
 import { useRouter } from "next/navigation";
 
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+import { DEFAULT_MAP_LEVEL } from "@/features/map/domain/config/mapPolicy";
 
 import { useGroupList } from "@/features/group/application/hooks/useGroupList";
 import { useGroupInvites } from "@/features/group/application/hooks/useGroupInvites";
@@ -321,14 +322,16 @@ function GroupPageContent() {
     };
 
     const openLocationEditModal = () => {
-        if (!groupDetail) return;
+        if (!groupDetail) {
+            return;
+        }
 
         setEditingLocation({
             latitude: groupDetail.location.latitude,
             longitude: groupDetail.location.longitude,
             address: groupDetail.location.address,
-            radiusMeters: 1000,
-            level: 4,
+            radiusMeters: groupDetail.location.radiusMeters,
+            level: DEFAULT_MAP_LEVEL,
         });
 
         clearLocationUpdateMessage();
@@ -340,19 +343,17 @@ function GroupPageContent() {
     ) => {
         if (selectedGroupId === null) return;
 
-        console.log("수정 요청 위치", {
-            groupId: selectedGroupId,
-            latitude: location.latitude,
-            longitude: location.longitude,
-            address: location.address,
-            level: location.level,
-        });
+//         console.log("수정 요청 위치", {
+//             groupId: selectedGroupId,
+//             latitude: location.latitude,
+//             longitude: location.longitude,
+//             address: location.address,
+//             level: location.level,
+//         });
 
         await updateLocation(
             selectedGroupId,
-            location.latitude,
-            location.longitude,
-            location.address,
+            location,
         );
 
         // 위치 수정 후 최신 상세 정보를 다시 조회
@@ -415,6 +416,7 @@ function GroupPageContent() {
             menuName: groupDetail.recentlyRecommendation.finalCandidate.menuName,
             latitude: String(groupDetail.location.latitude),
             longitude: String(groupDetail.location.longitude),
+            radiusMeters: String(groupDetail.location.radiusMeters),
             level: "4",
             source: "group",
         });

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -417,7 +417,7 @@ function GroupPageContent() {
             latitude: String(groupDetail.location.latitude),
             longitude: String(groupDetail.location.longitude),
             radiusMeters: String(groupDetail.location.radiusMeters),
-            level: "4",
+            level: String(DEFAULT_MAP_LEVEL),
             source: "group",
         });
 

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -416,9 +416,11 @@ function GroupPageContent() {
             menuName: groupDetail.recentlyRecommendation.finalCandidate.menuName,
             latitude: String(groupDetail.location.latitude),
             longitude: String(groupDetail.location.longitude),
+            address: groupDetail.location.address,
             radiusMeters: String(groupDetail.location.radiusMeters),
             level: String(DEFAULT_MAP_LEVEL),
             source: "group",
+            groupId: String(groupDetail.id),
         });
 
         router.push(`/recommendation-restaurants?${searchParams.toString()}`);

--- a/src/app/personal-recommendation/[requestId]/result/page.tsx
+++ b/src/app/personal-recommendation/[requestId]/result/page.tsx
@@ -142,9 +142,20 @@ function PersonalRecommendationResultPageContent() {
     const handleCompleteSelection = async (
         selectedCandidateId: number,
     ) => {
+        if (isLocationLoading) {
+            alert("위치 정보를 불러오는 중입니다.");
+            return;
+        }
+
+        if (!location) {
+            alert("설정된 위치가 없습니다. 위치를 설정해주세요.");
+            return;
+        }
+
         await completeSelection(
             recommendation.requestId,
             selectedCandidateId,
+            location,
         );
     };
 

--- a/src/app/personal-recommendation/[requestId]/result/page.tsx
+++ b/src/app/personal-recommendation/[requestId]/result/page.tsx
@@ -213,6 +213,8 @@ function PersonalRecommendationResultPageContent() {
             key={recommendation.requestId}
             recommendation={recommendation}
             keywords={keywords}
+            location={location}
+            isLocationLoading={isLocationLoading}
             isCompleting={isCompleting}
             isRerolling={isRerolling}
             onBack={() => router.push("/personal-recommendation")}

--- a/src/app/personal-recommendation/[requestId]/result/page.tsx
+++ b/src/app/personal-recommendation/[requestId]/result/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useAtomValue } from "jotai";
 import { useParams, useRouter } from "next/navigation";
 
@@ -27,6 +27,9 @@ import { parsePersonalRecommendationRequestId } from "@/features/personalRecomme
 import PersonalRecommendationResultContent from "@/features/personalRecommendation/ui/components/PersonalRecommendationResultContent";
 import { personalRecommendationResultPageStyles } from "@/ui/styles/personalRecommendationResultPageStyles";
 
+import LocationModal from "@/features/locationSetting/ui/components/LocationModal";
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+
 import AuthRequiredGuard from "@/features/routeGuard/ui/components/AuthRequiredGuard";
 
 export default function PersonalRecommendationResultPage() {
@@ -40,6 +43,11 @@ export default function PersonalRecommendationResultPage() {
 function PersonalRecommendationResultPageContent() {
     const router = useRouter();
     const params = useParams<{ requestId: string }>();
+
+    const [
+        isLocationModalOpen,
+        setIsLocationModalOpen,
+    ] = useState(false);
 
     const requestId =
         parsePersonalRecommendationRequestId(
@@ -76,10 +84,12 @@ function PersonalRecommendationResultPageContent() {
         isPreferenceLoadingAtom,
     );
 
-    // 서버에 저장된 개인 위치 조회
+    // 서버에 저장된 개인 위치 조회 및 저장
     const {
         location,
         isLoading: isLocationLoading,
+        isSaving: isLocationSaving,
+        saveLocation,
     } = useLocationSetting();
 
     // 추천 메뉴 선택 완료
@@ -182,6 +192,7 @@ function PersonalRecommendationResultPageContent() {
             menuName: candidate.menuName,
             latitude: String(location.latitude),
             longitude: String(location.longitude),
+            address: location.address,
             radiusMeters: String(location.radiusMeters),
             level: "4",
             source: "personal",
@@ -208,19 +219,49 @@ function PersonalRecommendationResultPageContent() {
         );
     };
 
+    const handleSaveLocation = async (
+        nextLocation: LocationSetting,
+    ) => {
+        const isSaved =
+            await saveLocation(nextLocation);
+
+        if (isSaved) {
+            setIsLocationModalOpen(false);
+        }
+
+        return isSaved;
+    };
+
     return (
-        <PersonalRecommendationResultContent
-            key={recommendation.requestId}
-            recommendation={recommendation}
-            keywords={keywords}
-            location={location}
-            isLocationLoading={isLocationLoading}
-            isCompleting={isCompleting}
-            isRerolling={isRerolling}
-            onBack={() => router.push("/personal-recommendation")}
-            onCompleteSelection={handleCompleteSelection}
-            onRetryRecommendation={handleRetryRecommendation}
-            onClickRestaurant={handleClickRestaurant}
-        />
+        <>
+            <PersonalRecommendationResultContent
+                key={recommendation.requestId}
+                recommendation={recommendation}
+                keywords={keywords}
+                location={location}
+                isLocationLoading={isLocationLoading}
+                isCompleting={isCompleting}
+                isRerolling={isRerolling}
+                onBack={() =>
+                    router.push("/personal-recommendation")
+                }
+                onCompleteSelection={handleCompleteSelection}
+                onRetryRecommendation={handleRetryRecommendation}
+                onClickRestaurant={handleClickRestaurant}
+                onClickChangeLocation={() =>
+                    setIsLocationModalOpen(true)
+                }
+            />
+
+            <LocationModal
+                isOpen={isLocationModalOpen}
+                initialLocation={location}
+                isSaving={isLocationSaving}
+                onClose={() =>
+                    setIsLocationModalOpen(false)
+                }
+                onSave={handleSaveLocation}
+            />
+        </>
     );
 }

--- a/src/app/personal-recommendation/page.tsx
+++ b/src/app/personal-recommendation/page.tsx
@@ -154,6 +154,11 @@ function PersonalRecommendationPageContent() {
                                             : location?.address ??
                                               "설정된 위치가 없습니다."
                                     }
+                                    radiusMeters={
+                                        isLocationLoading
+                                            ? null
+                                            : location?.radiusMeters ?? null
+                                    }
                                     onClickEdit={() =>
                                         setIsLocationModalOpen(true)
                                     }

--- a/src/features/group/application/hooks/useUpdateGroupLocation.ts
+++ b/src/features/group/application/hooks/useUpdateGroupLocation.ts
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+
 import { updateGroupLocation } from "@/features/group/application/usecase/updateGroupLocation";
 
 interface UseUpdateGroupLocationParams {
@@ -16,9 +18,7 @@ export function useUpdateGroupLocation({
 
     const update = async (
         groupId: number,
-        latitude: number,
-        longitude: number,
-        address: string,
+        location: LocationSetting,
     ) => {
         try {
             setIsUpdating(true);
@@ -26,9 +26,7 @@ export function useUpdateGroupLocation({
 
             await updateGroupLocation(
                 groupId,
-                latitude,
-                longitude,
-                address,
+                location,
             );
 
             setMessage("그룹 위치가 수정되었습니다.");
@@ -39,6 +37,8 @@ export function useUpdateGroupLocation({
                     ? error.message
                     : "그룹 위치 수정에 실패했습니다.",
             );
+
+            throw error;
         } finally {
             setIsUpdating(false);
         }

--- a/src/features/group/application/usecase/createGroup.ts
+++ b/src/features/group/application/usecase/createGroup.ts
@@ -1,12 +1,20 @@
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
 import type { GroupCreateRequest } from "@/features/group/infrastructure/api/dto/GroupCreateRequest";
 
+import { isLocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+
 import { groupApi } from "@/features/group/infrastructure/api/groupApi";
 
 function createRequest(
     groupName: string,
     location: LocationSetting,
 ): GroupCreateRequest {
+    if (!isLocationRadiusMeters(location.radiusMeters)) {
+        throw new Error(
+            "검색 반경은 1km, 3km, 5km 중에서 선택해주세요.",
+        );
+    }
+
     return {
         name: groupName,
 

--- a/src/features/group/application/usecase/createGroup.ts
+++ b/src/features/group/application/usecase/createGroup.ts
@@ -13,8 +13,8 @@ function createRequest(
         latitude: location.latitude,
         longitude: location.longitude,
 
-        radiusMeters: 1000,
-        address: location.address,
+        radiusMeters: location.radiusMeters,
+        address: location.address.trim(),
     };
 }
 

--- a/src/features/group/application/usecase/updateGroupLocation.ts
+++ b/src/features/group/application/usecase/updateGroupLocation.ts
@@ -1,15 +1,15 @@
 import { groupApi } from "@/features/group/infrastructure/api/groupApi";
 
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+
 export async function updateGroupLocation(
     groupId: number,
-    latitude: number,
-    longitude: number,
-    address: string,
+    location: LocationSetting,
 ) {
     return groupApi.updateGroup(groupId, {
-        latitude,
-        longitude,
-        radiusMeters: 1000,
-        address,
+        latitude: location.latitude,
+        longitude: location.longitude,
+        radiusMeters: location.radiusMeters,
+        address: location.address.trim(),
     });
 }

--- a/src/features/group/application/usecase/updateGroupLocation.ts
+++ b/src/features/group/application/usecase/updateGroupLocation.ts
@@ -1,11 +1,19 @@
 import { groupApi } from "@/features/group/infrastructure/api/groupApi";
 
+import { isLocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
 
 export async function updateGroupLocation(
     groupId: number,
     location: LocationSetting,
 ) {
+    if (!isLocationRadiusMeters(location.radiusMeters)) {
+        throw new Error(
+            "검색 반경은 1km, 3km, 5km 중에서 선택해주세요.",
+        );
+    }
+
     return groupApi.updateGroup(groupId, {
         latitude: location.latitude,
         longitude: location.longitude,

--- a/src/features/group/ui/components/GroupCreateModal.tsx
+++ b/src/features/group/ui/components/GroupCreateModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ArrowLeft, Check, Crosshair, Info, MapPin, Search, } from "lucide-react";
+import { ArrowLeft, Check, Crosshair, Info, MapPin, Search } from "lucide-react";
 
 import KakaoMapView from "@/features/map/ui/components/KakaoMapView";
 import { useLocationSearch } from "@/features/locationSetting/application/hooks/useLocationSearch";
@@ -38,14 +38,12 @@ export default function GroupCreateModal({
 
     const [selectedLocation, setSelectedLocation] =
         useState<LocationSetting>({
-            address: defaultLocationSetting.address,
-            latitude: defaultLocationSetting.latitude,
-            longitude: defaultLocationSetting.longitude,
-            radiusMeters: 1000,
-            level: 4,
+            ...defaultLocationSetting,
         });
 
-    if (!isOpen) return null;
+    if (!isOpen) {
+        return null;
+    }
 
     const isDisabled =
         groupName.trim().length === 0 ||
@@ -53,13 +51,11 @@ export default function GroupCreateModal({
         isCreating;
 
     const handleCreate = async () => {
-        if (isDisabled) return;
+        if (isDisabled) {
+            return;
+        }
 
-        await onCreate({
-            ...selectedLocation,
-            radiusMeters: 1000,
-            level: 4,
-        });
+        await onCreate(selectedLocation);
     };
 
     return (
@@ -69,6 +65,7 @@ export default function GroupCreateModal({
                     <button
                         type="button"
                         onClick={onClose}
+                        disabled={isCreating}
                         className={groupCreateModalStyles.backButton}
                     >
                         <ArrowLeft size={24} />
@@ -80,7 +77,8 @@ export default function GroupCreateModal({
                         </h2>
 
                         <p className={groupCreateModalStyles.description}>
-                            그룹명을 입력하고 주변 맛집 추천을 위해 위치를 등록해주세요.
+                            그룹명을 입력하고 주변 맛집 추천을 위해 위치를
+                            등록해주세요.
                         </p>
                     </div>
                 </header>
@@ -90,6 +88,7 @@ export default function GroupCreateModal({
                     value={groupName}
                     onChange={(event) => onChangeGroupName(event.target.value)}
                     placeholder="그룹명을 입력하세요."
+                    disabled={isCreating}
                     className={groupCreateModalStyles.groupNameInput}
                 />
 
@@ -107,11 +106,13 @@ export default function GroupCreateModal({
                                 setInputKeyword(event.target.value)
                             }
                             placeholder="주소 또는 장소 이름 검색"
+                            disabled={isCreating}
                             className={groupCreateModalStyles.searchInput}
                         />
 
                         <button
                             type="submit"
+                            disabled={isCreating}
                             className={groupCreateModalStyles.locationButton}
                         >
                             <Crosshair size={20} />
@@ -135,8 +136,7 @@ export default function GroupCreateModal({
                                     ...prev,
                                     latitude: center.latitude,
                                     longitude: center.longitude,
-                                    radiusMeters: 1000, //TODO: 후에 반경 설정 할 수 있도록 변경 필요
-                                    level: 4,
+                                    level: center.level,
                                 }));
                             }}
                             onAddressChanged={(address) => {
@@ -169,7 +169,7 @@ export default function GroupCreateModal({
                         <Info size={18} />
 
                         <span>
-                            지도를 드래그하거나 확대/축소하여 추천 범위를 조정하세요.
+                            지도를 드래그하거나 주소를 검색해 그룹 위치를 설정하세요.
                         </span>
                     </div>
 

--- a/src/features/group/ui/components/GroupCreateModal.tsx
+++ b/src/features/group/ui/components/GroupCreateModal.tsx
@@ -6,6 +6,12 @@ import { ArrowLeft, Check, Crosshair, Info, MapPin, Search } from "lucide-react"
 import KakaoMapView from "@/features/map/ui/components/KakaoMapView";
 import { useLocationSearch } from "@/features/locationSetting/application/hooks/useLocationSearch";
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+import type { LocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+import {
+    formatLocationRadius,
+    isLocationRadiusMeters,
+    LOCATION_RADIUS_OPTIONS,
+} from "@/features/locationSetting/domain/config/locationRadiusPolicy";
 import { defaultLocationSetting } from "@/features/locationSetting/ui/config/defaultLocationSetting";
 import { groupCreateModalStyles } from "@/ui/styles/groupCreateModalStyles";
 
@@ -41,19 +47,55 @@ export default function GroupCreateModal({
             ...defaultLocationSetting,
         });
 
+    const [radiusErrorMessage, setRadiusErrorMessage] =
+        useState<string | null>(null);
+
     if (!isOpen) {
         return null;
     }
 
+    const isRadiusValid = isLocationRadiusMeters(
+        selectedLocation.radiusMeters,
+    );
+
     const isDisabled =
         groupName.trim().length === 0 ||
         selectedLocation.address.trim().length === 0 ||
+        !isRadiusValid ||
         isCreating;
 
+    const handleChangeRadius = (
+        radiusMeters: LocationRadiusMeters,
+    ) => {
+        if (isCreating) {
+            return;
+        }
+
+        setRadiusErrorMessage(null);
+
+        setSelectedLocation((prev) => ({
+            ...prev,
+            radiusMeters,
+        }));
+    };
+
     const handleCreate = async () => {
+        if (isCreating) {
+            return;
+        }
+
+        if (!isRadiusValid) {
+            setRadiusErrorMessage(
+                "검색 반경은 1km, 3km, 5km 중에서 선택해주세요.",
+            );
+            return;
+        }
+
         if (isDisabled) {
             return;
         }
+
+        setRadiusErrorMessage(null);
 
         await onCreate(selectedLocation);
     };
@@ -77,8 +119,8 @@ export default function GroupCreateModal({
                         </h2>
 
                         <p className={groupCreateModalStyles.description}>
-                            그룹명을 입력하고 주변 맛집 추천을 위해 위치를
-                            등록해주세요.
+                            그룹명을 입력하고 주변 맛집 추천을 위해 위치와
+                            검색 반경을 설정해주세요.
                         </p>
                     </div>
                 </header>
@@ -130,6 +172,7 @@ export default function GroupCreateModal({
                             centerLatitude={selectedLocation.latitude}
                             centerLongitude={selectedLocation.longitude}
                             level={selectedLocation.level}
+                            radiusMeters={selectedLocation.radiusMeters}
                             searchKeyword={searchKeyword}
                             onCenterChanged={(center) => {
                                 setSelectedLocation((prev) => ({
@@ -164,12 +207,63 @@ export default function GroupCreateModal({
                     </div>
                 </div>
 
+                <div className={groupCreateModalStyles.radiusSection}>
+                    <div className={groupCreateModalStyles.radiusHeader}>
+                        <h3 className={groupCreateModalStyles.radiusTitle}>
+                            맛집 검색 반경
+                        </h3>
+
+                        <span className={groupCreateModalStyles.radiusValue}>
+                            {formatLocationRadius(
+                                selectedLocation.radiusMeters,
+                            )}
+                        </span>
+                    </div>
+
+                    <p className={groupCreateModalStyles.radiusDescription}>
+                        그룹 위치를 기준으로 맛집을 검색할 기본 범위입니다.
+                    </p>
+
+                    <div className={groupCreateModalStyles.radiusOptions}>
+                        {LOCATION_RADIUS_OPTIONS.map((radiusMeters) => {
+                            const isSelected =
+                                selectedLocation.radiusMeters === radiusMeters;
+
+                            return (
+                                <button
+                                    key={radiusMeters}
+                                    type="button"
+                                    onClick={() =>
+                                        handleChangeRadius(radiusMeters)
+                                    }
+                                    disabled={isCreating}
+                                    aria-pressed={isSelected}
+                                    className={
+                                        isSelected
+                                            ? groupCreateModalStyles.selectedRadiusButton
+                                            : groupCreateModalStyles.radiusButton
+                                    }
+                                >
+                                    {formatLocationRadius(radiusMeters)}
+                                </button>
+                            );
+                        })}
+                    </div>
+
+                    {radiusErrorMessage && (
+                        <p className={groupCreateModalStyles.radiusErrorMessage}>
+                            {radiusErrorMessage}
+                        </p>
+                    )}
+                </div>
+
                 <footer className={groupCreateModalStyles.footer}>
                     <div className={groupCreateModalStyles.guideBox}>
                         <Info size={18} />
 
                         <span>
-                            지도를 드래그하거나 주소를 검색해 그룹 위치를 설정하세요.
+                            지도를 드래그하거나 주소를 검색해 그룹 위치를
+                            설정하세요.
                         </span>
                     </div>
 

--- a/src/features/group/ui/components/GroupDetailPanel.tsx
+++ b/src/features/group/ui/components/GroupDetailPanel.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Copy, MapPin, User } from "lucide-react";
 import { useAtomValue } from "jotai";
 
 import type { GroupDetail } from "@/features/group/domain/model/GroupDetail";
+import { formatLocationRadius } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
 
 import { isGroupOwnerAtom } from "@/features/group/application/selectors/groupDetailSelectors";
 
@@ -73,9 +74,18 @@ export default function GroupDetailPanel({
                     </h2>
 
                     {group.location.address && (
-                        <div className={groupDetailPanelStyles.address}>
-                            <MapPin size={16} />
-                            <span>{group.location.address}</span>
+                        <div className={groupDetailPanelStyles.locationInfo}>
+                            <div className={groupDetailPanelStyles.address}>
+                                <MapPin size={16} />
+                                <span>{group.location.address}</span>
+                            </div>
+
+                            <span className={groupDetailPanelStyles.locationRadius}>
+                                기본 검색 반경{" "}
+                                {formatLocationRadius(
+                                    group.location.radiusMeters,
+                                )}
+                            </span>
                         </div>
                     )}
                 </section>

--- a/src/features/group/ui/components/GroupLocationEditModal.tsx
+++ b/src/features/group/ui/components/GroupLocationEditModal.tsx
@@ -6,6 +6,12 @@ import { ArrowLeft, Check, Crosshair, Info, MapPin, Search, } from "lucide-react
 import KakaoMapView from "@/features/map/ui/components/KakaoMapView";
 import { useLocationSearch } from "@/features/locationSetting/application/hooks/useLocationSearch";
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+import type { LocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+import {
+    formatLocationRadius,
+    isLocationRadiusMeters,
+    LOCATION_RADIUS_OPTIONS,
+} from "@/features/locationSetting/domain/config/locationRadiusPolicy";
 
 import { groupLocationEditModalStyles } from "@/ui/styles/groupLocationEditModalStyles";
 
@@ -37,14 +43,50 @@ export default function GroupLocationEditModal({
     const [initialLocation] =
         useState<LocationSetting>(location);
 
+    const [radiusErrorMessage, setRadiusErrorMessage] =
+        useState<string | null>(null);
+
+    const isRadiusValid = isLocationRadiusMeters(
+        selectedLocation.radiusMeters,
+    );
+
     const isDisabled =
         selectedLocation.address.trim().length === 0 ||
+        !isRadiusValid ||
         isUpdating;
 
+    const handleChangeRadius = (
+        radiusMeters: LocationRadiusMeters,
+    ) => {
+        if (isUpdating) {
+            return;
+        }
+
+        setRadiusErrorMessage(null);
+
+        setSelectedLocation((prev) => ({
+            ...prev,
+            radiusMeters,
+        }));
+    };
+
     const handleUpdate = () => {
+        if (isUpdating) {
+            return;
+        }
+
+        if (!isRadiusValid) {
+            setRadiusErrorMessage(
+                "검색 반경은 1km, 3km, 5km 중에서 선택해주세요.",
+            );
+            return;
+        }
+
         if (isDisabled) {
             return;
         }
+
+        setRadiusErrorMessage(null);
 
         onSubmit(selectedLocation);
     };
@@ -56,6 +98,7 @@ export default function GroupLocationEditModal({
                     <button
                         type="button"
                         onClick={onClose}
+                        disabled={isUpdating}
                         className={groupLocationEditModalStyles.backButton}
                     >
                         <ArrowLeft size={24} />
@@ -67,7 +110,8 @@ export default function GroupLocationEditModal({
                         </h2>
 
                         <p className={groupLocationEditModalStyles.description}>
-                            그룹 추천 기준이 되는 위치를 수정하세요.
+                            그룹 추천 기준이 되는 위치와 검색 반경을
+                            수정하세요.
                         </p>
                     </div>
                 </header>
@@ -86,11 +130,13 @@ export default function GroupLocationEditModal({
                                 setInputKeyword(event.target.value)
                             }
                             placeholder="주소 또는 장소 이름 검색"
+                            disabled={isUpdating}
                             className={groupLocationEditModalStyles.searchInput}
                         />
 
                         <button
                             type="submit"
+                            disabled={isUpdating}
                             className={groupLocationEditModalStyles.locationButton}
                         >
                             <Crosshair size={20} />
@@ -108,13 +154,14 @@ export default function GroupLocationEditModal({
                             centerLatitude={initialLocation.latitude}
                             centerLongitude={initialLocation.longitude}
                             level={initialLocation.level}
+                            radiusMeters={selectedLocation.radiusMeters}
                             searchKeyword={searchKeyword}
                             onCenterChanged={(center) => {
                                 setSelectedLocation((prev) => ({
                                     ...prev,
                                     latitude: center.latitude,
                                     longitude: center.longitude,
-                                    level: 4,
+                                    level: center.level,
                                 }));
                             }}
                             onAddressChanged={(address) => {
@@ -142,12 +189,63 @@ export default function GroupLocationEditModal({
                     </div>
                 </div>
 
+                <div className={groupLocationEditModalStyles.radiusSection}>
+                    <div className={groupLocationEditModalStyles.radiusHeader}>
+                        <h3 className={groupLocationEditModalStyles.radiusTitle}>
+                            맛집 검색 반경
+                        </h3>
+
+                        <span className={groupLocationEditModalStyles.radiusValue}>
+                            {formatLocationRadius(
+                                selectedLocation.radiusMeters,
+                            )}
+                        </span>
+                    </div>
+
+                    <p className={groupLocationEditModalStyles.radiusDescription}>
+                        그룹 위치를 기준으로 맛집을 검색할 기본 범위입니다.
+                    </p>
+
+                    <div className={groupLocationEditModalStyles.radiusOptions}>
+                        {LOCATION_RADIUS_OPTIONS.map((radiusMeters) => {
+                            const isSelected =
+                                selectedLocation.radiusMeters === radiusMeters;
+
+                            return (
+                                <button
+                                    key={radiusMeters}
+                                    type="button"
+                                    onClick={() =>
+                                        handleChangeRadius(radiusMeters)
+                                    }
+                                    disabled={isUpdating}
+                                    aria-pressed={isSelected}
+                                    className={
+                                        isSelected
+                                            ? groupLocationEditModalStyles.selectedRadiusButton
+                                            : groupLocationEditModalStyles.radiusButton
+                                    }
+                                >
+                                    {formatLocationRadius(radiusMeters)}
+                                </button>
+                            );
+                        })}
+                    </div>
+
+                    {radiusErrorMessage && (
+                        <p className={groupLocationEditModalStyles.radiusErrorMessage}>
+                            {radiusErrorMessage}
+                        </p>
+                    )}
+                </div>
+
                 <footer className={groupLocationEditModalStyles.footer}>
                     <div className={groupLocationEditModalStyles.guideBox}>
                         <Info size={18} />
 
                         <span>
-                            지도를 드래그하거나 확대/축소하여 추천 범위를 조정하세요.
+                            지도를 드래그하거나 검색하여 원하는 위치를
+                            설정하세요.
                         </span>
                     </div>
 

--- a/src/features/groupRecommendation/application/hooks/useFinalizeGroupRecommendation.ts
+++ b/src/features/groupRecommendation/application/hooks/useFinalizeGroupRecommendation.ts
@@ -4,6 +4,8 @@ import { useState } from "react";
 
 import { finalizeGroupRecommendation } from "@/features/groupRecommendation/application/usecase/finalizeGroupRecommendation";
 
+import type { GroupDetailLocation } from "@/features/group/domain/model/GroupDetail";
+
 interface UseFinalizeGroupRecommendationProps {
     readonly onSuccess?: () => void;
 }
@@ -16,6 +18,7 @@ export function useFinalizeGroupRecommendation({
     const finalize = async (
         groupId: number,
         sessionId: number,
+        location: GroupDetailLocation,
     ) => {
         try {
             setIsFinalizing(true);
@@ -23,6 +26,12 @@ export function useFinalizeGroupRecommendation({
             const result = await finalizeGroupRecommendation(
                 groupId,
                 sessionId,
+                {
+                    latitude: location.latitude,
+                    longitude: location.longitude,
+                    radiusMeters: location.radiusMeters,
+                    address: location.address,
+                },
             );
 
             onSuccess?.();

--- a/src/features/groupRecommendation/application/usecase/finalizeGroupRecommendation.ts
+++ b/src/features/groupRecommendation/application/usecase/finalizeGroupRecommendation.ts
@@ -1,11 +1,15 @@
 import { groupRecommendationApi } from "@/features/groupRecommendation/infrastructure/api/groupRecommendationApi";
 
+import type { FinalizeGroupRecommendationRequest } from "@/features/groupRecommendation/infrastructure/api/dto/FinalizeGroupRecommendationRequest";
+
 export async function finalizeGroupRecommendation(
     groupId: number,
     sessionId: number,
+    request: FinalizeGroupRecommendationRequest,
 ) {
     return groupRecommendationApi.finalizeRecommendation(
         groupId,
         sessionId,
+        request,
     );
 }

--- a/src/features/groupRecommendation/infrastructure/api/dto/FinalizeGroupRecommendationRequest.ts
+++ b/src/features/groupRecommendation/infrastructure/api/dto/FinalizeGroupRecommendationRequest.ts
@@ -1,0 +1,6 @@
+export interface FinalizeGroupRecommendationRequest {
+    readonly latitude: number;
+    readonly longitude: number;
+    readonly radiusMeters: number;
+    readonly address: string;
+}

--- a/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
+++ b/src/features/groupRecommendation/infrastructure/api/groupRecommendationApi.ts
@@ -7,6 +7,7 @@ import type { CompleteGroupRecommendationPreparationResponse } from "@/features/
 import type { GroupRecommendationSessionDetailResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationSessionDetailResponse";
 import type { GroupRecommendationVoteRequest } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationVoteRequest";
 import type { GroupRecommendationVoteResponse } from "@/features/groupRecommendation/infrastructure/api/dto/GroupRecommendationVoteResponse";
+import type { FinalizeGroupRecommendationRequest } from "@/features/groupRecommendation/infrastructure/api/dto/FinalizeGroupRecommendationRequest";
 import type { FinalizeGroupRecommendationResponse } from "@/features/groupRecommendation/infrastructure/api/dto/FinalizeGroupRecommendationResponse";
 
 import type { GroupRecommendationReadiness } from "@/features/groupRecommendation/domain/model/GroupRecommendationReadiness";
@@ -114,10 +115,12 @@ export const groupRecommendationApi = {
     async finalizeRecommendation(
         groupId: number,
         sessionId: number,
+        request: FinalizeGroupRecommendationRequest,
     ) {
         const response =
             await httpClient.patch<FinalizeGroupRecommendationResponse>(
                 `/api/v1/groups/${groupId}/recommendations/${sessionId}/finalize`,
+                request,
             );
 
         if (!response.success) {

--- a/src/features/locationSetting/domain/config/locationRadiusPolicy.ts
+++ b/src/features/locationSetting/domain/config/locationRadiusPolicy.ts
@@ -1,0 +1,33 @@
+export const LOCATION_RADIUS_OPTIONS = [
+    1000,
+    3000,
+    5000,
+] as const;
+
+export type LocationRadiusMeters =
+    (typeof LOCATION_RADIUS_OPTIONS)[number];
+
+export const DEFAULT_LOCATION_RADIUS_METERS: LocationRadiusMeters = 1000;
+
+export const MAX_RESTAURANT_SEARCH_RADIUS_METERS: LocationRadiusMeters =
+    LOCATION_RADIUS_OPTIONS[LOCATION_RADIUS_OPTIONS.length - 1];
+
+export function isLocationRadiusMeters(
+    value: number,
+): value is LocationRadiusMeters {
+    return LOCATION_RADIUS_OPTIONS.some(
+        (radiusMeters) => radiusMeters === value,
+    );
+}
+
+export function createRestaurantSearchRadiusSteps(
+    baseRadiusMeters: number,
+): readonly LocationRadiusMeters[] {
+    if (!isLocationRadiusMeters(baseRadiusMeters)) {
+        return [DEFAULT_LOCATION_RADIUS_METERS];
+    }
+
+    return LOCATION_RADIUS_OPTIONS.filter(
+        (radiusMeters) => radiusMeters >= baseRadiusMeters,
+    );
+}

--- a/src/features/locationSetting/domain/config/locationRadiusPolicy.ts
+++ b/src/features/locationSetting/domain/config/locationRadiusPolicy.ts
@@ -20,6 +20,20 @@ export function isLocationRadiusMeters(
     );
 }
 
+export function formatLocationRadius(
+    radiusMeters: number,
+): string {
+    if (!Number.isFinite(radiusMeters)) {
+        return "";
+    }
+
+    if (radiusMeters >= 1000) {
+        return `${radiusMeters / 1000}km`;
+    }
+
+    return `${radiusMeters}m`;
+}
+
 export function createRestaurantSearchRadiusSteps(
     baseRadiusMeters: number,
 ): readonly LocationRadiusMeters[] {

--- a/src/features/locationSetting/infrastructure/api/locationSettingApi.ts
+++ b/src/features/locationSetting/infrastructure/api/locationSettingApi.ts
@@ -1,5 +1,7 @@
 import { httpClient } from "@/infrastructure/http/httpClient";
 
+import { isLocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
 import type { MemberLocationResponse } from "@/features/locationSetting/infrastructure/api/dto/MemberLocationResponse";
 import type { SaveMemberLocationRequest } from "@/features/locationSetting/infrastructure/api/dto/SaveMemberLocationRequest";
@@ -34,6 +36,17 @@ export const locationSettingApi = {
     async saveMyLocation(
         location: LocationSetting,
     ): Promise<LocationSetting> {
+        if (
+            !Number.isFinite(location.radiusMeters) ||
+            !isLocationRadiusMeters(
+                location.radiusMeters,
+            )
+        ) {
+            throw new Error(
+                "검색 반경은 1km, 3km, 5km 중에서 선택해주세요.",
+            );
+        }
+
         const request: SaveMemberLocationRequest = {
             latitude: location.latitude,
             longitude: location.longitude,

--- a/src/features/locationSetting/infrastructure/api/locationSettingApi.ts
+++ b/src/features/locationSetting/infrastructure/api/locationSettingApi.ts
@@ -5,15 +5,14 @@ import type { MemberLocationResponse } from "@/features/locationSetting/infrastr
 import type { SaveMemberLocationRequest } from "@/features/locationSetting/infrastructure/api/dto/SaveMemberLocationRequest";
 
 import { mapMemberLocation } from "@/features/locationSetting/infrastructure/api/mapper/memberLocationMapper";
-
-const DEFAULT_RADIUS_METERS = 1000;
-const DEFAULT_MAP_LEVEL = 4;
+import { DEFAULT_MAP_LEVEL } from "@/features/map/domain/config/mapPolicy";
 
 export const locationSettingApi = {
     async fetchMyLocation(): Promise<LocationSetting | null> {
-        const response = await httpClient.get<MemberLocationResponse>(
-            "/api/v1/members/me/location",
-        );
+        const response =
+            await httpClient.get<MemberLocationResponse>(
+                "/api/v1/members/me/location",
+            );
 
         if (!response.success) {
             throw new Error(
@@ -38,7 +37,7 @@ export const locationSettingApi = {
         const request: SaveMemberLocationRequest = {
             latitude: location.latitude,
             longitude: location.longitude,
-            radiusMeters: DEFAULT_RADIUS_METERS,
+            radiusMeters: location.radiusMeters,
             address: location.address.trim(),
         };
 

--- a/src/features/locationSetting/ui/components/LocationModal.tsx
+++ b/src/features/locationSetting/ui/components/LocationModal.tsx
@@ -5,6 +5,12 @@ import {Check, ChevronLeft, Crosshair, Info, MapPin, Search } from "lucide-react
 
 import KakaoMapView from "@/features/map/ui/components/KakaoMapView";
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+import type { LocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+import {
+    formatLocationRadius,
+    isLocationRadiusMeters,
+    LOCATION_RADIUS_OPTIONS,
+} from "@/features/locationSetting/domain/config/locationRadiusPolicy";
 import { defaultLocationSetting } from "@/features/locationSetting/ui/config/defaultLocationSetting";
 import { useLocationSearch } from "@/features/locationSetting/application/hooks/useLocationSearch";
 import { locationModalStyles } from "@/ui/styles/locationModalStyles";
@@ -65,10 +71,37 @@ function LocationModalContent({
     const [selectedLocation, setSelectedLocation] =
         useState<LocationSetting>(baseLocation);
 
+    const [radiusErrorMessage, setRadiusErrorMessage] =
+        useState<string | null>(null);
+
+    const handleChangeRadius = (
+        radiusMeters: LocationRadiusMeters,
+    ) => {
+        if (isSaving) {
+            return;
+        }
+
+        setRadiusErrorMessage(null);
+
+        setSelectedLocation((prev) => ({
+            ...prev,
+            radiusMeters,
+        }));
+    };
+
     const handleSave = async () => {
         if (isSaving) {
             return;
         }
+
+        if (!isLocationRadiusMeters(selectedLocation.radiusMeters)) {
+            setRadiusErrorMessage(
+                "검색 반경은 1km, 3km, 5km 중에서 선택해주세요.",
+            );
+            return;
+        }
+
+        setRadiusErrorMessage(null);
 
         await onSave(selectedLocation);
     };
@@ -90,7 +123,7 @@ function LocationModalContent({
                         <h2 className={locationModalStyles.title}>위치 등록</h2>
 
                         <p className={locationModalStyles.description}>
-                            주변 맛집 추천을 위해 위치를 등록해주세요.
+                            주변 맛집 추천을 위해 위치와 검색 반경을 설정해주세요.
                         </p>
                     </div>
                 </header>
@@ -109,6 +142,7 @@ function LocationModalContent({
                                 setInputKeyword(event.target.value)
                             }
                             placeholder="주소 또는 장소 이름 검색"
+                            disabled={isSaving}
                             className={locationModalStyles.searchInput}
                         />
 
@@ -132,6 +166,7 @@ function LocationModalContent({
                             centerLatitude={baseLocation.latitude}
                             centerLongitude={baseLocation.longitude}
                             level={baseLocation.level}
+                            radiusMeters={selectedLocation.radiusMeters}
                             searchKeyword={searchKeyword}
                             onCenterChanged={(center) => {
                                 setSelectedLocation((prev) => ({
@@ -166,6 +201,56 @@ function LocationModalContent({
                     </div>
                 </div>
 
+                <div className={locationModalStyles.radiusSection}>
+                    <div className={locationModalStyles.radiusHeader}>
+                        <h3 className={locationModalStyles.radiusTitle}>
+                            맛집 검색 반경
+                        </h3>
+
+                        <span className={locationModalStyles.radiusValue}>
+                            {formatLocationRadius(
+                                selectedLocation.radiusMeters,
+                            )}
+                        </span>
+                    </div>
+
+                    <p className={locationModalStyles.radiusDescription}>
+                        선택한 위치를 기준으로 맛집을 검색할 기본 범위입니다.
+                    </p>
+
+                    <div className={locationModalStyles.radiusOptions}>
+                        {LOCATION_RADIUS_OPTIONS.map((radiusMeters) => {
+                            const isSelected =
+                                selectedLocation.radiusMeters === radiusMeters;
+
+                            return (
+                                <button
+                                    key={radiusMeters}
+                                    type="button"
+                                    onClick={() =>
+                                        handleChangeRadius(radiusMeters)
+                                    }
+                                    disabled={isSaving}
+                                    aria-pressed={isSelected}
+                                    className={
+                                        isSelected
+                                            ? locationModalStyles.selectedRadiusButton
+                                            : locationModalStyles.radiusButton
+                                    }
+                                >
+                                    {formatLocationRadius(radiusMeters)}
+                                </button>
+                            );
+                        })}
+                    </div>
+
+                    {radiusErrorMessage && (
+                        <p className={locationModalStyles.radiusErrorMessage}>
+                            {radiusErrorMessage}
+                        </p>
+                    )}
+                </div>
+
                 <footer className={locationModalStyles.footer}>
                     <div className={locationModalStyles.guideBox}>
                         <Info size={18} />
@@ -180,11 +265,16 @@ function LocationModalContent({
                         onClick={() => {
                             void handleSave();
                         }}
-                        disabled={isSaving}
+                        disabled={
+                            isSaving ||
+                            !isLocationRadiusMeters(
+                                selectedLocation.radiusMeters,
+                            )
+                        }
                         className={locationModalStyles.saveButton}
                     >
                         {isSaving ? "저장 중..." : "등록"}
-                        <Check size={18} />
+                        {!isSaving && <Check size={18} />}
                     </button>
                 </footer>
             </div>

--- a/src/features/locationSetting/ui/components/LocationModal.tsx
+++ b/src/features/locationSetting/ui/components/LocationModal.tsx
@@ -70,10 +70,7 @@ function LocationModalContent({
             return;
         }
 
-        await onSave({
-            ...selectedLocation,
-            radiusMeters: 1000,
-        });
+        await onSave(selectedLocation);
     };
 
     return (

--- a/src/features/locationSetting/ui/config/defaultLocationSetting.ts
+++ b/src/features/locationSetting/ui/config/defaultLocationSetting.ts
@@ -1,11 +1,15 @@
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
 
+import { DEFAULT_LOCATION_RADIUS_METERS } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+import { DEFAULT_MAP_LEVEL } from "@/features/map/domain/config/mapPolicy";
+
 export const defaultLocationSetting: LocationSetting = {
     address: "서울특별시 강남구 강남대로 396",
 
     latitude: 37.497942,
     longitude: 127.027621,
 
-    radiusMeters: 1000,
-    level: 4,
+    radiusMeters:
+        DEFAULT_LOCATION_RADIUS_METERS,
+    level: DEFAULT_MAP_LEVEL,
 };

--- a/src/features/map/domain/config/mapPolicy.ts
+++ b/src/features/map/domain/config/mapPolicy.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_MAP_LEVEL = 4;

--- a/src/features/map/ui/components/KakaoMapView.tsx
+++ b/src/features/map/ui/components/KakaoMapView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { clientEnv } from "@/infrastructure/config/env";
 import { loadKakaoMapScript } from "@/shared/lib/kakaoMap/loadKakaoMapScript";
@@ -12,6 +12,7 @@ interface KakaoMapViewProps {
     readonly centerLatitude: number;
     readonly centerLongitude: number;
     readonly level?: number;
+    readonly radiusMeters?: number;
     readonly searchKeyword?: string;
     readonly onCenterChanged?: (center: KakaoMapChangeValue) => void;
     readonly onAddressChanged?: (address: string) => void;
@@ -42,6 +43,7 @@ export default function KakaoMapView({
     centerLatitude,
     centerLongitude,
     level = 4,
+    radiusMeters,
     searchKeyword,
     onCenterChanged,
     onAddressChanged,
@@ -51,6 +53,9 @@ export default function KakaoMapView({
     const mapRef = useRef<kakao.maps.Map | null>(null);
     const geocoderRef = useRef<kakao.maps.services.Geocoder | null>(null);
     const placesRef = useRef<kakao.maps.services.Places | null>(null);
+    const radiusCircleRef = useRef<kakao.maps.Circle | null>(null);
+
+    const [isMapReady, setIsMapReady] = useState(false);
 
     const onCenterChangedRef = useRef(onCenterChanged);
     const onAddressChangedRef = useRef(onAddressChanged);
@@ -106,6 +111,10 @@ export default function KakaoMapView({
             placesRef.current = places;
 
             const notifyMapChanged = () => {
+                radiusCircleRef.current?.setPosition(
+                    map.getCenter(),
+                );
+
                 onCenterChangedRef.current?.(createMapChangeValue(map));
 
                 getAddressFromCenter(
@@ -128,9 +137,14 @@ export default function KakaoMapView({
             );
 
             setTimeout(() => {
+                if (cancelled) {
+                    return;
+                }
+
                 map.relayout();
                 map.setCenter(center);
                 notifyMapChanged();
+                setIsMapReady(true);
             }, 0);
         }
 
@@ -140,8 +154,50 @@ export default function KakaoMapView({
 
         return () => {
             cancelled = true;
+
+            setIsMapReady(false);
+
+            radiusCircleRef.current?.setMap(null);
+            radiusCircleRef.current = null;
+
+            mapRef.current = null;
+            geocoderRef.current = null;
+            placesRef.current = null;
         };
     }, []);
+
+    useEffect(() => {
+        const map = mapRef.current;
+
+        if (
+            !isMapReady ||
+            !map ||
+            !window.kakao?.maps ||
+            radiusMeters === undefined
+        ) {
+            return;
+        }
+
+        radiusCircleRef.current?.setMap(null);
+
+        const center = map.getCenter();
+
+        const radiusCircle = new window.kakao.maps.Circle({
+            map,
+            center,
+            radius: radiusMeters,
+            strokeWeight: 2,
+            strokeColor: "#10B981",
+            strokeOpacity: 0.8,
+            strokeStyle: "solid",
+            fillColor: "#10B981",
+            fillOpacity: 0.12,
+        });
+
+        radiusCircleRef.current = radiusCircle;
+
+        map.setBounds(radiusCircle.getBounds());
+    }, [isMapReady, radiusMeters]);
 
     useEffect(() => {
         const keyword = searchKeyword?.trim();
@@ -171,6 +227,10 @@ export default function KakaoMapView({
             );
 
             mapRef.current?.setCenter(nextCenter);
+
+            radiusCircleRef.current?.setPosition(
+                nextCenter,
+            );
 
             const nextAddress =
                 searchedPlace.road_address_name ||

--- a/src/features/personalRecommendation/application/hooks/useCompletePersonalRecommendationSelection.ts
+++ b/src/features/personalRecommendation/application/hooks/useCompletePersonalRecommendationSelection.ts
@@ -6,6 +6,8 @@ import { useSetAtom } from "jotai";
 import { personalRecommendationAtom } from "@/features/personalRecommendation/application/atoms/personalRecommendationAtom";
 import { personalRecommendationApi } from "@/features/personalRecommendation/infrastructure/api/personalRecommendationApi";
 
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+
 export function useCompletePersonalRecommendationSelection() {
     const setRecommendationState = useSetAtom(personalRecommendationAtom);
     const [isCompleting, setIsCompleting] = useState(false);
@@ -13,6 +15,7 @@ export function useCompletePersonalRecommendationSelection() {
     const completeSelection = async (
         requestId: number,
         selectedCandidateId: number,
+        location: LocationSetting,
     ) => {
         if (isCompleting) return;
 
@@ -21,7 +24,13 @@ export function useCompletePersonalRecommendationSelection() {
         try {
             const result = await personalRecommendationApi.selectCandidate(
                 requestId,
-                selectedCandidateId,
+                {
+                    selectedCandidateId,
+                    latitude: location.latitude,
+                    longitude: location.longitude,
+                    radiusMeters: location.radiusMeters,
+                    address: location.address,
+                },
             );
 
             setRecommendationState((prev) => {

--- a/src/features/personalRecommendation/infrastructure/api/dto/SelectPersonalRecommendationCandidateRequest.ts
+++ b/src/features/personalRecommendation/infrastructure/api/dto/SelectPersonalRecommendationCandidateRequest.ts
@@ -1,0 +1,8 @@
+export interface SelectPersonalRecommendationCandidateRequest {
+    readonly selectedCandidateId: number;
+
+    readonly latitude: number;
+    readonly longitude: number;
+    readonly radiusMeters: number;
+    readonly address: string;
+}

--- a/src/features/personalRecommendation/infrastructure/api/personalRecommendationApi.ts
+++ b/src/features/personalRecommendation/infrastructure/api/personalRecommendationApi.ts
@@ -4,6 +4,7 @@ import type { PersonalRecommendationHistory } from "@/features/personalRecommend
 import type { PersonalRecommendationRerollType } from "@/features/personalRecommendation/domain/model/PersonalRecommendationRerollType";
 
 import type { CreatePersonalRecommendationResponse } from "@/features/personalRecommendation/infrastructure/api/dto/CreatePersonalRecommendationResponse";
+import type { SelectPersonalRecommendationCandidateRequest } from "@/features/personalRecommendation/infrastructure/api/dto/SelectPersonalRecommendationCandidateRequest";
 import type { SelectPersonalRecommendationCandidateResponse } from "@/features/personalRecommendation/infrastructure/api/dto/SelectPersonalRecommendationCandidateResponse";
 import type { PersonalRecommendationHistoryResponse } from "@/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationHistoryResponse";
 import type { PersonalRecommendationDetailResponse } from "@/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse";
@@ -43,13 +44,14 @@ export const personalRecommendationApi = {
         return mapPersonalRecommendation(response.data);
     },
 
-    async selectCandidate(requestId: number, selectedCandidateId: number) {
+    async selectCandidate(
+        requestId: number,
+        request: SelectPersonalRecommendationCandidateRequest,
+    ) {
         const response =
             await httpClient.patch<SelectPersonalRecommendationCandidateResponse>(
                 `/api/v1/personal/recommendations/${requestId}`,
-                {
-                    selectedCandidateId,
-                },
+                request,
             );
 
         if (!response.success || !response.data) {

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationLocationCard.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationLocationCard.tsx
@@ -1,13 +1,16 @@
 import { MapPin } from "lucide-react";
+import { formatLocationRadius } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
 import { personalRecommendationPageStyles } from "@/ui/styles/personalRecommendationPageStyles";
 
 interface PersonalRecommendationLocationCardProps {
     readonly address: string;
+    readonly radiusMeters: number | null;
     readonly onClickEdit: () => void;
 }
 
 export default function PersonalRecommendationLocationCard({
     address,
+    radiusMeters,
     onClickEdit,
 }: PersonalRecommendationLocationCardProps) {
     return (
@@ -24,6 +27,12 @@ export default function PersonalRecommendationLocationCard({
                 <p className={personalRecommendationPageStyles.cardDescription}>
                     {address}
                 </p>
+
+                {radiusMeters !== null && (
+                    <p className={personalRecommendationPageStyles.locationRadius}>
+                        기본 검색 반경 {formatLocationRadius(radiusMeters)}
+                    </p>
+                )}
             </div>
 
             <button

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationResultContent.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationResultContent.tsx
@@ -27,6 +27,7 @@ interface PersonalRecommendationResultContentProps {
     ) => Promise<void>;
     readonly onRetryRecommendation: () => Promise<void>;
     readonly onClickRestaurant: (candidateId: number) => void;
+    readonly onClickChangeLocation: () => void;
 }
 
 export default function PersonalRecommendationResultContent({
@@ -40,6 +41,7 @@ export default function PersonalRecommendationResultContent({
     onCompleteSelection,
     onRetryRecommendation,
     onClickRestaurant,
+    onClickChangeLocation,
 }: PersonalRecommendationResultContentProps) {
     const [selectedCandidateId, setSelectedCandidateId] =
         useState<number | null>(
@@ -70,6 +72,7 @@ export default function PersonalRecommendationResultContent({
                 location={location}
                 isLocationLoading={isLocationLoading}
                 onBack={onBack}
+                onClickChangeLocation={onClickChangeLocation}
             />
         );
     }

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationResultContent.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationResultContent.tsx
@@ -3,16 +3,20 @@
 import { useState } from "react";
 import { ArrowLeft } from "lucide-react";
 
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
 import type { PersonalRecommendation } from "@/features/personalRecommendation/domain/model/PersonalRecommendation";
 
 import PersonalRecommendationResultCard from "@/features/personalRecommendation/ui/components/PersonalRecommendationResultCard";
 import PersonalRecommendationResultActionButtons from "@/features/personalRecommendation/ui/components/PersonalRecommendationResultActionButtons";
+import PersonalRecommendationSelectedResultContent from "@/features/personalRecommendation/ui/components/PersonalRecommendationSelectedResultContent";
 
 import { personalRecommendationResultPageStyles } from "@/ui/styles/personalRecommendationResultPageStyles";
 
 interface PersonalRecommendationResultContentProps {
     readonly recommendation: PersonalRecommendation;
     readonly keywords: readonly string[];
+    readonly location: LocationSetting | null;
+    readonly isLocationLoading: boolean;
 
     readonly isCompleting: boolean;
     readonly isRerolling: boolean;
@@ -28,6 +32,8 @@ interface PersonalRecommendationResultContentProps {
 export default function PersonalRecommendationResultContent({
     recommendation,
     keywords,
+    location,
+    isLocationLoading,
     isCompleting,
     isRerolling,
     onBack,
@@ -42,6 +48,11 @@ export default function PersonalRecommendationResultContent({
 
     const isClosed = recommendation.status !== "OPEN";
 
+    const selectedCandidate = recommendation.candidates.find(
+        (candidate) =>
+            candidate.id === recommendation.selectedCandidateId,
+    );
+
     const handleCompleteSelection = async () => {
         if (selectedCandidateId === null) {
             alert("추천 메뉴를 먼저 선택해 주세요.");
@@ -50,6 +61,18 @@ export default function PersonalRecommendationResultContent({
 
         await onCompleteSelection(selectedCandidateId);
     };
+
+    if (isClosed && selectedCandidate) {
+        return (
+            <PersonalRecommendationSelectedResultContent
+                selectedCandidate={selectedCandidate}
+                keywords={keywords}
+                location={location}
+                isLocationLoading={isLocationLoading}
+                onBack={onBack}
+            />
+        );
+    }
 
     return (
         <main className={personalRecommendationResultPageStyles.container}>
@@ -67,7 +90,7 @@ export default function PersonalRecommendationResultContent({
 
             {isClosed && (
                 <p className={personalRecommendationResultPageStyles.closedMessage}>
-                    메뉴 추천이 종료되었습니다.
+                    선택된 메뉴 정보를 불러오지 못했습니다.
                 </p>
             )}
 

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationSelectedRestaurantContent.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationSelectedRestaurantContent.tsx
@@ -15,11 +15,13 @@ import { personalRecommendationResultPageStyles } from "@/ui/styles/personalReco
 interface PersonalRecommendationSelectedRestaurantContentProps {
     readonly menuName: string;
     readonly location: LocationSetting;
+    readonly onClickChangeLocation: () => void;
 }
 
 export default function PersonalRecommendationSelectedRestaurantContent({
     menuName,
     location,
+    onClickChangeLocation,
 }: PersonalRecommendationSelectedRestaurantContentProps) {
     const baseRadiusMeters =
         location.radiusMeters as LocationRadiusMeters;
@@ -31,6 +33,9 @@ export default function PersonalRecommendationSelectedRestaurantContent({
         searchContext,
         isLoading,
         errorMessage,
+        isExpandedSearch,
+        hasNoRestaurants,
+        hasReachedMaximumRadius,
         selectRestaurant,
     } = useRecommendationRestaurants({
         menuName,
@@ -66,6 +71,20 @@ export default function PersonalRecommendationSelectedRestaurantContent({
                     >
                         {location.address}
                     </p>
+
+                    {isExpandedSearch && (
+                        <p
+                            className={
+                                personalRecommendationResultPageStyles.expandedSearchText
+                            }
+                        >
+                            기본 반경{" "}
+                            {formatLocationRadius(
+                                searchContext.baseRadiusMeters,
+                            )}
+                            에서 결과가 없어 검색 범위를 넓혔습니다.
+                        </p>
+                    )}
                 </div>
 
                 <span
@@ -100,32 +119,44 @@ export default function PersonalRecommendationSelectedRestaurantContent({
                 </div>
             )}
 
-            {!isLoading &&
-                !errorMessage &&
-                restaurants.length === 0 && (
+            {hasNoRestaurants &&
+                hasReachedMaximumRadius && (
                     <div
                         className={
-                            personalRecommendationResultPageStyles.messageBox
+                            personalRecommendationResultPageStyles.emptyRestaurantBox
                         }
                     >
-                        설정한 검색 반경 내에서 주변 맛집을 찾지
-                        못했습니다.
+                        <p>
+                            설정한 최대 반경 내에서 맛집을 찾지
+                            못했어요.
+                        </p>
+
+                        <button
+                            type="button"
+                            onClick={onClickChangeLocation}
+                            className={
+                                personalRecommendationResultPageStyles.changeLocationButton
+                            }
+                        >
+                            위치 변경
+                        </button>
                     </div>
                 )}
 
-            {!errorMessage && (
-                <div
-                    className={
-                        personalRecommendationResultPageStyles.restaurantLayout
-                    }
-                >
+            {!isLoading &&
+                !errorMessage &&
+                restaurants.length > 0 && (
                     <div
                         className={
-                            personalRecommendationResultPageStyles.restaurantList
+                            personalRecommendationResultPageStyles.restaurantLayout
                         }
                     >
-                        {!isLoading &&
-                            restaurants.map((restaurant) => (
+                        <div
+                            className={
+                                personalRecommendationResultPageStyles.restaurantList
+                            }
+                        >
+                            {restaurants.map((restaurant) => (
                                 <RecommendationRestaurantCard
                                     key={restaurant.id}
                                     restaurant={restaurant}
@@ -140,24 +171,24 @@ export default function PersonalRecommendationSelectedRestaurantContent({
                                     }
                                 />
                             ))}
-                    </div>
+                        </div>
 
-                    <RecommendationRestaurantMap
-                        latitude={location.latitude}
-                        longitude={location.longitude}
-                        level={DEFAULT_MAP_LEVEL}
-                        restaurants={restaurants}
-                        selectedRestaurant={selectedRestaurant}
-                        onSelectRestaurant={selectRestaurant}
-                        sectionClassName={
-                            personalRecommendationResultPageStyles.restaurantMapArea
-                        }
-                        mapClassName={
-                            personalRecommendationResultPageStyles.restaurantMap
-                        }
-                    />
-                </div>
-            )}
+                        <RecommendationRestaurantMap
+                            latitude={location.latitude}
+                            longitude={location.longitude}
+                            level={DEFAULT_MAP_LEVEL}
+                            restaurants={restaurants}
+                            selectedRestaurant={selectedRestaurant}
+                            onSelectRestaurant={selectRestaurant}
+                            sectionClassName={
+                                personalRecommendationResultPageStyles.restaurantMapArea
+                            }
+                            mapClassName={
+                                personalRecommendationResultPageStyles.restaurantMap
+                            }
+                        />
+                    </div>
+                )}
         </section>
     );
 }

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationSelectedRestaurantContent.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationSelectedRestaurantContent.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import type { LocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+import { formatLocationRadius } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+
+import { DEFAULT_MAP_LEVEL } from "@/features/map/domain/config/mapPolicy";
+
+import { useRecommendationRestaurants } from "@/features/recommendationRestaurant/application/hooks/useRecommendationRestaurants";
+import RecommendationRestaurantCard from "@/features/recommendationRestaurant/ui/components/RecommendationRestaurantCard";
+import RecommendationRestaurantMap from "@/features/recommendationRestaurant/ui/components/RecommendationRestaurantMap";
+
+import { personalRecommendationResultPageStyles } from "@/ui/styles/personalRecommendationResultPageStyles";
+
+interface PersonalRecommendationSelectedRestaurantContentProps {
+    readonly menuName: string;
+    readonly location: LocationSetting;
+}
+
+export default function PersonalRecommendationSelectedRestaurantContent({
+    menuName,
+    location,
+}: PersonalRecommendationSelectedRestaurantContentProps) {
+    const baseRadiusMeters =
+        location.radiusMeters as LocationRadiusMeters;
+
+    const {
+        restaurants,
+        selectedRestaurant,
+        selectedRestaurantId,
+        searchContext,
+        isLoading,
+        errorMessage,
+        selectRestaurant,
+    } = useRecommendationRestaurants({
+        menuName,
+        latitude: location.latitude,
+        longitude: location.longitude,
+        baseRadiusMeters,
+    });
+
+    return (
+        <section
+            className={
+                personalRecommendationResultPageStyles.restaurantSection
+            }
+        >
+            <div
+                className={
+                    personalRecommendationResultPageStyles.restaurantHeader
+                }
+            >
+                <div>
+                    <h2
+                        className={
+                            personalRecommendationResultPageStyles.restaurantTitle
+                        }
+                    >
+                        {menuName} 주변 맛집
+                    </h2>
+
+                    <p
+                        className={
+                            personalRecommendationResultPageStyles.restaurantDescription
+                        }
+                    >
+                        {location.address}
+                    </p>
+                </div>
+
+                <span
+                    className={
+                        personalRecommendationResultPageStyles.restaurantRadius
+                    }
+                >
+                    검색 반경{" "}
+                    {formatLocationRadius(
+                        searchContext.effectiveRadiusMeters,
+                    )}
+                </span>
+            </div>
+
+            {isLoading && (
+                <div
+                    className={
+                        personalRecommendationResultPageStyles.messageBox
+                    }
+                >
+                    주변 맛집을 불러오는 중입니다.
+                </div>
+            )}
+
+            {errorMessage && (
+                <div
+                    className={
+                        personalRecommendationResultPageStyles.errorBox
+                    }
+                >
+                    {errorMessage}
+                </div>
+            )}
+
+            {!isLoading &&
+                !errorMessage &&
+                restaurants.length === 0 && (
+                    <div
+                        className={
+                            personalRecommendationResultPageStyles.messageBox
+                        }
+                    >
+                        설정한 검색 반경 내에서 주변 맛집을 찾지
+                        못했습니다.
+                    </div>
+                )}
+
+            {!errorMessage && (
+                <div
+                    className={
+                        personalRecommendationResultPageStyles.restaurantLayout
+                    }
+                >
+                    <div
+                        className={
+                            personalRecommendationResultPageStyles.restaurantList
+                        }
+                    >
+                        {!isLoading &&
+                            restaurants.map((restaurant) => (
+                                <RecommendationRestaurantCard
+                                    key={restaurant.id}
+                                    restaurant={restaurant}
+                                    selected={
+                                        restaurant.id ===
+                                        selectedRestaurantId
+                                    }
+                                    onClick={() =>
+                                        selectRestaurant(
+                                            restaurant.id,
+                                        )
+                                    }
+                                />
+                            ))}
+                    </div>
+
+                    <RecommendationRestaurantMap
+                        latitude={location.latitude}
+                        longitude={location.longitude}
+                        level={DEFAULT_MAP_LEVEL}
+                        restaurants={restaurants}
+                        selectedRestaurant={selectedRestaurant}
+                        onSelectRestaurant={selectRestaurant}
+                        sectionClassName={
+                            personalRecommendationResultPageStyles.restaurantMapArea
+                        }
+                        mapClassName={
+                            personalRecommendationResultPageStyles.restaurantMap
+                        }
+                    />
+                </div>
+            )}
+        </section>
+    );
+}

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationSelectedResultContent.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationSelectedResultContent.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+
+import { isLocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+
+import type { RecommendedMenu } from "@/features/personalRecommendation/domain/model/PersonalRecommendation";
+
+import PersonalRecommendationSelectedRestaurantContent from "@/features/personalRecommendation/ui/components/PersonalRecommendationSelectedRestaurantContent";
+
+import { personalRecommendationResultPageStyles } from "@/ui/styles/personalRecommendationResultPageStyles";
+
+interface PersonalRecommendationSelectedResultContentProps {
+    readonly selectedCandidate: RecommendedMenu;
+    readonly keywords: readonly string[];
+    readonly location: LocationSetting | null;
+    readonly isLocationLoading: boolean;
+    readonly onBack: () => void;
+}
+
+export default function PersonalRecommendationSelectedResultContent({
+    selectedCandidate,
+    keywords,
+    location,
+    isLocationLoading,
+    onBack,
+}: PersonalRecommendationSelectedResultContentProps) {
+    return (
+        <main className={personalRecommendationResultPageStyles.container}>
+            <button
+                type="button"
+                onClick={onBack}
+                className={personalRecommendationResultPageStyles.backButton}
+            >
+                <ArrowLeft size={24} />
+            </button>
+
+            <h1 className={personalRecommendationResultPageStyles.title}>
+                메뉴 추천 결과
+            </h1>
+
+            <section className={personalRecommendationResultPageStyles.summaryCard}>
+                <h2 className={personalRecommendationResultPageStyles.summaryTitle}>
+                    취향 프로필 요약
+                </h2>
+
+                <div className={personalRecommendationResultPageStyles.keywordGroup}>
+                    {keywords.length > 0 ? (
+                        keywords.map((keyword) => (
+                            <span
+                                key={keyword}
+                                className={
+                                    personalRecommendationResultPageStyles.keywordChip
+                                }
+                            >
+                                #{keyword}
+                            </span>
+                        ))
+                    ) : (
+                        <span
+                            className={
+                                personalRecommendationResultPageStyles.emptyText
+                            }
+                        >
+                            표시할 취향 정보가 없습니다.
+                        </span>
+                    )}
+                </div>
+            </section>
+
+            <section
+                className={
+                    personalRecommendationResultPageStyles.selectedMenuSection
+                }
+            >
+                <span
+                    className={
+                        personalRecommendationResultPageStyles.selectedMenuLabel
+                    }
+                >
+                    선택한 메뉴
+                </span>
+
+                <h2
+                    className={
+                        personalRecommendationResultPageStyles.selectedMenuName
+                    }
+                >
+                    {selectedCandidate.menuName}
+                </h2>
+            </section>
+
+            {isLocationLoading && (
+                <div
+                    className={
+                        personalRecommendationResultPageStyles.messageBox
+                    }
+                >
+                    위치 정보를 불러오는 중입니다.
+                </div>
+            )}
+
+            {!isLocationLoading && location === null && (
+                <div
+                    className={
+                        personalRecommendationResultPageStyles.messageBox
+                    }
+                >
+                    설정된 위치가 없어 주변 맛집을 조회할 수 없습니다.
+                </div>
+            )}
+
+            {!isLocationLoading &&
+                location !== null &&
+                !isLocationRadiusMeters(location.radiusMeters) && (
+                    <div
+                        className={
+                            personalRecommendationResultPageStyles.errorBox
+                        }
+                    >
+                        저장된 맛집 검색 반경을 사용할 수 없습니다. 개인
+                        위치를 다시 설정해주세요.
+                    </div>
+                )}
+
+            {!isLocationLoading &&
+                location !== null &&
+                isLocationRadiusMeters(location.radiusMeters) && (
+                    <PersonalRecommendationSelectedRestaurantContent
+                        menuName={selectedCandidate.menuName}
+                        location={location}
+                    />
+                )}
+        </main>
+    );
+}

--- a/src/features/personalRecommendation/ui/components/PersonalRecommendationSelectedResultContent.tsx
+++ b/src/features/personalRecommendation/ui/components/PersonalRecommendationSelectedResultContent.tsx
@@ -17,6 +17,7 @@ interface PersonalRecommendationSelectedResultContentProps {
     readonly location: LocationSetting | null;
     readonly isLocationLoading: boolean;
     readonly onBack: () => void;
+    readonly onClickChangeLocation: () => void;
 }
 
 export default function PersonalRecommendationSelectedResultContent({
@@ -25,6 +26,7 @@ export default function PersonalRecommendationSelectedResultContent({
     location,
     isLocationLoading,
     onBack,
+    onClickChangeLocation,
 }: PersonalRecommendationSelectedResultContentProps) {
     return (
         <main className={personalRecommendationResultPageStyles.container}>
@@ -130,6 +132,9 @@ export default function PersonalRecommendationSelectedResultContent({
                     <PersonalRecommendationSelectedRestaurantContent
                         menuName={selectedCandidate.menuName}
                         location={location}
+                        onClickChangeLocation={
+                            onClickChangeLocation
+                        }
                     />
                 )}
         </main>

--- a/src/features/recommendationRestaurant/application/hooks/useRecommendationRestaurants.ts
+++ b/src/features/recommendationRestaurant/application/hooks/useRecommendationRestaurants.ts
@@ -3,7 +3,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { fetchRecommendationRestaurants } from "@/features/recommendationRestaurant/application/usecase/fetchRecommendationRestaurants";
-import { createRestaurantSearchRadiusSteps } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+import {
+    createRestaurantSearchRadiusSteps,
+    MAX_RESTAURANT_SEARCH_RADIUS_METERS,
+} from "@/features/locationSetting/domain/config/locationRadiusPolicy";
 
 import type { RecommendationRestaurant } from "@/features/recommendationRestaurant/domain/model/RecommendationRestaurant";
 import type { RecommendationRestaurantSearchContext } from "@/features/recommendationRestaurant/domain/model/RecommendationRestaurantSearchContext";
@@ -81,7 +84,10 @@ export function useRecommendationRestaurants({
                         radiusMeters,
                     });
 
-                if (requestSequenceRef.current !== currentRequestSequence) {
+                if (
+                    requestSequenceRef.current !==
+                    currentRequestSequence
+                ) {
                     return;
                 }
 
@@ -102,7 +108,10 @@ export function useRecommendationRestaurants({
             setRestaurants([]);
             setSelectedRestaurantId(null);
         } catch (error) {
-            if (requestSequenceRef.current !== currentRequestSequence) {
+            if (
+                requestSequenceRef.current !==
+                currentRequestSequence
+            ) {
                 return;
             }
 
@@ -115,7 +124,10 @@ export function useRecommendationRestaurants({
                     : "주변 맛집을 불러오지 못했습니다.",
             );
         } finally {
-            if (requestSequenceRef.current === currentRequestSequence) {
+            if (
+                requestSequenceRef.current ===
+                currentRequestSequence
+            ) {
                 setIsLoading(false);
             }
         }
@@ -149,6 +161,18 @@ export function useRecommendationRestaurants({
         effectiveRadiusMeters,
     };
 
+    const isExpandedSearch =
+        effectiveRadiusMeters > baseRadiusMeters;
+
+    const hasNoRestaurants =
+        !isLoading &&
+        errorMessage === null &&
+        restaurants.length === 0;
+
+    const hasReachedMaximumRadius =
+        effectiveRadiusMeters ===
+        MAX_RESTAURANT_SEARCH_RADIUS_METERS;
+
     return {
         restaurants,
         selectedRestaurant,
@@ -162,6 +186,9 @@ export function useRecommendationRestaurants({
 
         isLoading,
         errorMessage,
+        isExpandedSearch,
+        hasNoRestaurants,
+        hasReachedMaximumRadius,
 
         selectRestaurant: setSelectedRestaurantId,
         refetchRestaurants: loadRestaurants,

--- a/src/features/recommendationRestaurant/application/hooks/useRecommendationRestaurants.ts
+++ b/src/features/recommendationRestaurant/application/hooks/useRecommendationRestaurants.ts
@@ -1,77 +1,168 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { fetchRecommendationRestaurants } from "@/features/recommendationRestaurant/application/usecase/fetchRecommendationRestaurants";
+import { createRestaurantSearchRadiusSteps } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
 
 import type { RecommendationRestaurant } from "@/features/recommendationRestaurant/domain/model/RecommendationRestaurant";
-import { fetchRecommendationRestaurants } from "@/features/recommendationRestaurant/application/usecase/fetchRecommendationRestaurants";
+import type { RecommendationRestaurantSearchContext } from "@/features/recommendationRestaurant/domain/model/RecommendationRestaurantSearchContext";
+import type { LocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
 
 interface UseRecommendationRestaurantsParams {
     readonly menuName: string;
     readonly latitude: number;
     readonly longitude: number;
+    readonly baseRadiusMeters: LocationRadiusMeters;
 }
 
 export function useRecommendationRestaurants({
     menuName,
     latitude,
     longitude,
+    baseRadiusMeters,
 }: UseRecommendationRestaurantsParams) {
     const [restaurants, setRestaurants] = useState<
         readonly RecommendationRestaurant[]
     >([]);
+
     const [selectedRestaurantId, setSelectedRestaurantId] =
         useState<string | null>(null);
+
     const [isLoading, setIsLoading] = useState(false);
-    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [errorMessage, setErrorMessage] =
+        useState<string | null>(null);
+
+    const [
+        effectiveRadiusMeters,
+        setEffectiveRadiusMeters,
+    ] = useState<LocationRadiusMeters>(baseRadiusMeters);
+
+    const requestSequenceRef = useRef(0);
+
+    const resetSearchState = useCallback(() => {
+        setRestaurants([]);
+        setSelectedRestaurantId(null);
+        setErrorMessage(null);
+        setEffectiveRadiusMeters(baseRadiusMeters);
+    }, [baseRadiusMeters]);
 
     const loadRestaurants = useCallback(async () => {
         if (
-            !menuName ||
+            !menuName.trim() ||
             !Number.isFinite(latitude) ||
             !Number.isFinite(longitude)
         ) {
-            setRestaurants([]);
+            resetSearchState();
             return;
         }
 
+        const currentRequestSequence =
+            requestSequenceRef.current + 1;
+
+        requestSequenceRef.current =
+            currentRequestSequence;
+
+        const radiusSteps =
+            createRestaurantSearchRadiusSteps(
+                baseRadiusMeters,
+            );
+
         try {
             setIsLoading(true);
-            setErrorMessage(null);
+            resetSearchState();
 
-            const data = await fetchRecommendationRestaurants({
-                menuName,
-                latitude,
-                longitude,
-            });
+            for (const radiusMeters of radiusSteps) {
+                const data =
+                    await fetchRecommendationRestaurants({
+                        menuName,
+                        latitude,
+                        longitude,
+                        radiusMeters,
+                    });
 
-            setRestaurants(data);
-            setSelectedRestaurantId(data[0]?.id ?? null);
+                if (requestSequenceRef.current !== currentRequestSequence) {
+                    return;
+                }
+
+                setEffectiveRadiusMeters(radiusMeters);
+
+                if (data.length === 0) {
+                    continue;
+                }
+
+                setRestaurants(data);
+                setSelectedRestaurantId(
+                    data[0]?.id ?? null,
+                );
+
+                return;
+            }
+
+            setRestaurants([]);
+            setSelectedRestaurantId(null);
         } catch (error) {
+            if (requestSequenceRef.current !== currentRequestSequence) {
+                return;
+            }
+
+            setRestaurants([]);
+            setSelectedRestaurantId(null);
+
             setErrorMessage(
                 error instanceof Error
                     ? error.message
                     : "주변 맛집을 불러오지 못했습니다.",
             );
         } finally {
-            setIsLoading(false);
+            if (requestSequenceRef.current === currentRequestSequence) {
+                setIsLoading(false);
+            }
         }
-    }, [latitude, longitude, menuName]);
+    }, [
+        baseRadiusMeters,
+        latitude,
+        longitude,
+        menuName,
+        resetSearchState,
+    ]);
 
     useEffect(() => {
-        loadRestaurants();
+        void loadRestaurants();
+
+        return () => {
+            requestSequenceRef.current += 1;
+        };
     }, [loadRestaurants]);
 
     const selectedRestaurant =
         restaurants.find(
-            (restaurant) => restaurant.id === selectedRestaurantId,
+            (restaurant) =>
+                restaurant.id === selectedRestaurantId,
         ) ?? null;
+
+    const searchContext: RecommendationRestaurantSearchContext = {
+        menuName,
+        latitude,
+        longitude,
+        baseRadiusMeters,
+        effectiveRadiusMeters,
+    };
 
     return {
         restaurants,
         selectedRestaurant,
         selectedRestaurantId,
+
+        searchContext,
+        searchRadiusSteps:
+            createRestaurantSearchRadiusSteps(
+                baseRadiusMeters,
+            ),
+
         isLoading,
         errorMessage,
+
         selectRestaurant: setSelectedRestaurantId,
         refetchRestaurants: loadRestaurants,
     };

--- a/src/features/recommendationRestaurant/application/usecase/fetchRecommendationRestaurants.ts
+++ b/src/features/recommendationRestaurant/application/usecase/fetchRecommendationRestaurants.ts
@@ -1,9 +1,12 @@
 import { searchRecommendationRestaurants } from "@/features/recommendationRestaurant/infrastructure/kakao/searchRecommendationRestaurants";
 
+import type { LocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+
 interface FetchRecommendationRestaurantsParams {
     readonly menuName: string;
     readonly latitude: number;
     readonly longitude: number;
+    readonly radiusMeters: LocationRadiusMeters;
 }
 
 export async function fetchRecommendationRestaurants(

--- a/src/features/recommendationRestaurant/domain/model/RecommendationRestaurantSearchContext.ts
+++ b/src/features/recommendationRestaurant/domain/model/RecommendationRestaurantSearchContext.ts
@@ -1,0 +1,15 @@
+import type { LocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+
+export interface RecommendationRestaurantSearchContext {
+    readonly menuName: string;
+
+    readonly latitude: number;
+    readonly longitude: number;
+
+    // 서버에 저장된 개인 또는 그룹 위치의 기본 반경
+    // 자동 확장 결과로 변경하지 않음
+    readonly baseRadiusMeters: LocationRadiusMeters;
+
+    // 현재 카카오 맛집 검색에 실제 적용 중인 반경
+    readonly effectiveRadiusMeters: LocationRadiusMeters;
+}

--- a/src/features/recommendationRestaurant/infrastructure/kakao/searchRecommendationRestaurants.ts
+++ b/src/features/recommendationRestaurant/infrastructure/kakao/searchRecommendationRestaurants.ts
@@ -1,14 +1,15 @@
 import { clientEnv } from "@/infrastructure/config/env";
 import { loadKakaoMapScript } from "@/shared/lib/kakaoMap/loadKakaoMapScript";
+
 import type { RecommendationRestaurant } from "@/features/recommendationRestaurant/domain/model/RecommendationRestaurant";
+import type { LocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
 
 interface SearchRecommendationRestaurantsParams {
     readonly menuName: string;
     readonly latitude: number;
     readonly longitude: number;
+    readonly radiusMeters: LocationRadiusMeters;
 }
-
-const SEARCH_RADIUS_METERS = 1000;
 
 function formatDistance(distance?: string) {
     if (!distance) {
@@ -32,6 +33,7 @@ export async function searchRecommendationRestaurants({
     menuName,
     latitude,
     longitude,
+    radiusMeters,
 }: SearchRecommendationRestaurantsParams): Promise<
     readonly RecommendationRestaurant[]
 > {
@@ -39,23 +41,40 @@ export async function searchRecommendationRestaurants({
 
     return new Promise((resolve, reject) => {
         if (!window.kakao?.maps?.services) {
-            reject(new Error("카카오 지도 서비스를 불러오지 못했습니다."));
+            reject(
+                new Error(
+                    "카카오 지도 서비스를 불러오지 못했습니다.",
+                ),
+            );
             return;
         }
 
         const places = new window.kakao.maps.services.Places();
-        const location = new window.kakao.maps.LatLng(latitude, longitude);
+        const location = new window.kakao.maps.LatLng(
+            latitude,
+            longitude,
+        );
 
         places.keywordSearch(
             `${menuName} 맛집`,
             (result, status) => {
-                if (status === window.kakao?.maps.services.Status.ZERO_RESULT) {
+                if (
+                    status ===
+                    window.kakao?.maps.services.Status.ZERO_RESULT
+                ) {
                     resolve([]);
                     return;
                 }
 
-                if (status !== window.kakao?.maps.services.Status.OK) {
-                    reject(new Error("주변 맛집 검색에 실패했습니다."));
+                if (
+                    status !==
+                    window.kakao?.maps.services.Status.OK
+                ) {
+                    reject(
+                        new Error(
+                            "주변 맛집 검색에 실패했습니다.",
+                        ),
+                    );
                     return;
                 }
 
@@ -63,7 +82,9 @@ export async function searchRecommendationRestaurants({
                     result.map((place) => ({
                         id: place.id,
                         name: place.place_name,
-                        distanceText: formatDistance(place.distance),
+                        distanceText: formatDistance(
+                            place.distance,
+                        ),
                         latitude: Number(place.y),
                         longitude: Number(place.x),
                         address: place.address_name,
@@ -75,7 +96,7 @@ export async function searchRecommendationRestaurants({
             },
             {
                 location,
-                radius: SEARCH_RADIUS_METERS,
+                radius: radiusMeters,
                 sort: window.kakao.maps.services.SortBy.DISTANCE,
             },
         );

--- a/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantMap.tsx
+++ b/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantMap.tsx
@@ -21,6 +21,8 @@ interface RecommendationRestaurantMapProps {
     readonly restaurants: readonly RecommendationRestaurant[];
     readonly selectedRestaurant: RecommendationRestaurant | null;
     readonly onSelectRestaurant: (restaurantId: string) => void;
+    readonly sectionClassName?: string;
+    readonly mapClassName?: string;
 }
 
 export default function RecommendationRestaurantMap({
@@ -30,6 +32,8 @@ export default function RecommendationRestaurantMap({
     restaurants,
     selectedRestaurant,
     onSelectRestaurant,
+    sectionClassName,
+    mapClassName,
 }: RecommendationRestaurantMapProps) {
     const mapContainerRef = useRef<HTMLDivElement | null>(null);
     const mapRef = useRef<kakao.maps.Map | null>(null);
@@ -181,10 +185,18 @@ export default function RecommendationRestaurantMap({
     }, [selectedRestaurant]);
 
     return (
-        <section className={recommendationRestaurantPageStyles.mapArea}>
+        <section
+            className={
+                sectionClassName ??
+                recommendationRestaurantPageStyles.mapArea
+            }
+        >
             <div
                 ref={mapContainerRef}
-                className={recommendationRestaurantPageStyles.mapContainer}
+                className={
+                    mapClassName ??
+                    recommendationRestaurantPageStyles.mapContainer
+                }
             />
         </section>
     );

--- a/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantMap.tsx
+++ b/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantMap.tsx
@@ -77,11 +77,22 @@ export default function RecommendationRestaurantMap({
             marker.setMap(null);
         });
 
+        const bounds = new window.kakao.maps.LatLngBounds();
+
+        bounds.extend(
+            new window.kakao.maps.LatLng(
+                latitude,
+                longitude,
+            ),
+        );
+
         markerRecordsRef.current = restaurants.map((restaurant) => {
             const position = new window.kakao.maps.LatLng(
                 restaurant.latitude,
                 restaurant.longitude,
             );
+
+            bounds.extend(position);
 
             const marker = new window.kakao.maps.Marker({
                 map,
@@ -123,6 +134,10 @@ export default function RecommendationRestaurantMap({
             };
         });
 
+        if (restaurants.length > 0) {
+            map.setBounds(bounds);
+        }
+
         return () => {
             markerRecordsRef.current.forEach(({ marker, infoWindow }) => {
                 infoWindow?.close();
@@ -131,7 +146,12 @@ export default function RecommendationRestaurantMap({
 
             markerRecordsRef.current = [];
         };
-    }, [onSelectRestaurant, restaurants]);
+    }, [
+        latitude,
+        longitude,
+        onSelectRestaurant,
+        restaurants,
+    ]);
 
     useEffect(() => {
         const map = mapRef.current;

--- a/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantPageContent.tsx
+++ b/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantPageContent.tsx
@@ -7,6 +7,11 @@ import RecommendationRestaurantCard from "@/features/recommendationRestaurant/ui
 import RecommendationRestaurantMap from "@/features/recommendationRestaurant/ui/components/RecommendationRestaurantMap";
 import { useRecommendationRestaurants } from "@/features/recommendationRestaurant/application/hooks/useRecommendationRestaurants";
 
+import {
+    DEFAULT_LOCATION_RADIUS_METERS,
+    isLocationRadiusMeters,
+} from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+
 import { recommendationRestaurantPageStyles } from "@/ui/styles/recommendationRestaurantPageStyles";
 
 export default function RecommendationRestaurantPageContent() {
@@ -17,6 +22,16 @@ export default function RecommendationRestaurantPageContent() {
     const latitude = Number(searchParams.get("latitude"));
     const longitude = Number(searchParams.get("longitude"));
     const level = Number(searchParams.get("level") ?? 4);
+
+    const radiusMetersParam = Number(
+        searchParams.get("radiusMeters"),
+    );
+
+    const baseRadiusMeters = isLocationRadiusMeters(
+        radiusMetersParam,
+    )
+        ? radiusMetersParam
+        : DEFAULT_LOCATION_RADIUS_METERS;
 
     const source = searchParams.get("source") ?? "personal";
     const isGroupRecommendation = source === "group";
@@ -32,6 +47,7 @@ export default function RecommendationRestaurantPageContent() {
         menuName,
         latitude,
         longitude,
+        baseRadiusMeters,
     });
 
     if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
@@ -104,7 +120,9 @@ export default function RecommendationRestaurantPageContent() {
                                 key={restaurant.id}
                                 restaurant={restaurant}
                                 selected={restaurant.id === selectedRestaurantId}
-                                onClick={() => selectRestaurant(restaurant.id)}
+                                onClick={() =>
+                                    selectRestaurant(restaurant.id)
+                                }
                             />
                         ))}
                     </div>

--- a/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantPageContent.tsx
+++ b/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantPageContent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -7,8 +8,17 @@ import RecommendationRestaurantCard from "@/features/recommendationRestaurant/ui
 import RecommendationRestaurantMap from "@/features/recommendationRestaurant/ui/components/RecommendationRestaurantMap";
 import { useRecommendationRestaurants } from "@/features/recommendationRestaurant/application/hooks/useRecommendationRestaurants";
 
+import LocationModal from "@/features/locationSetting/ui/components/LocationModal";
+import GroupLocationEditModal from "@/features/group/ui/components/GroupLocationEditModal";
+
+import { useLocationSetting } from "@/features/locationSetting/application/hooks/useLocationSetting";
+import { useUpdateGroupLocation } from "@/features/group/application/hooks/useUpdateGroupLocation";
+
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+
 import {
     DEFAULT_LOCATION_RADIUS_METERS,
+    formatLocationRadius,
     isLocationRadiusMeters,
 } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
 
@@ -21,6 +31,7 @@ export default function RecommendationRestaurantPageContent() {
     const menuName = searchParams.get("menuName") ?? "추천 메뉴";
     const latitude = Number(searchParams.get("latitude"));
     const longitude = Number(searchParams.get("longitude"));
+    const address = searchParams.get("address") ?? "";
     const level = Number(searchParams.get("level") ?? 4);
 
     const radiusMetersParam = Number(
@@ -35,22 +46,107 @@ export default function RecommendationRestaurantPageContent() {
 
     const source = searchParams.get("source") ?? "personal";
     const isGroupRecommendation = source === "group";
+    const groupId = Number(searchParams.get("groupId"));
+
+    const [currentLocation, setCurrentLocation] =
+        useState<LocationSetting>({
+            latitude,
+            longitude,
+            address,
+            radiusMeters: baseRadiusMeters,
+            level,
+        });
+
+    const [
+        isLocationModalOpen,
+        setIsLocationModalOpen,
+    ] = useState(false);
+
+    const {
+        isSaving: isPersonalLocationSaving,
+        saveLocation,
+    } = useLocationSetting();
+
+    const {
+        isUpdating: isGroupLocationUpdating,
+        update: updateGroupLocation,
+        clearMessage: clearGroupLocationMessage,
+    } = useUpdateGroupLocation();
+
+    const currentBaseRadiusMeters =
+        isLocationRadiusMeters(
+            currentLocation.radiusMeters,
+        )
+            ? currentLocation.radiusMeters
+            : DEFAULT_LOCATION_RADIUS_METERS;
 
     const {
         restaurants,
         selectedRestaurant,
         selectedRestaurantId,
+        searchContext,
         isLoading,
         errorMessage,
+        isExpandedSearch,
+        hasNoRestaurants,
+        hasReachedMaximumRadius,
         selectRestaurant,
     } = useRecommendationRestaurants({
         menuName,
-        latitude,
-        longitude,
-        baseRadiusMeters,
+        latitude: currentLocation.latitude,
+        longitude: currentLocation.longitude,
+        baseRadiusMeters: currentBaseRadiusMeters,
     });
 
-    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    const handleOpenLocationModal = () => {
+        if (
+            isGroupRecommendation &&
+            !Number.isFinite(groupId)
+        ) {
+            alert("그룹 정보를 확인할 수 없습니다.");
+            return;
+        }
+
+        clearGroupLocationMessage();
+        setIsLocationModalOpen(true);
+    };
+
+    const handleSavePersonalLocation = async (
+        nextLocation: LocationSetting,
+    ) => {
+        const isSaved =
+            await saveLocation(nextLocation);
+
+        if (!isSaved) {
+            return false;
+        }
+
+        setCurrentLocation(nextLocation);
+        setIsLocationModalOpen(false);
+
+        return true;
+    };
+
+    const handleSaveGroupLocation = async (
+        nextLocation: LocationSetting,
+    ) => {
+        if (!Number.isFinite(groupId)) {
+            return;
+        }
+
+        await updateGroupLocation(
+            groupId,
+            nextLocation,
+        );
+
+        setCurrentLocation(nextLocation);
+        setIsLocationModalOpen(false);
+    };
+
+    if (
+        !Number.isFinite(currentLocation.latitude) ||
+        !Number.isFinite(currentLocation.longitude)
+    ) {
         return (
             <main className={recommendationRestaurantPageStyles.container}>
                 <section className={recommendationRestaurantPageStyles.listSection}>
@@ -59,7 +155,10 @@ export default function RecommendationRestaurantPageContent() {
                         onClick={() => router.back()}
                         className={recommendationRestaurantPageStyles.backButton}
                     >
-                        <ArrowLeft size={30} strokeWidth={2.5} />
+                        <ArrowLeft
+                            size={30}
+                            strokeWidth={2.5}
+                        />
                     </button>
 
                     <div className={recommendationRestaurantPageStyles.messageBox}>
@@ -71,72 +170,187 @@ export default function RecommendationRestaurantPageContent() {
     }
 
     return (
-        <main className={recommendationRestaurantPageStyles.container}>
-            <section className={recommendationRestaurantPageStyles.listSection}>
-                <button
-                    type="button"
-                    onClick={() => router.back()}
-                    className={recommendationRestaurantPageStyles.backButton}
-                >
-                    <ArrowLeft size={26} />
-                </button>
+        <>
+            <main className={recommendationRestaurantPageStyles.container}>
+                <section className={recommendationRestaurantPageStyles.listSection}>
+                    <button
+                        type="button"
+                        onClick={() => router.back()}
+                        className={recommendationRestaurantPageStyles.backButton}
+                    >
+                        <ArrowLeft size={26} />
+                    </button>
 
-                <div className={recommendationRestaurantPageStyles.titleSection}>
-                    <h1 className={recommendationRestaurantPageStyles.title}>
-                        {isGroupRecommendation
-                            ? "투표 결과"
-                            : `${menuName} 맛집`}
-                    </h1>
+                    <div className={recommendationRestaurantPageStyles.titleSection}>
+                        <h1 className={recommendationRestaurantPageStyles.title}>
+                            {isGroupRecommendation
+                                ? "투표 결과"
+                                : `${menuName} 맛집`}
+                        </h1>
 
-                    {isGroupRecommendation && (
-                        <p className={recommendationRestaurantPageStyles.selectedMenuText}>
-                            선정 메뉴: {menuName}
-                        </p>
-                    )}
-                </div>
-
-                {isLoading && (
-                    <div className={recommendationRestaurantPageStyles.messageBox}>
-                        주변 맛집을 불러오는 중...
-                    </div>
-                )}
-
-                {errorMessage && (
-                    <div className={recommendationRestaurantPageStyles.errorBox}>
-                        {errorMessage}
-                    </div>
-                )}
-
-                {!isLoading && !errorMessage && restaurants.length === 0 && (
-                    <div className={recommendationRestaurantPageStyles.messageBox}>
-                        주변 맛집을 찾지 못했습니다.
-                    </div>
-                )}
-
-                {!isLoading && !errorMessage && restaurants.length > 0 && (
-                    <div className={recommendationRestaurantPageStyles.restaurantList}>
-                        {restaurants.map((restaurant) => (
-                            <RecommendationRestaurantCard
-                                key={restaurant.id}
-                                restaurant={restaurant}
-                                selected={restaurant.id === selectedRestaurantId}
-                                onClick={() =>
-                                    selectRestaurant(restaurant.id)
+                        {isGroupRecommendation && (
+                            <p
+                                className={
+                                    recommendationRestaurantPageStyles.selectedMenuText
                                 }
-                            />
-                        ))}
-                    </div>
-                )}
-            </section>
+                            >
+                                선정 메뉴: {menuName}
+                            </p>
+                        )}
 
-            <RecommendationRestaurantMap
-                latitude={latitude}
-                longitude={longitude}
-                level={level}
-                restaurants={restaurants}
-                selectedRestaurant={selectedRestaurant}
-                onSelectRestaurant={selectRestaurant}
-            />
-        </main>
+                        <p
+                            className={
+                                recommendationRestaurantPageStyles.searchLocationText
+                            }
+                        >
+                            {currentLocation.address}
+                        </p>
+
+                        <p
+                            className={
+                                recommendationRestaurantPageStyles.searchRadiusText
+                            }
+                        >
+                            검색 반경{" "}
+                            {formatLocationRadius(
+                                searchContext.effectiveRadiusMeters,
+                            )}
+                        </p>
+
+                        {isExpandedSearch && (
+                            <p
+                                className={
+                                    recommendationRestaurantPageStyles.expandedSearchText
+                                }
+                            >
+                                기본 반경{" "}
+                                {formatLocationRadius(
+                                    searchContext.baseRadiusMeters,
+                                )}
+                                에서 결과가 없어 검색 범위를
+                                넓혔습니다.
+                            </p>
+                        )}
+                    </div>
+
+                    {isLoading && (
+                        <div className={recommendationRestaurantPageStyles.messageBox}>
+                            주변 맛집을 불러오는 중...
+                        </div>
+                    )}
+
+                    {errorMessage && (
+                        <div className={recommendationRestaurantPageStyles.errorBox}>
+                            {errorMessage}
+                        </div>
+                    )}
+
+                    {hasNoRestaurants &&
+                        hasReachedMaximumRadius && (
+                            <div
+                                className={
+                                    recommendationRestaurantPageStyles.emptyResultBox
+                                }
+                            >
+                                <p>
+                                    설정한 최대 반경 내에서 맛집을
+                                    찾지 못했어요.
+                                </p>
+
+                                <button
+                                    type="button"
+                                    onClick={
+                                        handleOpenLocationModal
+                                    }
+                                    className={
+                                        recommendationRestaurantPageStyles.changeLocationButton
+                                    }
+                                >
+                                    위치 변경
+                                </button>
+                            </div>
+                        )}
+
+                    {!isLoading &&
+                        !errorMessage &&
+                        restaurants.length > 0 && (
+                            <div
+                                className={
+                                    recommendationRestaurantPageStyles.restaurantList
+                                }
+                            >
+                                {restaurants.map(
+                                    (restaurant) => (
+                                        <RecommendationRestaurantCard
+                                            key={restaurant.id}
+                                            restaurant={
+                                                restaurant
+                                            }
+                                            selected={
+                                                restaurant.id ===
+                                                selectedRestaurantId
+                                            }
+                                            onClick={() =>
+                                                selectRestaurant(
+                                                    restaurant.id,
+                                                )
+                                            }
+                                        />
+                                    ),
+                                )}
+                            </div>
+                        )}
+                </section>
+
+                <RecommendationRestaurantMap
+                    latitude={
+                        currentLocation.latitude
+                    }
+                    longitude={
+                        currentLocation.longitude
+                    }
+                    level={currentLocation.level}
+                    restaurants={restaurants}
+                    selectedRestaurant={
+                        selectedRestaurant
+                    }
+                    onSelectRestaurant={
+                        selectRestaurant
+                    }
+                />
+            </main>
+
+            {!isGroupRecommendation && (
+                <LocationModal
+                    isOpen={isLocationModalOpen}
+                    initialLocation={currentLocation}
+                    isSaving={
+                        isPersonalLocationSaving
+                    }
+                    onClose={() =>
+                        setIsLocationModalOpen(false)
+                    }
+                    onSave={
+                        handleSavePersonalLocation
+                    }
+                />
+            )}
+
+            {isGroupRecommendation &&
+                isLocationModalOpen && (
+                    <GroupLocationEditModal
+                        location={currentLocation}
+                        isUpdating={
+                            isGroupLocationUpdating
+                        }
+                        onClose={() =>
+                            setIsLocationModalOpen(false)
+                        }
+                        onSubmit={
+                            handleSaveGroupLocation
+                        }
+                    />
+                )}
+        </>
     );
 }

--- a/src/shared/lib/kakaoMap/kakaoMap.d.ts
+++ b/src/shared/lib/kakaoMap/kakaoMap.d.ts
@@ -22,6 +22,8 @@ declare global {
             panTo(latlng: LatLng): void;
 
             getBounds(): LatLngBounds;
+            setBounds(bounds: LatLngBounds): void;
+
             getLevel(): number;
             setLevel(level: number): void;
 
@@ -33,6 +35,16 @@ declare global {
             setMap(map: Map | null): void;
         }
 
+        class Circle {
+            constructor(options: CircleOptions);
+
+            setMap(map: Map | null): void;
+            setPosition(position: LatLng): void;
+            setRadius(radius: number): void;
+
+            getBounds(): LatLngBounds;
+        }
+
         class InfoWindow {
             constructor(options: InfoWindowOptions);
             open(map: Map, marker: Marker): void;
@@ -40,8 +52,12 @@ declare global {
         }
 
         class LatLngBounds {
+            constructor(sw?: LatLng, ne?: LatLng);
+
             getSouthWest(): LatLng;
             getNorthEast(): LatLng;
+
+            extend(latlng: LatLng): void;
         }
 
         interface MapOptions {
@@ -52,6 +68,20 @@ declare global {
         interface MarkerOptions {
             map?: Map;
             position: LatLng;
+        }
+
+        interface CircleOptions {
+            map?: Map;
+            center: LatLng;
+            radius: number;
+
+            strokeWeight?: number;
+            strokeColor?: string;
+            strokeOpacity?: number;
+            strokeStyle?: string;
+
+            fillColor?: string;
+            fillOpacity?: number;
         }
 
         interface InfoWindowOptions {

--- a/src/ui/styles/groupCreateModalStyles.ts
+++ b/src/ui/styles/groupCreateModalStyles.ts
@@ -33,4 +33,15 @@ export const groupCreateModalStyles = {
         "flex items-center gap-2 rounded-full bg-blue-600 px-10 py-4 text-lg font-bold text-white shadow-lg transition cursor-pointer hover:bg-blue-700",
     disabledButton:
         "flex cursor-not-allowed items-center gap-2 rounded-full bg-zinc-300 px-10 py-4 text-lg font-bold text-zinc-500",
+    radiusSection: "rounded-2xl border border-gray-200 bg-white p-5",
+    radiusHeader: "flex items-center justify-between gap-4",
+    radiusTitle: "text-base font-semibold text-gray-900",
+    radiusValue: "rounded-full bg-emerald-50 px-3 py-1 text-sm font-semibold text-emerald-700",
+    radiusDescription: "mt-1 text-sm text-gray-500",
+    radiusOptions: "mt-4 grid grid-cols-3 gap-2",
+    radiusButton:
+        "rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:border-emerald-300 hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-50",
+    selectedRadiusButton:
+        "rounded-xl border border-emerald-500 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700 transition disabled:cursor-not-allowed disabled:opacity-50",
+    radiusErrorMessage: "mt-2 text-sm text-red-500",
 } as const;

--- a/src/ui/styles/groupDetailPanelStyles.ts
+++ b/src/ui/styles/groupDetailPanelStyles.ts
@@ -47,4 +47,7 @@ export const groupDetailPanelStyles = {
     activitySection: "mt-8 flex-1",
     emptyActivityBox:
         "flex h-full min-h-[180px] items-center justify-center rounded-[28px] border border-zinc-200 text-slate-400",
+
+    locationInfo: "flex flex-col gap-1",
+    locationRadius: "pl-6 text-sm font-medium text-emerald-700",
 } as const;

--- a/src/ui/styles/groupLocationEditModalStyles.ts
+++ b/src/ui/styles/groupLocationEditModalStyles.ts
@@ -25,4 +25,15 @@ export const groupLocationEditModalStyles = {
         "flex h-12 items-center gap-2 rounded-full bg-indigo-600 px-9 text-sm font-semibold text-white shadow-lg transition cursor-pointer hover:bg-indigo-700",
     disabledButton:
         "flex h-12 cursor-not-allowed items-center gap-2 rounded-full bg-zinc-300 px-9 text-sm font-semibold text-zinc-500",
+    radiusSection: "rounded-2xl border border-gray-200 bg-white p-5",
+    radiusHeader: "flex items-center justify-between gap-4",
+    radiusTitle: "text-base font-semibold text-gray-900",
+    radiusValue: "rounded-full bg-emerald-50 px-3 py-1 text-sm font-semibold text-emerald-700",
+    radiusDescription: "mt-1 text-sm text-gray-500",
+    radiusOptions: "mt-4 grid grid-cols-3 gap-2",
+    radiusButton:
+        "rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:border-emerald-300 hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-50",
+    selectedRadiusButton:
+        "rounded-xl border border-emerald-500 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700 transition disabled:cursor-not-allowed disabled:opacity-50",
+    radiusErrorMessage: "mt-2 text-sm text-red-500",
 } as const;

--- a/src/ui/styles/locationModalStyles.ts
+++ b/src/ui/styles/locationModalStyles.ts
@@ -39,4 +39,22 @@ export const locationModalStyles = {
         "flex items-center gap-2 text-sm font-medium text-zinc-600",
     saveButton:
         "flex h-14 w-[150px] items-center justify-center gap-2 rounded-full bg-[#4f46e5] text-base font-semibold text-white shadow-lg transition cursor-pointer hover:bg-[#4338ca]",
+    radiusSection:
+        "rounded-2xl border border-gray-200 bg-white p-5",
+    radiusHeader:
+        "flex items-center justify-between gap-4",
+    radiusTitle:
+        "text-base font-semibold text-gray-900",
+    radiusValue:
+        "rounded-full bg-emerald-50 px-3 py-1 text-sm font-semibold text-emerald-700",
+    radiusDescription:
+        "mt-1 text-sm text-gray-500",
+    radiusOptions:
+        "mt-4 grid grid-cols-3 gap-2",
+    radiusButton:
+        "rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:border-emerald-300 hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-50",
+    selectedRadiusButton:
+        "rounded-xl border border-emerald-500 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700 transition disabled:cursor-not-allowed disabled:opacity-50",
+    radiusErrorMessage:
+        "mt-2 text-sm text-red-500",
 } as const;

--- a/src/ui/styles/personalRecommendationPageStyles.ts
+++ b/src/ui/styles/personalRecommendationPageStyles.ts
@@ -37,4 +37,6 @@ export const personalRecommendationPageStyles = {
         "flex items-center justify-between rounded-2xl bg-zinc-100 px-5 py-4 text-left text-zinc-500 transition hover:bg-zinc-200",
     historyDetailButton:
         "text-sm cursor-pointer font-semibold text-orange-500",
+    locationRadius:
+        "mt-1 text-sm font-medium text-emerald-700",
 } as const;

--- a/src/ui/styles/personalRecommendationResultPageStyles.ts
+++ b/src/ui/styles/personalRecommendationResultPageStyles.ts
@@ -19,4 +19,32 @@ export const personalRecommendationResultPageStyles = {
         "text-sm font-medium text-zinc-500",
     cardGrid:
         "mt-16 grid grid-cols-3 gap-8",
+    selectedMenuSection:
+        "mt-6 rounded-2xl border border-emerald-200 bg-emerald-50 px-6 py-5",
+    selectedMenuLabel:
+        "text-sm font-medium text-emerald-700",
+    selectedMenuName:
+        "mt-1 text-3xl font-bold text-gray-900",
+    restaurantSection:
+        "mt-6 rounded-2xl border border-gray-200 bg-white p-6",
+    restaurantHeader:
+        "flex items-start justify-between gap-4",
+    restaurantTitle:
+        "text-xl font-bold text-gray-900",
+    restaurantDescription:
+        "mt-1 text-sm text-gray-500",
+    restaurantRadius:
+        "shrink-0 rounded-full bg-emerald-50 px-3 py-1 text-sm font-semibold text-emerald-700",
+    restaurantLayout:
+        "mt-5 grid min-h-[520px] grid-cols-[360px_minmax(0,1fr)] overflow-hidden rounded-2xl border border-gray-200",
+    restaurantList:
+        "max-h-[520px] overflow-y-auto border-r border-gray-200 bg-white p-4",
+    restaurantMapArea:
+        "min-h-[520px] bg-gray-100",
+    restaurantMap:
+        "h-full min-h-[520px] w-full",
+    messageBox:
+        "mt-5 rounded-xl bg-gray-50 px-5 py-4 text-sm text-gray-600",
+    errorBox:
+        "mt-5 rounded-xl bg-red-50 px-5 py-4 text-sm text-red-600",
 } as const;

--- a/src/ui/styles/personalRecommendationResultPageStyles.ts
+++ b/src/ui/styles/personalRecommendationResultPageStyles.ts
@@ -47,4 +47,10 @@ export const personalRecommendationResultPageStyles = {
         "mt-5 rounded-xl bg-gray-50 px-5 py-4 text-sm text-gray-600",
     errorBox:
         "mt-5 rounded-xl bg-red-50 px-5 py-4 text-sm text-red-600",
+    expandedSearchText:
+        "mt-2 text-sm text-emerald-600",
+    emptyRestaurantBox:
+        "mt-5 flex flex-col items-center gap-4 rounded-xl bg-gray-50 px-5 py-6 text-center text-sm text-gray-600",
+    changeLocationButton:
+        "rounded-xl bg-emerald-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-emerald-600",
 } as const;

--- a/src/ui/styles/recommendationRestaurantPageStyles.ts
+++ b/src/ui/styles/recommendationRestaurantPageStyles.ts
@@ -32,4 +32,11 @@ export const recommendationRestaurantPageStyles = {
 
     mapArea: "relative min-w-0 flex-1 overflow-hidden bg-[#E9E7E2]",
     mapContainer: "h-full w-full",
+
+    searchLocationText: "mt-2 text-sm text-gray-500",
+    searchRadiusText: "mt-1 text-sm font-semibold text-emerald-700",
+    expandedSearchText: "mt-1 text-sm text-emerald-600",
+    emptyResultBox: "flex flex-col items-center gap-4 rounded-2xl bg-white px-6 py-8 text-center text-gray-600",
+    changeLocationButton:
+        "rounded-xl bg-emerald-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-emerald-600",
 } as const;


### PR DESCRIPTION
## 관련 노션 백로그
MC- 85, 86, 87, 88, 89, 90

## 요약
- 무엇을 변경했나요?
  - 개인 메뉴 선택 및 그룹 최종 메뉴 확정 요청에 확정 시점의 위도, 경도, 주소, 기본 검색 반경을 포함하도록 수정
  - 개인/그룹 위치와 맛집 검색에서 사용하는 반경 정책을 공통 상수와 검색 단계 생성 함수로 통합 및 저장된 기본 반경과 실제 검색에 적용된 반경을 분리
  - 개인 위치 설정, 그룹 생성 및 그룹 위치 수정 화면에서 1km, 3km, 5km 중 기본 맛집 검색 반경을 선택하고 저장할 수 있도록 추가
  - 개인 추천 메뉴가 확정된 경우 취향 프로필 요약, 선택 메뉴명, 해당 메뉴의 맛집 지도와 목록을 한 화면에서 확인하도록 결과 화면을 개편
  - 히스토리의 자세히 보기에서도 동일한 화면을 사용하도록 연결
  - 기본 반경에서 맛집이 없으면 저장된 반경을 기준으로 최대 5km까지 단계적으로 검색하고, 확장 검색에 실제 사용된 반경을 화면에 표시하도록 구현
  - 최대 반경에서도 맛집이 없으면 개인 또는 그룹 위치 변경 모달을 열 수 있는 위치 변경 버튼을 제공하고, 위치 저장 후 새 위치와 기본 반경을 기준으로 다시 검색하도록 처리
 
- 왜 이 변경이 필요한가요?
  - 추천 확정 당시의 위치 컨텍스트를 서버에 정확히 저장하여 이후 추천 이력과 결과의 기준을 일관되게 유지
  - 여러 파일에 하드코딩된 반경 값을 공통 정책으로 관리하고, 자동 확장에 사용한 임시 반경이 사용자의 저장 위치나 추천 확정 스냅샷에 잘못 반영되는 문제를 방지
  - 사용자가 자신의 이동 가능 범위에 맞게 기본 맛집 검색 반경을 설정하고, 개인 및 그룹 추천 전 과정에서 동일한 반경을 사용
  - 메뉴 선택 이후 별도의 화면을 반복해서 이동하지 않고 선택 메뉴와 주변 맛집을 한 화면에서 확인할 수 있도록 사용자 흐름을 개선
  - 기본 반경에서 검색 결과가 없을 때 단순히 빈 상태만 보여주지 않고 자동 반경 확장과 위치 변경이라는 다음 행동을 제공하여 맛집 탐색이 중단되지 않도록 하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
