### PR TITLE
[Fix] 개인 메뉴 추천 이력 위치 및 지도 마커 오류 수정

### DIFF
--- a/src/app/personal-recommendation/[requestId]/result/page.tsx
+++ b/src/app/personal-recommendation/[requestId]/result/page.tsx
@@ -159,26 +159,28 @@ function PersonalRecommendationResultPageContent() {
             preference,
         );
 
+    const isOpenRecommendation =
+        recommendation.status === "OPEN";
+
     const resultLocation =
-        recommendation.status !== "OPEN"
-            ? recommendation.locationSnapshot ??
-              location
-            : location;
+        isOpenRecommendation
+            ? location
+            : recommendation.locationSnapshot ?? null;
+
+    const isResultLocationLoading =
+        isOpenRecommendation &&
+        isLocationLoading;
 
     const handleCompleteSelection = async (
         selectedCandidateId: number,
     ) => {
         if (isLocationLoading) {
-            alert(
-                "위치 정보를 불러오는 중입니다.",
-            );
+            alert("위치 정보를 불러오는 중입니다.");
             return;
         }
 
         if (!location) {
-            alert(
-                "설정된 위치가 없습니다. 위치를 설정해주세요.",
-            );
+            alert("설정된 위치가 없습니다. 위치를 설정해주세요.");
             return;
         }
 
@@ -215,8 +217,7 @@ function PersonalRecommendationResultPageContent() {
     ) => {
         const candidate =
             recommendation.candidates.find(
-                (item) =>
-                    item.id === candidateId,
+                (item) => item.id === candidateId
             );
 
         if (!candidate) {
@@ -224,38 +225,24 @@ function PersonalRecommendationResultPageContent() {
         }
 
         if (isLocationLoading) {
-            alert(
-                "위치 정보를 불러오는 중입니다.",
-            );
+            alert("위치 정보를 불러오는 중입니다.");
             return;
         }
 
         if (!location) {
-            alert(
-                "설정된 위치가 없습니다. 위치를 설정해주세요.",
-            );
+            alert("설정된 위치가 없습니다. 위치를 설정해주세요.");
             return;
         }
 
         const searchParams =
             new URLSearchParams({
-                requestId: String(
-                    recommendation.requestId,
-                ),
-                candidateId: String(
-                    candidate.id,
-                ),
+                requestId: String(recommendation.requestId),
+                candidateId: String(candidate.id),
                 menuName: candidate.menuName,
-                latitude: String(
-                    location.latitude,
-                ),
-                longitude: String(
-                    location.longitude,
-                ),
+                latitude: String(location.latitude),
+                longitude: String(location.longitude),
                 address: location.address,
-                radiusMeters: String(
-                    location.radiusMeters,
-                ),
+                radiusMeters: String(location.radiusMeters),
                 level: "4",
                 source: "personal",
             });
@@ -285,10 +272,7 @@ function PersonalRecommendationResultPageContent() {
     const handleSaveLocation = async (
         nextLocation: LocationSetting,
     ) => {
-        const isSaved =
-            await saveLocation(
-                nextLocation,
-            );
+        const isSaved = await saveLocation(nextLocation);
 
         if (isSaved) {
             setIsLocationModalOpen(false);
@@ -304,37 +288,23 @@ function PersonalRecommendationResultPageContent() {
                 recommendation={recommendation}
                 keywords={keywords}
                 location={resultLocation}
-                isLocationLoading={
-                    isLocationLoading
-                }
+                isLocationLoading={isResultLocationLoading}
                 isCompleting={isCompleting}
                 isRerolling={isRerolling}
                 onBack={() =>
-                    router.push(
-                        "/personal-recommendation",
-                    )
+                    router.push("/personal-recommendation")
                 }
-                onCompleteSelection={
-                    handleCompleteSelection
-                }
-                onRetryRecommendation={
-                    handleRetryRecommendation
-                }
-                onClickRestaurant={
-                    handleClickRestaurant
-                }
-                onClickChangeLocation={() =>
-                    setIsLocationModalOpen(true)
-                }
+                onCompleteSelection={handleCompleteSelection}
+                onRetryRecommendation={handleRetryRecommendation}
+                onClickRestaurant={handleClickRestaurant}
+                onClickChangeLocation={() => setIsLocationModalOpen(true)}
             />
 
             <LocationModal
                 isOpen={isLocationModalOpen}
                 initialLocation={location}
                 isSaving={isLocationSaving}
-                onClose={() =>
-                    setIsLocationModalOpen(false)
-                }
+                onClose={() => setIsLocationModalOpen(false)}
                 onSave={handleSaveLocation}
             />
         </>

--- a/src/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse.ts
+++ b/src/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse.ts
@@ -11,7 +11,7 @@ export interface PersonalRecommendationDetailData {
     readonly id: number;
     readonly status: string;
     readonly closedAt: string | null;
-    readonly contextJson: Record<string, unknown> | null;
+    readonly contextJson: string | null;
     readonly candidates:
         readonly PersonalRecommendationDetailCandidateResponse[];
     readonly selectedCandidateId: number | null;

--- a/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationDetailMapper.ts
+++ b/src/features/personalRecommendation/infrastructure/api/mapper/personalRecommendationDetailMapper.ts
@@ -1,5 +1,4 @@
 import {
-    DEFAULT_LOCATION_RADIUS_METERS,
     isLocationRadiusMeters,
 } from "@/features/locationSetting/domain/config/locationRadiusPolicy";
 import type { LocationSetting } from "@/features/locationSetting/domain/model/LocationSetting";
@@ -8,42 +7,56 @@ import { DEFAULT_MAP_LEVEL } from "@/features/map/domain/config/mapPolicy";
 import type { PersonalRecommendation } from "@/features/personalRecommendation/domain/model/PersonalRecommendation";
 import type { PersonalRecommendationDetailData } from "@/features/personalRecommendation/infrastructure/api/dto/PersonalRecommendationDetailResponse";
 
-function mapLocationSnapshot(
-    contextJson: Record<string, unknown> | null,
-): LocationSetting | null {
-    if (contextJson === null) {
+function parseContextJson(
+    contextJson: string | null,
+): Record<string, unknown> | null {
+    if (!contextJson) {
         return null;
     }
 
-    const latitude = Number(
-        contextJson.latitude,
-    );
+    try {
+        const parsed: unknown = JSON.parse(contextJson);
 
-    const longitude = Number(
-        contextJson.longitude,
-    );
+        if (
+            typeof parsed !== "object" ||
+            parsed === null ||
+            Array.isArray(parsed)
+        ) {
+            return null;
+        }
 
-    const radiusMetersValue = Number(
-        contextJson.radiusMeters,
-    );
+        return parsed as Record<string, unknown>;
+    } catch {
+        return null;
+    }
+}
+
+function mapLocationSnapshot(
+    contextJson: string | null,
+): LocationSetting | null {
+    const context = parseContextJson(contextJson);
+
+    if (context === null) {
+        return null;
+    }
+
+    const latitude = Number(context.latitude);
+    const longitude = Number(context.longitude);
+    const radiusMeters = Number(context.radiusMeters);
 
     const address =
-        typeof contextJson.address === "string"
-            ? contextJson.address
+        typeof context.address === "string"
+            ? context.address
             : "";
 
     if (
         !Number.isFinite(latitude) ||
         !Number.isFinite(longitude) ||
+        !isLocationRadiusMeters(radiusMeters) ||
         address.trim().length === 0
     ) {
         return null;
     }
-
-    const radiusMeters =
-        isLocationRadiusMeters(radiusMetersValue)
-            ? radiusMetersValue
-            : DEFAULT_LOCATION_RADIUS_METERS;
 
     return {
         latitude,

--- a/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantMap.tsx
+++ b/src/features/recommendationRestaurant/ui/components/RecommendationRestaurantMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { clientEnv } from "@/infrastructure/config/env";
 import { captureExternalSdkError } from "@/infrastructure/monitoring/sentryMonitoring";
@@ -44,12 +44,14 @@ export default function RecommendationRestaurantMap({
     sectionClassName,
     mapClassName,
 }: RecommendationRestaurantMapProps) {
-    const mapContainerRef =
-        useRef<HTMLDivElement | null>(null);
-    const mapRef =
-        useRef<kakao.maps.Map | null>(null);
-    const markerRecordsRef =
-        useRef<MarkerRecord[]>([]);
+    const mapContainerRef = useRef<HTMLDivElement | null>(null);
+    const mapRef = useRef<kakao.maps.Map | null>(null);
+    const markerRecordsRef = useRef<MarkerRecord[]>([]);
+
+    const [
+        mapInitializationVersion,
+        setMapInitializationVersion,
+    ] = useState(0);
 
     useEffect(() => {
         if (!mapContainerRef.current) return;
@@ -57,9 +59,7 @@ export default function RecommendationRestaurantMap({
         let cancelled = false;
 
         async function initializeMap() {
-            await loadKakaoMapScript(
-                clientEnv.kakaoMapAppKey,
-            );
+            await loadKakaoMapScript(clientEnv.kakaoMapAppKey);
 
             if (
                 cancelled ||
@@ -83,6 +83,10 @@ export default function RecommendationRestaurantMap({
                         level,
                     },
                 );
+
+            setMapInitializationVersion(
+                (version) => version + 1,
+            );
         }
 
         initializeMap().catch((error) => {
@@ -120,8 +124,7 @@ export default function RecommendationRestaurantMap({
             },
         );
 
-        const bounds =
-            new window.kakao.maps.LatLngBounds();
+        const bounds = new window.kakao.maps.LatLngBounds();
 
         bounds.extend(
             new window.kakao.maps.LatLng(
@@ -211,6 +214,7 @@ export default function RecommendationRestaurantMap({
     }, [
         latitude,
         longitude,
+        mapInitializationVersion,
         onSelectRestaurant,
         restaurants,
     ]);
@@ -245,7 +249,10 @@ export default function RecommendationRestaurantMap({
             map,
             selectedMarkerRecord.marker,
         );
-    }, [selectedRestaurant]);
+    }, [
+        mapInitializationVersion,
+        selectedRestaurant,
+    ]);
 
     return (
         <section


### PR DESCRIPTION
## 노션 백로그
MC-106, 107

## 요약
- 무엇을 변경했나요?
  - 개인 메뉴 추천 상세 조회의 contextJson을 파싱하여 추천 당시 위치/반경 정보를 locationSnapshot으로 복원하도록 수정
  - 완료된 메뉴 추천 이력 조회 시 현재 개인 위치가 아닌 추천 당시의 locationSnapshot을 기준으로 맛집을 조회하도록 수정
  - Kakao Map 초기화 완료 시점을 상태로 관리하여 지도 초기화 이후 맛집 마커가 정상적으로 생성되도록 수정
  - 지도 초기화 이후에도 선택된 맛집과 마커의 선택 상태가 정상적으로 연동되도록 처리

- 왜 이 변경이 필요한가요?
  - 사용자가 위치/반경을 변경하더라도 과거 개인 메뉴 추천 이력은 추천 당시의 위치 정보를 기준으로 동일한 결과를 제공해야 함
  - 메뉴 선택 완료 결과 화면에서 주변 맛집은 조회되지만 지도 초기화 시점에 따라 마커가 표시되지 않는 문제를 해결을 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
