### PR TITLE
[Fix] Refresh Token 갱신 요청 중복 실행 방지 (MC-108)

### DIFF
--- a/src/infrastructure/http/httpClient.ts
+++ b/src/infrastructure/http/httpClient.ts
@@ -38,22 +38,28 @@ class HttpError extends Error {
 }
 
 interface RefreshResult {
-    accessToken: string;
-    onboarding: OnboardingState;
-    member: LoginMember;
+    readonly accessToken: string;
+    readonly onboarding: OnboardingState;
+    readonly member: LoginMember;
 }
+
+interface RefreshResponseBody {
+    readonly data: RefreshResult;
+}
+
+const REFRESH_PATH = "/api/v1/auth/refresh";
 
 const NO_REFRESH_PATHS = [
     "/api/v1/auth/oauth2/exchange",
     "/api/v1/auth/login",
-    "/api/v1/auth/refresh",
+    REFRESH_PATH,
     "/api/v1/members/signup",
     "/api/v1/auth/email",
     "/api/v1/auth/email/confirm",
 ];
 
 const SILENT_ERROR_LOG_PATHS = [
-    "/api/v1/auth/refresh",
+    REFRESH_PATH,
     "/api/v1/auth/email/confirm",
     "/api/v1/groups/invites/nickname",
 ];
@@ -67,6 +73,8 @@ const MONITORED_CLIENT_ERROR_STATUSES = [
     408,
     429,
 ];
+
+let refreshRequestPromise: Promise<unknown> | null = null;
 
 function shouldTryRefresh(path: string, isRetry: boolean) {
     if (isRetry) {
@@ -114,36 +122,56 @@ function shouldCaptureApiError(
 }
 
 async function refreshAccessToken(): Promise<RefreshResult> {
-    const response = await fetch(
-        `${clientEnv.apiBaseUrl}/api/v1/auth/refresh`,
+    const response = await request<RefreshResponseBody>(
+        REFRESH_PATH,
         {
             method: "POST",
-            credentials: "include",
         },
     );
 
-    if (!response.ok) {
-        const errorBody = await response.json().catch(() => null);
+    return response.data;
+}
 
-        logger.error("[httpClient] refresh 실패 응답:", {
-            status: response.status,
-            statusText: response.statusText,
-            body: errorBody,
-        });
-
-        throw new Error("Refresh failed");
+async function requestRefresh<T>(
+    options?: RequestInit,
+    isRetry = false,
+): Promise<T> {
+    if (refreshRequestPromise) {
+        return refreshRequestPromise as Promise<T>;
     }
 
-    const body = await response.json();
+    const currentRequest = executeRequest<T>(
+        REFRESH_PATH,
+        options,
+        isRetry,
+    );
 
-    return {
-        accessToken: body.data.accessToken,
-        onboarding: body.data.onboarding,
-        member: body.data.member,
-    };
+    refreshRequestPromise = currentRequest;
+
+    try {
+        return await currentRequest;
+    } finally {
+        if (refreshRequestPromise === currentRequest) {
+            refreshRequestPromise = null;
+        }
+    }
 }
 
 async function request<T>(
+    path: string,
+    options?: RequestInit,
+    isRetry = false,
+): Promise<T> {
+    const method = options?.method ?? "GET";
+
+    if (path === REFRESH_PATH && method === "POST") {
+        return requestRefresh<T>(options, isRetry);
+    }
+
+    return executeRequest<T>(path, options, isRetry);
+}
+
+async function executeRequest<T>(
     path: string,
     options?: RequestInit,
     isRetry = false,


### PR DESCRIPTION
## 노션 백로그
MC-108

## 요약
- 무엇을 변경했나요?
  - Refresh 요청이 동시에 발생할 경우 진행 중인 요청의 결과를 공유하도록 single-flight 방식의 Refresh 처리 로직을 적용
  - useAuthInit과 httpClient의 401 재처리 과정에서 발생하는 Refresh 요청이 공통 로직을 사용하도록 통합
  - Refresh가 진행 중일 때 추가 호출이 발생해도 실제 POST /api/v1/auth/refresh 요청은 한 번만 전송되도록 수정

- 왜 이 변경이 필요한가요?
  - 인증 상태 초기화 과정에서 Refresh 요청이 중복으로 전송되어 동일한 Refresh Token에 대한 처리 충돌이 발생하는 문제를 방지
  - Refresh 요청을 단일 요청으로 관리하여 토큰 갱신 및 인증 상태가 안정적으로 처리되도록 하기 위함

## 범위 점검
- [x] 불필요한 의존성을 추가하지 않았습니다.
- [ ] 동작/프로세스가 바뀌면 문서를 함께 수정했습니다.

## 로컬 검증
- [x] `npm run lint`
- [ ] `npm run test`
- [x] `npm run build`

## UI 증빙
- [ ] UI 변경 시 스크린샷 또는 짧은 녹화본을 첨부했습니다.

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
