### PR TITLE
[Fix] 개인 추천 확정 시 선택 메뉴의 실제 검색 반경 저장 (MC-91)

### DIFF
--- a/src/app/personal-recommendation/[requestId]/result/page.tsx
+++ b/src/app/personal-recommendation/[requestId]/result/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/features/personalRecommendation/application/selectors/personalRecommendationSelectors";
 
 import { parsePersonalRecommendationRequestId } from "@/features/personalRecommendation/application/usecase/parsePersonalRecommendationRequestId";
+import { personalRecommendationSearchRadiusStorage } from "@/features/personalRecommendation/infrastructure/storage/personalRecommendationSearchRadiusStorage";
 
 import PersonalRecommendationResultContent from "@/features/personalRecommendation/ui/components/PersonalRecommendationResultContent";
 import { personalRecommendationResultPageStyles } from "@/ui/styles/personalRecommendationResultPageStyles";
@@ -54,15 +55,12 @@ function PersonalRecommendationResultPageContent() {
             params.requestId,
         );
 
-    // URL의 requestId를 기준으로 추천 상세 조회 실행
     usePersonalRecommendationDetail({
         requestId,
     });
 
-    // 새로고침 또는 직접 접근 시 취향 정보 조회 실행
     usePreferenceList();
 
-    // 추천 결과 화면에 필요한 개인 추천 상태
     const recommendation = useAtomValue(
         personalRecommendationResultAtom,
     );
@@ -75,7 +73,6 @@ function PersonalRecommendationResultPageContent() {
         personalRecommendationErrorAtom,
     );
 
-    // 추천 결과 화면에 필요한 취향 상태
     const preference = useAtomValue(
         userPreferenceAtom,
     );
@@ -84,7 +81,6 @@ function PersonalRecommendationResultPageContent() {
         isPreferenceLoadingAtom,
     );
 
-    // 서버에 저장된 개인 위치 조회 및 저장
     const {
         location,
         isLoading: isLocationLoading,
@@ -92,12 +88,16 @@ function PersonalRecommendationResultPageContent() {
         saveLocation,
     } = useLocationSetting();
 
-    // 추천 메뉴 선택 완료
-    const { isCompleting, completeSelection } =
+    const {
+        isCompleting,
+        completeSelection,
+    } =
         useCompletePersonalRecommendationSelection();
 
-    // 개인 메뉴 추천 재요청
-    const { isRerolling, rerollRecommendation } =
+    const {
+        isRerolling,
+        rerollRecommendation,
+    } =
         useRerollPersonalRecommendation();
 
     useEffect(() => {
@@ -105,8 +105,13 @@ function PersonalRecommendationResultPageContent() {
             return;
         }
 
-        alert("유효하지 않은 추천 결과 경로입니다.");
-        router.replace("/personal-recommendation");
+        alert(
+            "유효하지 않은 추천 결과 경로입니다.",
+        );
+
+        router.replace(
+            "/personal-recommendation",
+        );
     }, [requestId, router]);
 
     useEffect(() => {
@@ -115,10 +120,12 @@ function PersonalRecommendationResultPageContent() {
         }
 
         alert(recommendationError);
-        router.replace("/personal-recommendation");
+
+        router.replace(
+            "/personal-recommendation",
+        );
     }, [recommendationError, router]);
 
-    // 잘못된 경로는 redirect가 완료될 때까지 화면을 렌더링하지 않음
     if (requestId === null) {
         return null;
     }
@@ -126,7 +133,6 @@ function PersonalRecommendationResultPageContent() {
     const isCurrentRecommendation =
         recommendation?.requestId === requestId;
 
-    // 결과 데이터가 준비될 때까지 결과 페이지의 기본 영역을 유지
     if (
         isRecommendationLoading ||
         isPreferenceLoading ||
@@ -134,7 +140,9 @@ function PersonalRecommendationResultPageContent() {
     ) {
         return (
             <main
-                className={personalRecommendationResultPageStyles.container}
+                className={
+                    personalRecommendationResultPageStyles.container
+                }
             />
         );
     }
@@ -147,83 +155,140 @@ function PersonalRecommendationResultPageContent() {
     }
 
     const keywords =
-        getPreferenceSummaryKeywords(preference);
+        getPreferenceSummaryKeywords(
+            preference,
+        );
+
+    const resultLocation =
+        recommendation.status !== "OPEN"
+            ? recommendation.locationSnapshot ??
+              location
+            : location;
 
     const handleCompleteSelection = async (
         selectedCandidateId: number,
     ) => {
         if (isLocationLoading) {
-            alert("위치 정보를 불러오는 중입니다.");
+            alert(
+                "위치 정보를 불러오는 중입니다.",
+            );
             return;
         }
 
         if (!location) {
-            alert("설정된 위치가 없습니다. 위치를 설정해주세요.");
+            alert(
+                "설정된 위치가 없습니다. 위치를 설정해주세요.",
+            );
             return;
         }
 
-        await completeSelection(
+        const effectiveRadiusMeters =
+            personalRecommendationSearchRadiusStorage.get(
+                recommendation.requestId,
+                selectedCandidateId,
+            ) ?? location.radiusMeters;
+
+        const selectionLocation: LocationSetting = {
+            ...location,
+            radiusMeters:
+                effectiveRadiusMeters,
+        };
+
+        const result = await completeSelection(
             recommendation.requestId,
             selectedCandidateId,
-            location,
+            selectionLocation,
+        );
+
+        if (!result) {
+            return;
+        }
+
+        personalRecommendationSearchRadiusStorage.remove(
+            recommendation.requestId,
+            selectedCandidateId,
         );
     };
 
-    const handleClickRestaurant = (candidateId: number) => {
-        const candidate = recommendation.candidates.find(
-            (item) => item.id === candidateId,
-        );
+    const handleClickRestaurant = (
+        candidateId: number,
+    ) => {
+        const candidate =
+            recommendation.candidates.find(
+                (item) =>
+                    item.id === candidateId,
+            );
 
         if (!candidate) {
             return;
         }
 
         if (isLocationLoading) {
-            alert("위치 정보를 불러오는 중입니다.");
+            alert(
+                "위치 정보를 불러오는 중입니다.",
+            );
             return;
         }
 
         if (!location) {
-            alert("설정된 위치가 없습니다. 위치를 설정해주세요.");
+            alert(
+                "설정된 위치가 없습니다. 위치를 설정해주세요.",
+            );
             return;
         }
 
-        const searchParams = new URLSearchParams({
-            menuName: candidate.menuName,
-            latitude: String(location.latitude),
-            longitude: String(location.longitude),
-            address: location.address,
-            radiusMeters: String(location.radiusMeters),
-            level: "4",
-            source: "personal",
-        });
+        const searchParams =
+            new URLSearchParams({
+                requestId: String(
+                    recommendation.requestId,
+                ),
+                candidateId: String(
+                    candidate.id,
+                ),
+                menuName: candidate.menuName,
+                latitude: String(
+                    location.latitude,
+                ),
+                longitude: String(
+                    location.longitude,
+                ),
+                address: location.address,
+                radiusMeters: String(
+                    location.radiusMeters,
+                ),
+                level: "4",
+                source: "personal",
+            });
 
         router.push(
             `/recommendation-restaurants?${searchParams.toString()}`,
         );
     };
 
-    const handleRetryRecommendation = async () => {
-        const nextRecommendation =
-            await rerollRecommendation(
-                recommendation.requestId,
-                "NOT_SATISFIED",
+    const handleRetryRecommendation =
+        async () => {
+            const nextRecommendation =
+                await rerollRecommendation(
+                    recommendation.requestId,
+                    "NOT_SATISFIED",
+                );
+
+            if (!nextRecommendation) {
+                return;
+            }
+
+            router.replace(
+                `/personal-recommendation/${nextRecommendation.requestId}/result`,
             );
-
-        if (!nextRecommendation) {
-            return;
-        }
-
-        router.replace(
-            `/personal-recommendation/${nextRecommendation.requestId}/result`,
-        );
-    };
+        };
 
     const handleSaveLocation = async (
         nextLocation: LocationSetting,
     ) => {
         const isSaved =
-            await saveLocation(nextLocation);
+            await saveLocation(
+                nextLocation,
+            );
 
         if (isSaved) {
             setIsLocationModalOpen(false);
@@ -238,16 +303,26 @@ function PersonalRecommendationResultPageContent() {
                 key={recommendation.requestId}
                 recommendation={recommendation}
                 keywords={keywords}
-                location={location}
-                isLocationLoading={isLocationLoading}
+                location={resultLocation}
+                isLocationLoading={
+                    isLocationLoading
+                }
                 isCompleting={isCompleting}
                 isRerolling={isRerolling}
                 onBack={() =>
-                    router.push("/personal-recommendation")
+                    router.push(
+                        "/personal-recommendation",
+                    )
                 }
-                onCompleteSelection={handleCompleteSelection}
-                onRetryRecommendation={handleRetryRecommendation}
-                onClickRestaurant={handleClickRestaurant}
+                onCompleteSelection={
+                    handleCompleteSelection
+                }
+                onRetryRecommendation={
+                    handleRetryRecommendation
+                }
+                onClickRestaurant={
+                    handleClickRestaurant
+                }
                 onClickChangeLocation={() =>
                     setIsLocationModalOpen(true)
                 }

--- a/src/features/personalRecommendation/application/hooks/useCompletePersonalRecommendationSelection.ts
+++ b/src/features/personalRecommendation/application/hooks/useCompletePersonalRecommendationSelection.ts
@@ -9,8 +9,13 @@ import { personalRecommendationApi } from "@/features/personalRecommendation/inf
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
 
 export function useCompletePersonalRecommendationSelection() {
-    const setRecommendationState = useSetAtom(personalRecommendationAtom);
-    const [isCompleting, setIsCompleting] = useState(false);
+    const setRecommendationState =
+        useSetAtom(
+            personalRecommendationAtom,
+        );
+
+    const [isCompleting, setIsCompleting] =
+        useState(false);
 
     const completeSelection = async (
         requestId: number,
@@ -22,27 +27,33 @@ export function useCompletePersonalRecommendationSelection() {
         setIsCompleting(true);
 
         try {
-            const result = await personalRecommendationApi.selectCandidate(
-                requestId,
-                {
-                    selectedCandidateId,
-                    latitude: location.latitude,
-                    longitude: location.longitude,
-                    radiusMeters: location.radiusMeters,
-                    address: location.address,
-                },
-            );
+            const result =
+                await personalRecommendationApi.selectCandidate(
+                    requestId,
+                    {
+                        selectedCandidateId,
+                        latitude: location.latitude,
+                        longitude: location.longitude,
+                        radiusMeters:
+                            location.radiusMeters,
+                        address: location.address,
+                    },
+                );
 
             setRecommendationState((prev) => {
-                if (prev.status !== "SUCCESS") return prev;
+                if (prev.status !== "SUCCESS") {
+                    return prev;
+                }
 
                 return {
                     status: "SUCCESS",
                     data: {
                         ...prev.data,
                         status: result.status,
-                        selectedCandidateId: result.selectedCandidateId,
+                        selectedCandidateId:
+                            result.selectedCandidateId,
                         closedAt: result.closedAt,
+                        locationSnapshot: location,
                     },
                 };
             });

--- a/src/features/personalRecommendation/domain/model/PersonalRecommendation.ts
+++ b/src/features/personalRecommendation/domain/model/PersonalRecommendation.ts
@@ -1,3 +1,5 @@
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+
 export interface RecommendedMenu {
     readonly id: number;
     readonly menuId: number;
@@ -13,5 +15,6 @@ export interface PersonalRecommendation {
     readonly requestedAt: string;
     readonly closedAt: string | null;
     readonly selectedCandidateId?: number | null;
+    readonly locationSnapshot?: LocationSetting | null;
     readonly candidates: readonly RecommendedMenu[];
 }

--- a/src/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse.ts
+++ b/src/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse.ts
@@ -11,8 +11,9 @@ export interface PersonalRecommendationDetailData {
     readonly id: number;
     readonly status: string;
     readonly closedAt: string | null;
-    readonly contextJson: Record<string, unknown>;
-    readonly candidates: readonly PersonalRecommendationDetailCandidateResponse[];
+    readonly contextJson: Record<string, unknown> | null;
+    readonly candidates:
+        readonly PersonalRecommendationDetailCandidateResponse[];
     readonly selectedCandidateId: number | null;
 }
 

--- a/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationDetailMapper.ts
+++ b/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationDetailMapper.ts
@@ -1,5 +1,58 @@
+import {
+    DEFAULT_LOCATION_RADIUS_METERS,
+    isLocationRadiusMeters,
+} from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
+import { DEFAULT_MAP_LEVEL } from "@/features/map/domain/config/mapPolicy";
+
 import type { PersonalRecommendation } from "@/features/personalRecommendation/domain/model/PersonalRecommendation";
 import type { PersonalRecommendationDetailData } from "@/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse";
+
+function mapLocationSnapshot(
+    contextJson: Record<string, unknown> | null,
+): LocationSetting | null {
+    if (contextJson === null) {
+        return null;
+    }
+
+    const latitude = Number(
+        contextJson.latitude,
+    );
+
+    const longitude = Number(
+        contextJson.longitude,
+    );
+
+    const radiusMetersValue = Number(
+        contextJson.radiusMeters,
+    );
+
+    const address =
+        typeof contextJson.address === "string"
+            ? contextJson.address
+            : "";
+
+    if (
+        !Number.isFinite(latitude) ||
+        !Number.isFinite(longitude) ||
+        address.trim().length === 0
+    ) {
+        return null;
+    }
+
+    const radiusMeters =
+        isLocationRadiusMeters(radiusMetersValue)
+            ? radiusMetersValue
+            : DEFAULT_LOCATION_RADIUS_METERS;
+
+    return {
+        latitude,
+        longitude,
+        radiusMeters,
+        address,
+        level: DEFAULT_MAP_LEVEL,
+    };
+}
 
 export function mapPersonalRecommendationDetail(
     data: PersonalRecommendationDetailData,
@@ -9,14 +62,22 @@ export function mapPersonalRecommendationDetail(
         status: data.status,
         requestedAt: "",
         closedAt: data.closedAt,
-        selectedCandidateId: data.selectedCandidateId,
-        candidates: data.candidates.map((candidate) => ({
-            id: candidate.id,
-            menuId: candidate.menuId,
-            menuName: candidate.menuName,
-            rankNo: candidate.rankNo,
-            score: candidate.score,
-            thumbnailUrl: candidate.thumbnailUrl,
-        })),
+        selectedCandidateId:
+            data.selectedCandidateId,
+        locationSnapshot:
+            mapLocationSnapshot(
+                data.contextJson,
+            ),
+        candidates: data.candidates.map(
+            (candidate) => ({
+                id: candidate.id,
+                menuId: candidate.menuId,
+                menuName: candidate.menuName,
+                rankNo: candidate.rankNo,
+                score: candidate.score,
+                thumbnailUrl:
+                    candidate.thumbnailUrl,
+            }),
+        ),
     };
 }

--- a/src/features/personalRecommendation/infrastructure/storage/personalRecommendationSearchRadiusStorage.ts
+++ b/src/features/personalRecommendation/infrastructure/storage/personalRecommendationSearchRadiusStorage.ts
@@ -1,0 +1,82 @@
+import type { LocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+import { isLocationRadiusMeters } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+
+interface PersonalRecommendationSearchRadiusStorageValue {
+    readonly requestId: number;
+    readonly candidateId: number;
+    readonly radiusMeters: LocationRadiusMeters;
+}
+
+const STORAGE_KEY_PREFIX =
+    "personalRecommendationSearchRadius";
+
+function createStorageKey(
+    requestId: number,
+    candidateId: number,
+) {
+    return `${STORAGE_KEY_PREFIX}:${requestId}:${candidateId}`;
+}
+
+export const personalRecommendationSearchRadiusStorage = {
+    save({
+        requestId,
+        candidateId,
+        radiusMeters,
+    }: PersonalRecommendationSearchRadiusStorageValue) {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        window.sessionStorage.setItem(
+            createStorageKey(
+                requestId,
+                candidateId,
+            ),
+            String(radiusMeters),
+        );
+    },
+
+    get(
+        requestId: number,
+        candidateId: number,
+    ): LocationRadiusMeters | null {
+        if (typeof window === "undefined") {
+            return null;
+        }
+
+        const storedValue =
+            window.sessionStorage.getItem(
+                createStorageKey(
+                    requestId,
+                    candidateId,
+                ),
+            );
+
+        if (storedValue === null) {
+            return null;
+        }
+
+        const radiusMeters =
+            Number(storedValue);
+
+        return isLocationRadiusMeters(radiusMeters)
+            ? radiusMeters
+            : null;
+    },
+
+    remove(
+        requestId: number,
+        candidateId: number,
+    ) {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        window.sessionStorage.removeItem(
+            createStorageKey(
+                requestId,
+                candidateId,
+            ),
+        );
+    },
+};

--- a/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantMap.tsx
+++ b/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantMap.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import {
+    useEffect,
+    useRef,
+    useState,
+} from "react";
 
 import { clientEnv } from "@/infrastructure/config/env";
 import { loadKakaoMapScript } from "@/shared/lib/kakaoMap/loadKakaoMapScript";
@@ -18,9 +22,13 @@ interface RecommendationRestaurantMapProps {
     readonly latitude: number;
     readonly longitude: number;
     readonly level: number;
-    readonly restaurants: readonly RecommendationRestaurant[];
-    readonly selectedRestaurant: RecommendationRestaurant | null;
-    readonly onSelectRestaurant: (restaurantId: string) => void;
+    readonly restaurants:
+        readonly RecommendationRestaurant[];
+    readonly selectedRestaurant:
+        RecommendationRestaurant | null;
+    readonly onSelectRestaurant: (
+        restaurantId: string,
+    ) => void;
     readonly sectionClassName?: string;
     readonly mapClassName?: string;
 }
@@ -35,53 +43,100 @@ export default function RecommendationRestaurantMap({
     sectionClassName,
     mapClassName,
 }: RecommendationRestaurantMapProps) {
-    const mapContainerRef = useRef<HTMLDivElement | null>(null);
-    const mapRef = useRef<kakao.maps.Map | null>(null);
-    const markerRecordsRef = useRef<MarkerRecord[]>([]);
+    const mapContainerRef =
+        useRef<HTMLDivElement | null>(null);
+
+    const mapRef =
+        useRef<kakao.maps.Map | null>(null);
+
+    const markerRecordsRef =
+        useRef<MarkerRecord[]>([]);
+
+    const [isMapReady, setIsMapReady] =
+        useState(false);
 
     useEffect(() => {
-        if (!mapContainerRef.current) return;
+        if (!mapContainerRef.current) {
+            return;
+        }
 
         let cancelled = false;
 
         async function initializeMap() {
-            await loadKakaoMapScript(clientEnv.kakaoMapAppKey);
+            setIsMapReady(false);
 
-            if (cancelled || !mapContainerRef.current || !window.kakao?.maps) {
+            await loadKakaoMapScript(
+                clientEnv.kakaoMapAppKey,
+            );
+
+            if (
+                cancelled ||
+                !mapContainerRef.current ||
+                !window.kakao?.maps
+            ) {
                 return;
             }
 
-            const center = new window.kakao.maps.LatLng(latitude, longitude);
+            const center =
+                new window.kakao.maps.LatLng(
+                    latitude,
+                    longitude,
+                );
 
-            mapRef.current = new window.kakao.maps.Map(
-                mapContainerRef.current,
-                {
-                    center,
-                    level,
-                },
-            );
+            mapRef.current =
+                new window.kakao.maps.Map(
+                    mapContainerRef.current,
+                    {
+                        center,
+                        level,
+                    },
+                );
+
+            setIsMapReady(true);
         }
 
-        initializeMap();
+        void initializeMap();
 
         return () => {
             cancelled = true;
+            setIsMapReady(false);
+
+            markerRecordsRef.current.forEach(
+                ({ marker, infoWindow }) => {
+                    infoWindow?.close();
+                    marker.setMap(null);
+                },
+            );
+
+            markerRecordsRef.current = [];
+            mapRef.current = null;
         };
-    }, [latitude, level, longitude]);
+    }, [
+        latitude,
+        level,
+        longitude,
+    ]);
 
     useEffect(() => {
         const map = mapRef.current;
 
-        if (!map || !window.kakao?.maps) {
+        if (
+            !isMapReady ||
+            !map ||
+            !window.kakao?.maps
+        ) {
             return;
         }
 
-        markerRecordsRef.current.forEach(({ marker, infoWindow }) => {
-            infoWindow?.close();
-            marker.setMap(null);
-        });
+        markerRecordsRef.current.forEach(
+            ({ marker, infoWindow }) => {
+                infoWindow?.close();
+                marker.setMap(null);
+            },
+        );
 
-        const bounds = new window.kakao.maps.LatLngBounds();
+        const bounds =
+            new window.kakao.maps.LatLngBounds();
 
         bounds.extend(
             new window.kakao.maps.LatLng(
@@ -90,67 +145,87 @@ export default function RecommendationRestaurantMap({
             ),
         );
 
-        markerRecordsRef.current = restaurants.map((restaurant) => {
-            const position = new window.kakao.maps.LatLng(
-                restaurant.latitude,
-                restaurant.longitude,
-            );
+        markerRecordsRef.current =
+            restaurants.map((restaurant) => {
+                const position =
+                    new window.kakao.maps.LatLng(
+                        restaurant.latitude,
+                        restaurant.longitude,
+                    );
 
-            bounds.extend(position);
+                bounds.extend(position);
 
-            const marker = new window.kakao.maps.Marker({
-                map,
-                position,
+                const marker =
+                    new window.kakao.maps.Marker({
+                        map,
+                        position,
+                    });
+
+                const infoWindow =
+                    new window.kakao.maps.InfoWindow({
+                        content: `
+                            <div
+                                style="
+                                    padding:6px 10px;
+                                    font-size:13px;
+                                    font-weight:500;
+                                    color:#000000;
+                                    white-space:nowrap;
+                                "
+                            >
+                                ${restaurant.name}
+                            </div>
+                        `,
+                    });
+
+                window.kakao.maps.event.addListener(
+                    marker,
+                    "click",
+                    () => {
+                        onSelectRestaurant(
+                            restaurant.id,
+                        );
+
+                        map.panTo(position);
+
+                        markerRecordsRef.current.forEach(
+                            (record) => {
+                                record.infoWindow?.close();
+                            },
+                        );
+
+                        infoWindow.open(
+                            map,
+                            marker,
+                        );
+                    },
+                );
+
+                return {
+                    restaurantId:
+                        restaurant.id,
+                    marker,
+                    infoWindow,
+                    position,
+                };
             });
-
-            const infoWindow = new window.kakao.maps.InfoWindow({
-                content: `
-                    <div
-                        style="
-                            padding:6px 10px;
-                            font-size:13px;
-                            font-weight:500;
-                            color:#000000;
-                            white-space:nowrap;
-                        "
-                    >
-                        ${restaurant.name}
-                    </div>
-                `,
-            });
-
-            window.kakao.maps.event.addListener(marker, "click", () => {
-                onSelectRestaurant(restaurant.id);
-                map.panTo(position);
-
-                markerRecordsRef.current.forEach((record) => {
-                    record.infoWindow?.close();
-                });
-
-                infoWindow.open(map, marker);
-            });
-
-            return {
-                restaurantId: restaurant.id,
-                marker,
-                infoWindow,
-                position,
-            };
-        });
 
         if (restaurants.length > 0) {
             map.setBounds(bounds);
         }
 
         return () => {
-            markerRecordsRef.current.forEach(({ marker, infoWindow }) => {
-                infoWindow?.close();
-                marker.setMap(null);
-            });
+            markerRecordsRef.current.forEach(
+                ({ marker, infoWindow }) => {
+                    infoWindow?.close();
+                    marker.setMap(null);
+                },
+            );
 
             markerRecordsRef.current = [];
         };
     }, [
+        isMapReady,
         latitude,
         longitude,
         onSelectRestaurant,
@@ -160,29 +235,43 @@ export default function RecommendationRestaurantMap({
     useEffect(() => {
         const map = mapRef.current;
 
-        if (!map || !selectedRestaurant) {
+        if (
+            !isMapReady ||
+            !map ||
+            !selectedRestaurant
+        ) {
             return;
         }
 
-        const selectedMarkerRecord = markerRecordsRef.current.find(
-            (record) => record.restaurantId === selectedRestaurant.id,
-        );
+        const selectedMarkerRecord =
+            markerRecordsRef.current.find(
+                (record) =>
+                    record.restaurantId ===
+                    selectedRestaurant.id,
+            );
 
         if (!selectedMarkerRecord) {
             return;
         }
 
-        markerRecordsRef.current.forEach((record) => {
-            record.infoWindow?.close();
-        });
+        markerRecordsRef.current.forEach(
+            (record) => {
+                record.infoWindow?.close();
+            },
+        );
 
-        map.panTo(selectedMarkerRecord.position);
+        map.panTo(
+            selectedMarkerRecord.position,
+        );
 
         selectedMarkerRecord.infoWindow?.open(
             map,
             selectedMarkerRecord.marker,
         );
-    }, [selectedRestaurant]);
+    }, [
+        isMapReady,
+        selectedRestaurant,
+    ]);
 
     return (
         <section

--- a/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantPageContent.tsx
+++ b/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantPageContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -21,6 +21,8 @@ import {
     formatLocationRadius,
     isLocationRadiusMeters,
 } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
+
+import { personalRecommendationSearchRadiusStorage } from "@/features/personalRecommendation/infrastructure/storage/personalRecommendationSearchRadiusStorage";
 
 import { recommendationRestaurantPageStyles } from "@/ui/styles/recommendationRestaurantPageStyles";
 
@@ -46,7 +48,18 @@ export default function RecommendationRestaurantPageContent() {
 
     const source = searchParams.get("source") ?? "personal";
     const isGroupRecommendation = source === "group";
-    const groupId = Number(searchParams.get("groupId"));
+
+    const groupId = Number(
+        searchParams.get("groupId"),
+    );
+
+    const requestId = Number(
+        searchParams.get("requestId"),
+    );
+
+    const candidateId = Number(
+        searchParams.get("candidateId"),
+    );
 
     const [currentLocation, setCurrentLocation] =
         useState<LocationSetting>({
@@ -97,6 +110,49 @@ export default function RecommendationRestaurantPageContent() {
         longitude: currentLocation.longitude,
         baseRadiusMeters: currentBaseRadiusMeters,
     });
+
+    useEffect(() => {
+        const isPersonalCandidateSearch =
+            source === "personal" &&
+            Number.isInteger(requestId) &&
+            requestId > 0 &&
+            Number.isInteger(candidateId) &&
+            candidateId > 0;
+
+        if (
+            !isPersonalCandidateSearch ||
+            isLoading
+        ) {
+            return;
+        }
+
+        if (
+            errorMessage !== null ||
+            restaurants.length === 0
+        ) {
+            personalRecommendationSearchRadiusStorage.remove(
+                requestId,
+                candidateId,
+            );
+
+            return;
+        }
+
+        personalRecommendationSearchRadiusStorage.save({
+            requestId,
+            candidateId,
+            radiusMeters:
+                searchContext.effectiveRadiusMeters,
+        });
+    }, [
+        candidateId,
+        errorMessage,
+        isLoading,
+        requestId,
+        restaurants.length,
+        searchContext.effectiveRadiusMeters,
+        source,
+    ]);
 
     const handleOpenLocationModal = () => {
         if (


### PR DESCRIPTION
## 관련 노션 백로그
MC-91

## 요약
- 무엇을 변경했나요?
  - 추천 메뉴 확정 시 선택한 메뉴의 실제 검색 반경(자동 확장 반경 포함)을 위치 컨텍스트 스냅샷으로 저장하도록 수정
  - 추천 결과 및 히스토리 화면에서 저장된 위치 스냅샷을 우선 사용하도록 변경하여, 추천 당시의 위치와 검색 반경이 그대로 재현되도록 개선
  - 위치 스냅샷이 없는 기존 추천 데이터도 정상적으로 조회할 수 있도록 예외 처리를 추가

- 왜 이 변경이 필요한가요?
  - 자동 반경 확장 후 메뉴를 선택했음에도 결과 화면과 히스토리에서 기존 기본 반경으로 표시되는 문제가 있었음
  - 추천이 확정된 시점의 위치 컨텍스트를 저장하고 이를 기준으로 화면을 구성해야 사용자가 실제로 추천받았던 맛집 검색 결과를 동일하게 확인

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
